### PR TITLE
feat: add superbank_ingest_chain_tip_lag metric

### DIFF
--- a/crates/superbank/src/cli.rs
+++ b/crates/superbank/src/cli.rs
@@ -233,6 +233,18 @@ struct CliArgs {
     )]
     grpc_health_watch_enabled: bool,
 
+    /// Subscribe to slot notifications on the gRPC stream to populate the chain-tip lag metric.
+    #[arg(
+        long,
+        env = "GRPC_SLOT_NOTIFICATIONS",
+        default_value_t = true,
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = true,
+        action = clap::ArgAction::Set
+    )]
+    grpc_slot_notifications: bool,
+
     /// Solana JSON-RPC URL (required for rpc source)
     #[arg(long, env = "RPC_URL")]
     rpc_url: Option<String>,
@@ -428,6 +440,7 @@ pub(crate) struct Args {
     pub(crate) grpc_http2_adaptive_window: bool,
     pub(crate) grpc_idle_timeout_secs: u64,
     pub(crate) grpc_health_watch_enabled: bool,
+    pub(crate) grpc_slot_notifications: bool,
     pub(crate) rpc_url: Option<String>,
     pub(crate) rpc_to_slot: Option<u64>,
     pub(crate) rpc_slot_count: Option<u64>,
@@ -511,6 +524,8 @@ struct FileConfig {
     grpc_idle_timeout_secs: Option<u64>,
     #[serde(alias = "grpc_health_watch_enabled")]
     grpc_health_watch_enabled: Option<bool>,
+    #[serde(alias = "grpc_slot_notifications")]
+    grpc_slot_notifications: Option<bool>,
     #[serde(alias = "rpc_url")]
     rpc_url: Option<String>,
     #[serde(alias = "rpc_to_slot")]
@@ -707,6 +722,12 @@ pub(crate) fn resolve_args() -> Result<Args> {
             "grpc_health_watch_enabled",
             cli.grpc_health_watch_enabled,
             file_config.grpc_health_watch_enabled,
+        ),
+        grpc_slot_notifications: merge_value(
+            &matches,
+            "grpc_slot_notifications",
+            cli.grpc_slot_notifications,
+            file_config.grpc_slot_notifications,
         ),
         rpc_url: merge_option(&matches, "rpc_url", cli.rpc_url, file_config.rpc_url),
         rpc_to_slot: merge_option(
@@ -1621,6 +1642,7 @@ rpc-from-slot: 456
             grpc_http2_adaptive_window: false,
             grpc_idle_timeout_secs: 30,
             grpc_health_watch_enabled: true,
+            grpc_slot_notifications: true,
             rpc_url: None,
             rpc_to_slot: None,
             rpc_slot_count: None,

--- a/crates/superbank/src/clickhouse.rs
+++ b/crates/superbank/src/clickhouse.rs
@@ -476,6 +476,7 @@ mod tests {
             grpc_http2_adaptive_window: false,
             grpc_idle_timeout_secs: 30,
             grpc_health_watch_enabled: true,
+            grpc_slot_notifications: true,
             rpc_url: None,
             rpc_to_slot: None,
             rpc_slot_count: None,

--- a/crates/superbank/src/ingest/fumarole.rs
+++ b/crates/superbank/src/ingest/fumarole.rs
@@ -142,8 +142,11 @@ pub(crate) async fn run_fumarole_ingest(args: &Args) -> Result<()> {
                         reset_idle_timer(idle_timer.as_mut(), idle_timeout);
                         match block_assembler.handle_update(slot, update)? {
                             FumaroleAssembledUpdate::None => {}
-                            FumaroleAssembledUpdate::SlotStatus(status_slot) => {
+                            FumaroleAssembledUpdate::SlotStatus(status_slot, status) => {
                                 observe_processed_slot(&mut last_processed_block_slot, status_slot);
+                                if status == commitment {
+                                    metrics::set_network_tip_slot(status_slot);
+                                }
                             }
                             FumaroleAssembledUpdate::Block(update) => {
                                 let update = *update;
@@ -323,7 +326,7 @@ fn build_fumarole_subscribe_request(commitment: i32, include_entries: bool) -> S
 
 enum FumaroleAssembledUpdate {
     None,
-    SlotStatus(u64),
+    SlotStatus(u64, i32),
     Block(Box<SubscribeUpdate>),
 }
 
@@ -347,7 +350,9 @@ impl FumaroleBlockAssembler {
         update: SubscribeUpdate,
     ) -> Result<FumaroleAssembledUpdate> {
         match update.update_oneof {
-            Some(UpdateOneof::Slot(slot)) => Ok(FumaroleAssembledUpdate::SlotStatus(slot.slot)),
+            Some(UpdateOneof::Slot(slot)) => {
+                Ok(FumaroleAssembledUpdate::SlotStatus(slot.slot, slot.status))
+            }
             Some(UpdateOneof::Block(block)) => {
                 Ok(FumaroleAssembledUpdate::Block(Box::new(SubscribeUpdate {
                     filters: update.filters,

--- a/crates/superbank/src/ingest/grpc.rs
+++ b/crates/superbank/src/ingest/grpc.rs
@@ -367,7 +367,12 @@ async fn connect_grpc_stream(
     let mut client = build_grpc_client(endpoint, args).await?;
     let mut pending_update = None;
     let build_request = |from_slot| {
-        build_subscribe_request(commitment, from_slot, include_entries, include_slot_notifications)
+        build_subscribe_request(
+            commitment,
+            from_slot,
+            include_entries,
+            include_slot_notifications,
+        )
     };
     let stream = match subscribe_from_slot_mode {
         Some(FromSlotMode::Zero) | Some(FromSlotMode::LatestDb) => {

--- a/crates/superbank/src/ingest/grpc.rs
+++ b/crates/superbank/src/ingest/grpc.rs
@@ -19,8 +19,8 @@ use tonic::{Code, Status};
 use tracing::{debug, info, warn};
 use yellowstone_grpc_client::{ClientTlsConfig, GeyserGrpcClient};
 use yellowstone_grpc_proto::prelude::{
-    RewardType, SubscribeRequest, SubscribeRequestFilterBlocks, SubscribeUpdate,
-    SubscribeUpdateBlock, SubscribeUpdateEntry, SubscribeUpdateTransactionInfo,
+    RewardType, SubscribeRequest, SubscribeRequestFilterBlocks, SubscribeRequestFilterSlots,
+    SubscribeUpdate, SubscribeUpdateBlock, SubscribeUpdateEntry, SubscribeUpdateTransactionInfo,
     subscribe_update::UpdateOneof,
 };
 
@@ -178,6 +178,7 @@ pub(crate) async fn run_grpc_ingest(args: &Args) -> Result<()> {
         subscribe_from_slot,
         subscribe_from_slot_mode,
         include_entries,
+        args.grpc_slot_notifications,
     )
     .await?;
 
@@ -268,6 +269,9 @@ pub(crate) async fn run_grpc_ingest(args: &Args) -> Result<()> {
                             last_processed_block_slot = Some(slot);
                             metrics::set_last_processed_slot(slot);
                         }
+                        if let Some(UpdateOneof::Slot(slot_update)) = &update.update_oneof {
+                            metrics::set_network_tip_slot(slot_update.slot);
+                        }
                         process_update(
                             update,
                             args,
@@ -355,13 +359,16 @@ async fn connect_grpc_stream(
     subscribe_from_slot: Option<u64>,
     subscribe_from_slot_mode: Option<FromSlotMode>,
     include_entries: bool,
+    include_slot_notifications: bool,
 ) -> Result<(
     Option<SubscribeUpdate>,
     impl futures::Stream<Item = Result<SubscribeUpdate, Status>>,
 )> {
     let mut client = build_grpc_client(endpoint, args).await?;
     let mut pending_update = None;
-    let build_request = |from_slot| build_subscribe_request(commitment, from_slot, include_entries);
+    let build_request = |from_slot| {
+        build_subscribe_request(commitment, from_slot, include_entries, include_slot_notifications)
+    };
     let stream = match subscribe_from_slot_mode {
         Some(FromSlotMode::Zero) | Some(FromSlotMode::LatestDb) => {
             let request = build_request(subscribe_from_slot);
@@ -487,6 +494,7 @@ pub(crate) fn build_subscribe_request(
     commitment: i32,
     from_slot: Option<u64>,
     include_entries: bool,
+    include_slot_notifications: bool,
 ) -> SubscribeRequest {
     let mut blocks = HashMap::new();
     blocks.insert(
@@ -499,8 +507,20 @@ pub(crate) fn build_subscribe_request(
         },
     );
 
+    let mut slots = HashMap::new();
+    if include_slot_notifications {
+        slots.insert(
+            "slots".to_string(),
+            SubscribeRequestFilterSlots {
+                filter_by_commitment: Some(true),
+                interslot_updates: Some(false),
+            },
+        );
+    }
+
     SubscribeRequest {
         blocks,
+        slots,
         commitment: Some(commitment),
         from_slot,
         ..Default::default()

--- a/crates/superbank/src/metrics.rs
+++ b/crates/superbank/src/metrics.rs
@@ -53,6 +53,7 @@ struct SourceErrorLabels {
 struct SlotState {
     last_processed_slot: u64,
     last_inserted_slot: u64,
+    last_network_tip_slot: u64,
 }
 
 pub(crate) struct Metrics {
@@ -61,6 +62,7 @@ pub(crate) struct Metrics {
     last_processed_slot: Gauge,
     last_inserted_slot: Gauge,
     slot_lag: Gauge,
+    chain_tip_lag: Gauge,
     inserted_slots_total: Counter,
     inserted_transactions_total: Counter,
     fumarole_data_channel_capacity: Gauge,
@@ -78,6 +80,7 @@ impl Metrics {
         let last_processed_slot = Gauge::default();
         let last_inserted_slot = Gauge::default();
         let slot_lag = Gauge::default();
+        let chain_tip_lag = Gauge::default();
         let inserted_slots_total = Counter::default();
         let inserted_transactions_total = Counter::default();
         let fumarole_data_channel_capacity = Gauge::default();
@@ -116,6 +119,11 @@ impl Metrics {
             "ingest_slot_lag",
             "Difference between the highest processed slot and highest durably inserted slot",
             slot_lag.clone(),
+        );
+        registry_for_metrics.register(
+            "ingest_chain_tip_lag",
+            "Slots between the current network tip (at configured commitment) and the last durably inserted slot; only populated for fumarole and grpc sources",
+            chain_tip_lag.clone(),
         );
         registry_for_metrics.register(
             "ingest_inserted_slots_total",
@@ -169,6 +177,7 @@ impl Metrics {
             last_processed_slot,
             last_inserted_slot,
             slot_lag,
+            chain_tip_lag,
             inserted_slots_total,
             inserted_transactions_total,
             fumarole_data_channel_capacity,
@@ -257,6 +266,12 @@ impl Metrics {
         Ok(buffer.into_bytes())
     }
 
+    fn set_network_tip_slot(&self, slot: u64) {
+        self.update_slot_state(|state| {
+            state.last_network_tip_slot = state.last_network_tip_slot.max(slot);
+        });
+    }
+
     fn update_slot_state(&self, update: impl FnOnce(&mut SlotState)) {
         let guard = self.slot_state.lock();
         let mut guard = match guard {
@@ -268,6 +283,10 @@ impl Metrics {
             .last_processed_slot
             .saturating_sub(guard.last_inserted_slot);
         self.slot_lag.set(clamp_i64(lag));
+        let chain_tip_lag = guard
+            .last_network_tip_slot
+            .saturating_sub(guard.last_inserted_slot);
+        self.chain_tip_lag.set(clamp_i64(chain_tip_lag));
     }
 }
 
@@ -286,6 +305,10 @@ pub(crate) fn force_init(source: &str, cluster_label: Option<&str>) {
 
 pub(crate) fn set_last_processed_slot(slot: u64) {
     metrics().set_last_processed_slot(slot);
+}
+
+pub(crate) fn set_network_tip_slot(slot: u64) {
+    metrics().set_network_tip_slot(slot);
 }
 
 pub(crate) fn observe_block_insert(table: &str, rows: usize, max_slot: Option<u64>) {


### PR DESCRIPTION
## Problem

`superbank_ingest_slot_lag` measures `last_processed_slot −
last_inserted_slot` — the internal processing backlog. It does not answer the question operators actually need:

> **How far behind the live Solana chain is my ClickHouse data?**

## Solution

Add `superbank_ingest_chain_tip_lag` (`network_tip_slot − last_inserted_slot`), the end-to-end query availability lag.

The data is already flowing in both live sources:
- **Fumarole** receives `UpdateOneof::Slot` events with a `status` field; previously the status was discarded. Now the slot is recorded as the network tip when its commitment matches the configured level.
- **gRPC (DragonsMouth)** gets a new `SubscribeRequestFilterSlots` added to its subscription (`filter_by_commitment: true`) so the server sends slot notifications at the configured commitment. The event loop records each one via `set_network_tip_slot()`.

`rpc` and `bigtable` sources process bounded historical ranges with no live chain concept; the metric stays at 0 for those and is documented as such.

## New flag

`--grpc-slot-notifications` / `GRPC_SLOT_NOTIFICATIONS` (default
`true`) — some managed/shared Yellowstone gRPC endpoints restrict
subscriptions to a single filter type. Setting this to `false`
disables the slot subscription so block ingestion continues to work;
`chain_tip_lag` simply will not be populated.

## Verification

```bash
cargo test --workspace --locked        # 45 + 273 tests pass
cargo clippy --workspace --all-targets --locked -- -D warnings
cargo fmt --all -- --check

# After starting with fumarole or grpc source:
curl -s http://localhost:9901/metrics | grep chain_tip_lag
# superbank_ingest_chain_tip_lag 3
```

Tested:
<img width="2266" height="550" alt="superbank-grpc-log" src="https://github.com/user-attachments/assets/b052e51d-0941-4d1e-8134-5614416bd88a" />

Closes: #5 

