### PR TITLE
docs: add --recurse-submodules note and clarify jetstreamer-clickhouse-plugin build path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,21 @@ running ClickHouse locally, building/running the ingestor and RPC server, and ru
 
 If you just want to run Superbank locally, start with `README.md`.
 
+## Getting the repo
+
+```bash
+git clone --recurse-submodules https://github.com/solana-rpc/superbank.git
+cd superbank
+```
+
+`ingest/jetstreamer` is a git submodule. Cloning without `--recurse-submodules` leaves it empty
+and causes build errors when compiling the Jetstreamer ClickHouse plugin. If you already cloned
+without the flag, populate it with:
+
+```bash
+git submodule update --init
+```
+
 ## Who This Is For
 
 Contributors to:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <br/>Superbank
 </h1>
 
-[![CI](https://github.com/rpcpool/superbank/actions/workflows/ci.yml/badge.svg)](https://github.com/rpcpool/superbank/actions/workflows/ci.yml)
+[![CI](https://github.com/solana-rpc/superbank/actions/workflows/ci.yml/badge.svg)](https://github.com/solana-rpc/superbank/actions/workflows/ci.yml)
 
 Ingest Solana ledger data into ClickHouse and serve Solana-compatible JSON-RPC from that data.
 
@@ -237,8 +237,8 @@ rows already present on the target by exact table key instead of failing the run
 - `ddl/` ClickHouse schemas (transactions, block metadata, optional PoH entries, GSFA/signatures, token owner activity)
 - `tests/k6/` load/validation tests for `superbank-rpc`
 - `scripts/` helper scripts (local runs, analysis, k6 orchestration)
-- `ingest/jetstreamer` standalone Jetstreamer workspace (not part of the root Cargo workspace)
-- `ingest/jetstreamer-clickhouse-plugin` Jetstreamer ClickHouse ingestion plugin (standalone)
+- `ingest/jetstreamer` git submodule — standalone Jetstreamer workspace (not part of the root Cargo workspace); requires `git clone --recurse-submodules` or `git submodule update --init`
+- `ingest/jetstreamer-clickhouse-plugin` Jetstreamer ClickHouse ingestion plugin (standalone workspace — build with `cargo build --release` from within this directory, not `-p jetstreamer-clickhouse-plugin` from the repo root)
 
 ## Development
 

--- a/ingest/jetstreamer-clickhouse-plugin/README.md
+++ b/ingest/jetstreamer-clickhouse-plugin/README.md
@@ -64,6 +64,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ## Standalone runner
 
+> **Note:** `ingest/jetstreamer-clickhouse-plugin` is its own Cargo workspace, separate from the
+> root workspace. Run all `cargo` commands from within this directory. Running
+> `cargo build --release -p jetstreamer-clickhouse-plugin` from the repo root will silently do
+> nothing because the crate is not a member of the root workspace.
+>
+> Also: `ingest/jetstreamer` (a dependency) is a git submodule. If the build fails with missing
+> source files, populate it first:
+> ```bash
+> git submodule update --init
+> ```
+
 This crate ships a minimal runner binary so you can copy just this folder and run the plugin:
 
 ```bash


### PR DESCRIPTION
## Summary

- **CONTRIBUTING.md** — adds a new "Getting the repo" section as the
  first step, with `git clone --recurse-submodules` and a recovery
  command (`git submodule update --init`) for users who already cloned
  without it.
- **README.md** — updates the "Repository layout" entries for
  `ingest/jetstreamer` (now noted as a git submodule) and
  `ingest/jetstreamer-clickhouse-plugin` (now notes the standalone
  workspace constraint and correct build approach).
- **ingest/jetstreamer-clickhouse-plugin/README.md** — adds a
  blockquote warning at the top of "Standalone runner" covering both
  the standalone workspace (don't use `-p` from root) and the
  submodule dependency (`git submodule update --init` if missing).

No source code changes; documentation only.

## Test plan

- [x] Render CONTRIBUTING.md and README.md — confirm the new sections
  display correctly and links are intact
- [x] Fresh clone *without* `--recurse-submodules`, follow the new
  recovery instruction (`git submodule update --init`), then build
  `ingest/jetstreamer-clickhouse-plugin` — confirm it compiles
- [x] Attempt `cargo build --release -p jetstreamer-clickhouse-plugin`
  from repo root — confirm it still silently does nothing (expected;
  the note now explains why)

Closes: #2 