### PR TITLE
feat: RocksDB Disk Cache

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,8 @@
+# librocksdb-sys (disk-cache feature) compiled against the Nix dev shell's hardened
+# libc++ trips a false-positive unique_ptr<T[]> bounds assertion on RocksDB's
+# cache-line-aligned striped mutexes (first SST load aborts with SIGTRAP). The
+# index is provably in range (FastRangeGeneric maps into [0, stripe_count)); the
+# checker mishandles over-aligned array allocations. Harmless on libstdc++ (Linux
+# CI), where the macro is ignored. `force` is off, so an explicit CXXFLAGS wins.
+[env]
+CXXFLAGS = "-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_NONE"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,4 +86,4 @@ jobs:
         run: cargo test --workspace --locked
 
       - name: Test optional features (superbank-rpc)
-        run: cargo test -p superbank-rpc --features grpc-head-cache,pyroscope --locked
+        run: cargo test -p superbank-rpc --features grpc-head-cache,pyroscope,disk-cache --locked

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Config lives in `superbank.example.yaml`; copy to `superbank.yaml` for local run
   `cargo fmt --all -- --check`
   `cargo clippy --workspace --all-targets --locked -- -D warnings`
   `cargo test --workspace --locked`
-  `cargo test -p superbank-rpc --features grpc-head-cache,pyroscope --locked`
+  `cargo test -p superbank-rpc --features grpc-head-cache,pyroscope,disk-cache --locked`
 - Load tests:
   `scripts/test/run-k6.sh` (or run a single scenario under `tests/k6/scenarios/`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ cargo clippy --workspace --all-targets --locked -- -D warnings
 cargo test --workspace --locked
 
 # Tests with optional features
-cargo test -p superbank-rpc --features grpc-head-cache,pyroscope --locked
+cargo test -p superbank-rpc --features grpc-head-cache,pyroscope,disk-cache --locked
 
 # k6 load test (basic)
 k6 run tests/k6/scenarios/basic/superbank-rpc-get-signatures.js -e RPC_URL=http://localhost:8899

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -246,7 +246,7 @@ cargo test --workspace --locked
 CI also exercises optional features for `superbank-rpc`:
 
 ```bash
-cargo test -p superbank-rpc --features grpc-head-cache,pyroscope --locked
+cargo test -p superbank-rpc --features grpc-head-cache,pyroscope,disk-cache --locked
 ```
 
 If you change RPC behavior, ClickHouse queries, or response formats:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,20 +71,6 @@ dependencies = [
 
 [[package]]
 name = "agave-feature-set"
-version = "3.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe79fc4c114c51ea8461d829bb49853a21a76c7c8ef20e9041b071558f628ce"
-dependencies = [
- "ahash",
- "solana-epoch-schedule",
- "solana-hash 3.1.0",
- "solana-pubkey 3.0.0",
- "solana-sha256-hasher",
- "solana-svm-feature-set 3.1.14",
-]
-
-[[package]]
-name = "agave-feature-set"
 version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33e41538180f5ded6d08a69c75b4f48c4c6ba8098d7e790b3d694a6bc081fbc7"
@@ -95,18 +81,7 @@ dependencies = [
  "solana-keypair",
  "solana-pubkey 4.1.0",
  "solana-sha256-hasher",
- "solana-svm-feature-set 4.0.0-rc.0",
-]
-
-[[package]]
-name = "agave-reserved-account-keys"
-version = "3.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e8ceb5117fa390898f473b0d165f88482a2b36fb4a47441d8b40e22823207cb"
-dependencies = [
- "agave-feature-set 3.1.14",
- "solana-pubkey 3.0.0",
- "solana-sdk-ids",
+ "solana-svm-feature-set",
 ]
 
 [[package]]
@@ -115,7 +90,7 @@ version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b4ca5cad691b655986da68c0bf4a13f116e3ff0a1df315b854d447338f95f21"
 dependencies = [
- "agave-feature-set 4.0.0-rc.0",
+ "agave-feature-set",
  "solana-pubkey 4.1.0",
  "solana-sdk-ids",
 ]
@@ -4605,48 +4580,6 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "3.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "751157b033a30c178a272ec2bbab8a5bae14b21490451627990cbe84391b8264"
-dependencies = [
- "Inflector",
- "base64 0.22.1",
- "bincode",
- "bs58",
- "bv",
- "serde",
- "serde_json",
- "solana-account",
- "solana-account-decoder-client-types 3.1.14",
- "solana-address-lookup-table-interface",
- "solana-clock",
- "solana-config-interface",
- "solana-epoch-schedule",
- "solana-fee-calculator",
- "solana-instruction",
- "solana-loader-v3-interface",
- "solana-nonce",
- "solana-program-option",
- "solana-program-pack",
- "solana-pubkey 3.0.0",
- "solana-rent 3.1.0",
- "solana-sdk-ids",
- "solana-slot-hashes",
- "solana-slot-history",
- "solana-stake-interface",
- "solana-sysvar",
- "solana-vote-interface 4.0.4",
- "spl-generic-token",
- "spl-token-2022-interface",
- "spl-token-group-interface",
- "spl-token-interface",
- "spl-token-metadata-interface",
- "thiserror 2.0.18",
- "zstd",
-]
-
-[[package]]
-name = "solana-account-decoder"
 version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b46a77a786c876cba3faff781288ae910723433fe90090d002fbacb7fbfaa4f"
@@ -4659,7 +4592,7 @@ dependencies = [
  "serde",
  "serde_json",
  "solana-account",
- "solana-account-decoder-client-types 4.0.0-rc.0",
+ "solana-account-decoder-client-types",
  "solana-address-lookup-table-interface",
  "solana-clock",
  "solana-config-interface",
@@ -4677,28 +4610,13 @@ dependencies = [
  "solana-slot-history",
  "solana-stake-interface",
  "solana-sysvar",
- "solana-vote-interface 5.1.1",
+ "solana-vote-interface",
  "spl-generic-token",
  "spl-token-2022-interface",
  "spl-token-group-interface",
  "spl-token-interface",
  "spl-token-metadata-interface",
  "thiserror 2.0.18",
- "zstd",
-]
-
-[[package]]
-name = "solana-account-decoder-client-types"
-version = "3.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c200fb0019770f6ccf869a9b71653d37b76a633114d79176eedea6931c09cc7c"
-dependencies = [
- "base64 0.22.1",
- "bs58",
- "serde",
- "serde_json",
- "solana-account",
- "solana-pubkey 3.0.0",
  "zstd",
 ]
 
@@ -5438,16 +5356,6 @@ dependencies = [
 
 [[package]]
 name = "solana-reward-info"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82be7946105c2ee6be9f9ee7bd18a068b558389221d29efa92b906476102bfcc"
-dependencies = [
- "serde",
- "serde_derive",
-]
-
-[[package]]
-name = "solana-reward-info"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8f4c5c5b5599e640c15ead65be499d60f6ee62a5ba7aa7e23f5b0537046ed49"
@@ -5475,8 +5383,8 @@ dependencies = [
  "serde",
  "serde_json",
  "solana-account",
- "solana-account-decoder 4.0.0-rc.0",
- "solana-account-decoder-client-types 4.0.0-rc.0",
+ "solana-account-decoder",
+ "solana-account-decoder-client-types",
  "solana-clock",
  "solana-commitment-config",
  "solana-epoch-info",
@@ -5490,9 +5398,9 @@ dependencies = [
  "solana-signature",
  "solana-transaction",
  "solana-transaction-error",
- "solana-transaction-status-client-types 4.0.0-rc.0",
+ "solana-transaction-status-client-types",
  "solana-version",
- "solana-vote-interface 5.1.1",
+ "solana-vote-interface",
  "tokio",
 ]
 
@@ -5508,12 +5416,12 @@ dependencies = [
  "reqwest-middleware",
  "serde",
  "serde_json",
- "solana-account-decoder-client-types 4.0.0-rc.0",
+ "solana-account-decoder-client-types",
  "solana-clock",
  "solana-rpc-client-types",
  "solana-signer",
  "solana-transaction-error",
- "solana-transaction-status-client-types 4.0.0-rc.0",
+ "solana-transaction-status-client-types",
  "thiserror 2.0.18",
 ]
 
@@ -5529,16 +5437,16 @@ dependencies = [
  "serde",
  "serde_json",
  "solana-account",
- "solana-account-decoder-client-types 4.0.0-rc.0",
+ "solana-account-decoder-client-types",
  "solana-address 2.6.0",
  "solana-clock",
  "solana-commitment-config",
  "solana-fee-calculator",
  "solana-inflation",
- "solana-reward-info 5.0.0",
+ "solana-reward-info",
  "solana-transaction",
  "solana-transaction-error",
- "solana-transaction-status-client-types 4.0.0-rc.0",
+ "solana-transaction-status-client-types",
  "solana-version",
  "spl-generic-token",
  "thiserror 2.0.18",
@@ -5549,20 +5457,6 @@ name = "solana-sanitize"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
-
-[[package]]
-name = "solana-sbpf"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15b079e08471a9dbfe1e48b2c7439c85aa2a055cbd54eddd8bd257b0a7dbb29"
-dependencies = [
- "byteorder",
- "combine 3.8.1",
- "hash32",
- "log",
- "rustc-demangle",
- "thiserror 2.0.18",
-]
 
 [[package]]
 name = "solana-sbpf"
@@ -5816,7 +5710,7 @@ version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2075de0bc96d33606072e0dd76353f9b39b17c3b962fa47ac7e52674fdf8329d"
 dependencies = [
- "agave-reserved-account-keys 4.0.0-rc.0",
+ "agave-reserved-account-keys",
  "backoff",
  "bincode",
  "bytes",
@@ -5844,7 +5738,7 @@ dependencies = [
  "solana-time-utils",
  "solana-transaction",
  "solana-transaction-error",
- "solana-transaction-status 4.0.0-rc.0",
+ "solana-transaction-status",
  "thiserror 2.0.18",
  "tokio",
  "tonic 0.9.2",
@@ -5862,7 +5756,7 @@ dependencies = [
  "prost 0.11.9",
  "protobuf-src",
  "serde",
- "solana-account-decoder 4.0.0-rc.0",
+ "solana-account-decoder",
  "solana-hash 4.3.0",
  "solana-instruction",
  "solana-message",
@@ -5870,17 +5764,11 @@ dependencies = [
  "solana-serde",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context 4.0.0-rc.0",
+ "solana-transaction-context",
  "solana-transaction-error",
- "solana-transaction-status 4.0.0-rc.0",
+ "solana-transaction-status",
  "tonic-build 0.9.2",
 ]
-
-[[package]]
-name = "solana-svm-feature-set"
-version = "3.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc2e2fdebd77159b7a14ee45c9dbb3f1d202e8e7ccc14e4cda78c006a7a78a9"
 
 [[package]]
 name = "solana-svm-feature-set"
@@ -5992,23 +5880,6 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-context"
-version = "3.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a3c3a69688293a195b02c60a5384d855b8de19981f404c71ccb9e7f139b98f"
-dependencies = [
- "bincode",
- "serde",
- "solana-account",
- "solana-instruction",
- "solana-instructions-sysvar",
- "solana-pubkey 3.0.0",
- "solana-rent 3.1.0",
- "solana-sbpf 0.13.1",
- "solana-sdk-ids",
-]
-
-[[package]]
-name = "solana-transaction-context"
 version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ee065d9e0a7d374c012d541083b1e72832a7f016ac2ab493f535d07fa89c26d"
@@ -6020,7 +5891,7 @@ dependencies = [
  "solana-instructions-sysvar",
  "solana-pubkey 4.1.0",
  "solana-rent 3.1.0",
- "solana-sbpf 0.14.4",
+ "solana-sbpf",
  "solana-sdk-ids",
 ]
 
@@ -6039,55 +5910,12 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "3.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56d3f07d7cd026143e96d09cbccf37f5d5a06c4816719f7c48da32978f28aa8e"
-dependencies = [
- "Inflector",
- "agave-reserved-account-keys 3.1.14",
- "base64 0.22.1",
- "bincode",
- "borsh",
- "bs58",
- "log",
- "serde",
- "serde_json",
- "solana-account-decoder 3.1.14",
- "solana-address-lookup-table-interface",
- "solana-clock",
- "solana-hash 3.1.0",
- "solana-instruction",
- "solana-loader-v2-interface",
- "solana-loader-v3-interface",
- "solana-message",
- "solana-program-option",
- "solana-pubkey 3.0.0",
- "solana-reward-info 3.0.0",
- "solana-sdk-ids",
- "solana-signature",
- "solana-stake-interface",
- "solana-system-interface 2.0.0",
- "solana-transaction",
- "solana-transaction-error",
- "solana-transaction-status-client-types 3.1.14",
- "solana-vote-interface 4.0.4",
- "spl-associated-token-account-interface",
- "spl-memo-interface",
- "spl-token-2022-interface",
- "spl-token-group-interface",
- "spl-token-interface",
- "spl-token-metadata-interface",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "solana-transaction-status"
 version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "404b5057815311b17d79ebff956d366562d68a09d75313d0b64c5a71c4cafa7c"
 dependencies = [
  "Inflector",
- "agave-reserved-account-keys 4.0.0-rc.0",
+ "agave-reserved-account-keys",
  "base64 0.22.1",
  "bincode",
  "borsh",
@@ -6095,7 +5923,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "solana-account-decoder 4.0.0-rc.0",
+ "solana-account-decoder",
  "solana-address-lookup-table-interface",
  "solana-clock",
  "solana-hash 4.3.0",
@@ -6105,45 +5933,21 @@ dependencies = [
  "solana-message",
  "solana-program-option",
  "solana-pubkey 4.1.0",
- "solana-reward-info 5.0.0",
+ "solana-reward-info",
  "solana-sdk-ids",
  "solana-signature",
  "solana-stake-interface",
  "solana-system-interface 3.2.0",
  "solana-transaction",
  "solana-transaction-error",
- "solana-transaction-status-client-types 4.0.0-rc.0",
- "solana-vote-interface 5.1.1",
+ "solana-transaction-status-client-types",
+ "solana-vote-interface",
  "spl-associated-token-account-interface",
  "spl-memo-interface",
  "spl-token-2022-interface",
  "spl-token-group-interface",
  "spl-token-interface",
  "spl-token-metadata-interface",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "solana-transaction-status-client-types"
-version = "3.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f7c3d15f25111cd1e320ad8ee3515ccae9983ab750cec83517c8553419b70a"
-dependencies = [
- "base64 0.22.1",
- "bincode",
- "bs58",
- "serde",
- "serde_json",
- "solana-account-decoder-client-types 3.1.14",
- "solana-commitment-config",
- "solana-instruction",
- "solana-message",
- "solana-pubkey 3.0.0",
- "solana-reward-info 3.0.0",
- "solana-signature",
- "solana-transaction",
- "solana-transaction-context 3.1.14",
- "solana-transaction-error",
  "thiserror 2.0.18",
 ]
 
@@ -6158,15 +5962,15 @@ dependencies = [
  "bs58",
  "serde",
  "serde_json",
- "solana-account-decoder-client-types 4.0.0-rc.0",
+ "solana-account-decoder-client-types",
  "solana-commitment-config",
  "solana-instruction",
  "solana-message",
  "solana-pubkey 4.1.0",
- "solana-reward-info 5.0.0",
+ "solana-reward-info",
  "solana-signature",
  "solana-transaction",
- "solana-transaction-context 4.0.0-rc.0",
+ "solana-transaction-context",
  "solana-transaction-error",
  "thiserror 2.0.18",
 ]
@@ -6177,38 +5981,12 @@ version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05a72745825b1cf786bfd14024a0f52e15b5b95c7eb58152af6608804cd0fa95"
 dependencies = [
- "agave-feature-set 4.0.0-rc.0",
+ "agave-feature-set",
  "rand 0.9.2",
  "semver",
  "serde",
  "solana-sanitize",
  "solana-serde-varint",
-]
-
-[[package]]
-name = "solana-vote-interface"
-version = "4.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6e123e16bfdd7a81d71b4c4699e0b29580b619f4cd2ef5b6aae1eb85e8979f"
-dependencies = [
- "bincode",
- "cfg_eval",
- "num-derive",
- "num-traits",
- "serde",
- "serde_derive",
- "serde_with",
- "solana-clock",
- "solana-hash 3.1.0",
- "solana-instruction",
- "solana-instruction-error",
- "solana-pubkey 3.0.0",
- "solana-rent 3.1.0",
- "solana-sdk-ids",
- "solana-serde-varint",
- "solana-serialize-utils",
- "solana-short-vec",
- "solana-system-interface 2.0.0",
 ]
 
 [[package]]
@@ -6557,8 +6335,8 @@ dependencies = [
  "solana-storage-bigtable",
  "solana-transaction",
  "solana-transaction-error",
- "solana-transaction-status 4.0.0-rc.0",
- "solana-transaction-status-client-types 4.0.0-rc.0",
+ "solana-transaction-status",
+ "solana-transaction-status-client-types",
  "tokio",
  "tonic 0.14.5",
  "tracing",
@@ -6566,8 +6344,8 @@ dependencies = [
  "wincode 0.2.5",
  "wincode 0.5.3",
  "yellowstone-fumarole-client",
- "yellowstone-grpc-client 13.1.0",
- "yellowstone-grpc-proto 12.3.0",
+ "yellowstone-grpc-client",
+ "yellowstone-grpc-proto",
 ]
 
 [[package]]
@@ -6601,14 +6379,14 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "serde_yaml",
- "solana-account-decoder-client-types 4.0.0-rc.0",
+ "solana-account-decoder-client-types",
  "solana-clock",
  "solana-commitment-config",
  "solana-rpc-client-api",
  "solana-rpc-client-types",
  "solana-sdk",
- "solana-transaction-context 4.0.0-rc.0",
- "solana-transaction-status 4.0.0-rc.0",
+ "solana-transaction-context",
+ "solana-transaction-status",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -6618,8 +6396,8 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "yellowstone-block-machine",
- "yellowstone-grpc-client 11.0.0",
- "yellowstone-grpc-proto 11.0.0",
+ "yellowstone-grpc-client",
+ "yellowstone-grpc-proto",
 ]
 
 [[package]]
@@ -8169,9 +7947,9 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yellowstone-block-machine"
-version = "0.3.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f2f738fe13c97c0d3b908bdd2871270be9a32806fbbed22d68ad82190fa033"
+checksum = "f2bde506698bf9064ce7c5887046a03c4db54e8e74327bc9f3e7e86120477569"
 dependencies = [
  "bs58",
  "bytesize 2.3.1",
@@ -8186,14 +7964,11 @@ dependencies = [
  "solana-pubkey 4.1.0",
  "solana-signature",
  "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
- "tokio-util",
  "tonic 0.14.5",
  "tracing",
  "tracing-subscriber",
- "yellowstone-grpc-client 11.0.0",
- "yellowstone-grpc-proto 11.0.0",
+ "yellowstone-grpc-client",
+ "yellowstone-grpc-proto",
 ]
 
 [[package]]
@@ -8230,21 +8005,7 @@ dependencies = [
  "tower 0.5.3",
  "tracing",
  "uuid",
- "yellowstone-grpc-proto 12.3.0",
-]
-
-[[package]]
-name = "yellowstone-grpc-client"
-version = "11.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4024d13119c2b12e02829ed8e38dc676200cc0b0f5384bda94af7e47097a2ac"
-dependencies = [
- "bytes",
- "futures",
- "thiserror 2.0.18",
- "tonic 0.14.5",
- "tonic-health",
- "yellowstone-grpc-proto 11.0.0",
+ "yellowstone-grpc-proto",
 ]
 
 [[package]]
@@ -8264,35 +8025,7 @@ dependencies = [
  "tonic 0.14.5",
  "tonic-health",
  "tower 0.4.13",
- "yellowstone-grpc-proto 12.3.0",
-]
-
-[[package]]
-name = "yellowstone-grpc-proto"
-version = "11.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc56c7739daf7410bf6ef04ce71ce9b9a22483ef73b78a873815f87e9a8d1d2f"
-dependencies = [
- "anyhow",
- "bincode",
- "prost 0.14.3",
- "prost-types 0.14.3",
- "protoc-bin-vendored",
- "solana-account",
- "solana-account-decoder 3.1.14",
- "solana-clock",
- "solana-hash 4.3.0",
- "solana-message",
- "solana-pubkey 4.1.0",
- "solana-signature",
- "solana-transaction",
- "solana-transaction-context 3.1.14",
- "solana-transaction-error",
- "solana-transaction-status 3.1.14",
- "tonic 0.14.5",
- "tonic-build 0.14.5",
- "tonic-prost",
- "tonic-prost-build",
+ "yellowstone-grpc-proto",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,6 +515,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,6 +723,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,6 +749,15 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "cfg-if"
@@ -800,6 +837,17 @@ name = "cityhash-rs"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93a719913643003b84bd13022b4b7e703c09342cd03b679c4641c7d2e50dc34d"
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "clap"
@@ -1784,6 +1832,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "goauth"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2581,6 +2635,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "librocksdb-sys"
+version = "0.17.3+10.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+ "zstd-sys",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2733,6 +2823,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2806,6 +2902,16 @@ dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -3915,6 +4021,16 @@ name = "rle-decode-fast"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
+name = "rocksdb"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddb7af00d2b17dbd07d82c0063e25411959748ff03e8d4f96134c2ff41fce34f"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -6479,6 +6595,7 @@ dependencies = [
  "pyroscope",
  "pyroscope_pprofrs",
  "reqwest 0.13.2",
+ "rocksdb",
  "serde",
  "serde-big-array",
  "serde_bytes",
@@ -6492,6 +6609,7 @@ dependencies = [
  "solana-sdk",
  "solana-transaction-context 4.0.0-rc.0",
  "solana-transaction-status 4.0.0-rc.0",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tower 0.5.3",

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ Solana-compatible JSON-RPC endpoints backed by that data.
 > [!NOTE]
 > Superbank is licensed under **AGPL-3.0-only** (see `LICENSE`).
 > `superbank-rpc` supports an optional in-memory gRPC "head cache" (`--features grpc-head-cache`) to reduce
-> perceived ingestion lag and (optionally) expose `processed` commitment for a subset of methods.
-> See `crates/superbank-rpc/README.md` for details.
+> perceived ingestion lag and (optionally) expose `processed` commitment for a subset of methods,
+> and an optional RocksDB "disk cache" (`--features disk-cache`) that serves recent finalized slots
+> in place of ClickHouse. See `crates/superbank-rpc/README.md` for details.
 
 ## Features
 
@@ -248,7 +249,7 @@ cargo build -p superbank -p superbank-rpc
 cargo fmt --all -- --check
 cargo clippy --workspace --all-targets --locked -- -D warnings
 cargo test --workspace --locked
-cargo test -p superbank-rpc --features grpc-head-cache,pyroscope --locked
+cargo test -p superbank-rpc --features grpc-head-cache,pyroscope,disk-cache --locked
 ```
 
 Local RPC helper:

--- a/README.md
+++ b/README.md
@@ -258,6 +258,19 @@ Local RPC helper:
 scripts/dev/run-local-rpc.sh
 ```
 
+Disk-cache RPC helper:
+
+```bash
+DRAGONSMOUTH_ENDPOINT=https://YOUR_DRAGONSMOUTH_ENDPOINT ./test-disk-cache-rpc.sh
+```
+
+This builds `target/release/superbank-rpc` with `--features disk-cache`, runs the disk-cache test
+suite with the larger test stack this repo currently needs, then starts the server with
+`HEAD_CACHE_ENABLED=true` and `DISK_CACHE_ENABLED=true`. It defaults to local ClickHouse
+(`http://localhost:8123`, database `default`) and `target/disk-cache/superbank-rpc`; override the
+environment variables shown by `./test-disk-cache-rpc.sh --help` as needed. Use `RUN_SERVER=0` for
+build/test only or `RUN_TESTS=0` to skip tests.
+
 ### Nix (flakes)
 
 This repo includes a Nix flake with a dev shell that provides `tilt`, `docker`, `kubectl`, `kind`,

--- a/README.md
+++ b/README.md
@@ -258,19 +258,6 @@ Local RPC helper:
 scripts/dev/run-local-rpc.sh
 ```
 
-Disk-cache RPC helper:
-
-```bash
-DRAGONSMOUTH_ENDPOINT=https://YOUR_DRAGONSMOUTH_ENDPOINT ./test-disk-cache-rpc.sh
-```
-
-This builds `target/release/superbank-rpc` with `--features disk-cache`, runs the disk-cache test
-suite with the larger test stack this repo currently needs, then starts the server with
-`HEAD_CACHE_ENABLED=true` and `DISK_CACHE_ENABLED=true`. It defaults to local ClickHouse
-(`http://localhost:8123`, database `default`) and `target/disk-cache/superbank-rpc`; override the
-environment variables shown by `./test-disk-cache-rpc.sh --help` as needed. Use `RUN_SERVER=0` for
-build/test only or `RUN_TESTS=0` to skip tests.
-
 ### Nix (flakes)
 
 This repo includes a Nix flake with a dev shell that provides `tilt`, `docker`, `kubectl`, `kind`,

--- a/crates/superbank-rpc/Cargo.toml
+++ b/crates/superbank-rpc/Cargo.toml
@@ -68,9 +68,9 @@ rocksdb = { version = "0.24", optional = true, default-features = false, feature
 ] }
 pyroscope = { version = "0.5.8", optional = true }
 pyroscope_pprofrs = { version = "0.2.10", optional = true }
-yellowstone-block-machine = { version = "0.3.0", features = ["dragonsmouth"], optional = true }
-yellowstone-grpc-client = { version = "11.0.0", optional = true }
-yellowstone-grpc-proto = { version = "11.0.0", optional = true }
+yellowstone-block-machine = { version = "0.8.0", features = ["dragonsmouth"], optional = true }
+yellowstone-grpc-client = { version = "13.1.0", optional = true }
+yellowstone-grpc-proto = { version = "12.3.0", optional = true }
 
 [dev-dependencies]
 base64 = "0.22"

--- a/crates/superbank-rpc/Cargo.toml
+++ b/crates/superbank-rpc/Cargo.toml
@@ -16,6 +16,9 @@ grpc-head-cache = [
     "dep:yellowstone-grpc-client",
     "dep:yellowstone-grpc-proto",
 ]
+# RocksDB-backed cache of recent finalized slots served in place of ClickHouse.
+# Requires `grpc-head-cache`: the DragonsMouth stream is the live ingestion source.
+disk-cache = ["grpc-head-cache", "dep:rocksdb"]
 pyroscope = ["dep:pyroscope", "dep:pyroscope_pprofrs"]
 
 [dependencies]
@@ -57,6 +60,12 @@ bs58 = "0.5"
 hex = "0.4"
 ch_cityhash102 = "0.1"
 dashmap = { version = "6.1.0", optional = true }
+rocksdb = { version = "0.24", optional = true, default-features = false, features = [
+    "lz4",
+    "zstd",
+    "multi-threaded-cf",
+    "bindgen-runtime",
+] }
 pyroscope = { version = "0.5.8", optional = true }
 pyroscope_pprofrs = { version = "0.2.10", optional = true }
 yellowstone-block-machine = { version = "0.3.0", features = ["dragonsmouth"], optional = true }
@@ -65,6 +74,7 @@ yellowstone-grpc-proto = { version = "11.0.0", optional = true }
 
 [dev-dependencies]
 base64 = "0.22"
+tempfile = "3"
 
 [[bin]]
 name = "superbank-rpc"

--- a/crates/superbank-rpc/README.md
+++ b/crates/superbank-rpc/README.md
@@ -144,6 +144,80 @@ Configuration:
 License note: superbank-rpc is licensed under AGPL-3.0-only (see `../../LICENSE`).
 The optional `grpc-head-cache` feature pulls in `yellowstone-block-machine` (also AGPL-3.0).
 
+## Optional RocksDB disk cache (`disk-cache`)
+
+When compiled with `--features disk-cache` (which implies `grpc-head-cache`) and enabled at
+runtime, superbank-rpc keeps a RocksDB-backed cache of recent **finalized** slots on local disk
+and serves it *in place of* ClickHouse. The read tiering becomes:
+
+```
+head cache (memory, unfinalized tip) -> disk cache (finalized, recent slots) -> ClickHouse (full history)
+```
+
+The cache is hydrated FROM ClickHouse ("backfill") on startup, kept current by copying slots out
+of the head cache as the DragonsMouth stream finalizes them, and self-repairs gaps from
+ClickHouse. It never writes to ClickHouse. Coverage is tracked per slot and claimed atomically
+with the data, so the cache never serves a slot it holds partially; any miss, hole, or decode
+failure silently degrades to a ClickHouse read.
+
+Served from disk when covered: `getBlock` (all `transactionDetails` levels), `getBlocks`,
+`getBlocksWithLimit`, `getBlockTime`, `getTransaction`, `getSignatureStatuses`,
+`getSignaturesForAddress`, and `getTransactionsForAddress` (including `tokenAccounts` filters via
+an on-disk port of the `gsfa` and `token_owner_activity` materialized views). Address queries are
+answered from the contiguous covered span; ClickHouse is consulted only for the remainder strictly
+below the coverage floor.
+
+> [!WARNING]
+> **Sizing:** at mainnet volume the default 10-epoch window (4,320,000 slots) needs on the order
+> of **15–20 TB** of NVMe even with compression (~1.5–2 TB per epoch across the record and index
+> column families). Set `DISK_CACHE_MAX_BYTES` to bound disk usage — the retention window shrinks
+> to fit, with the tighter of the slot window and the byte budget winning.
+
+Requires `HEAD_CACHE_ENABLED=true` with a usable `DRAGONSMOUTH_ENDPOINT` (the stream is the live
+ingestion source). `HEAD_CACHE_RETAIN_SLOTS` is clamped to at least `64` when the disk cache is
+enabled: the default `32` roughly equals the mainnet finalization lag, so finalized slots would
+already be evicted from the head cache when the disk snapshot hook fires; `150` is a comfortable
+setting (~1.5–3 GB of head-cache memory at mainnet rates).
+
+Run example:
+
+```bash
+RPC_HOST=0.0.0.0 RPC_PORT=8899 CLICKHOUSE_URL=http://localhost:8123 CLICKHOUSE_DATABASE=default HEAD_CACHE_ENABLED=true HEAD_CACHE_RETAIN_SLOTS=150 DRAGONSMOUTH_ENDPOINT=https://YOUR_DRAGONSMOUTH_ENDPOINT DISK_CACHE_ENABLED=true DISK_CACHE_PATH=/var/lib/superbank/disk-cache DISK_CACHE_MAX_BYTES=2199023255552 cargo run -p superbank-rpc --features disk-cache --
+```
+
+Configuration:
+
+| Option | Environment | Default | Notes |
+| --- | --- | --- | --- |
+| `--disk-cache-enabled` | `DISK_CACHE_ENABLED` | `false` | Enables the feature at runtime. |
+| `--disk-cache-path` | `DISK_CACHE_PATH` | — | RocksDB directory; required when enabled. |
+| `--disk-cache-retain-slots` | `DISK_CACHE_RETAIN_SLOTS` | `4320000` | Finalized slots to retain (~10 epochs). |
+| `--disk-cache-max-bytes` | `DISK_CACHE_MAX_BYTES` | `0` | Disk byte budget; `0` = unlimited. Tighter of window/budget wins. |
+| `--disk-cache-block-cache-bytes` | `DISK_CACHE_BLOCK_CACHE_BYTES` | `4294967296` | RocksDB block cache shared across column families. |
+| `--disk-cache-write-queue-slots` | `DISK_CACHE_WRITE_QUEUE_SLOTS` | `64` | Live write queue depth; overflow defers slots to repair. |
+| `--disk-cache-read-concurrency` | `DISK_CACHE_READ_CONCURRENCY` | `64` | Max concurrent blocking disk reads. |
+| `--disk-cache-backfill-enabled` | `DISK_CACHE_BACKFILL_ENABLED` | `true` | ClickHouse->disk backfill/repair task. |
+| `--disk-cache-backfill-slots-per-query` | `DISK_CACHE_BACKFILL_SLOTS_PER_QUERY` | `8` | Slots per ClickHouse range query. |
+| `--disk-cache-backfill-max-slots-per-sec` | `DISK_CACHE_BACKFILL_MAX_SLOTS_PER_SEC` | `50` | Backfill rate limit (the default fills 10 epochs in ~24h). |
+| `--disk-cache-backfill-query-timeout-ms` | `DISK_CACHE_BACKFILL_QUERY_TIMEOUT_MS` | `30000` | Range scans need more than the interactive query timeout. |
+| `--disk-cache-repair-interval-ms` | `DISK_CACHE_REPAIR_INTERVAL_MS` | `5000` | Idle wait between repair/backfill planning rounds. |
+| `--disk-cache-repair-min-lag-slots` | `DISK_CACHE_REPAIR_MIN_LAG_SLOTS` | `75` | Never backfill slots ClickHouse ingest may not have landed. |
+
+Observability: `superbank_disk_cache_*` metrics cover coverage span, hit/miss per operation,
+write/backfill/repair/eviction activity, and the route metrics gain a `disk_cache_read` label.
+The `X-Superbank-Sources` response header reports `disk-cache` combinations.
+
+Parity validation against a reference target (e.g. the same build with the disk cache disabled):
+
+```bash
+k6 run tests/k6/scenarios/validation/superbank-rpc-disk-cache-parity.js \
+  -e RPC_URL=http://disk-enabled:8899 -e REFERENCE_RPC_URL=http://reference:8899 \
+  -e ADDRESS_FILE=tests/k6/data/pools/addresses.txt
+```
+
+License note: the `disk-cache` feature implies `grpc-head-cache` and therefore also pulls in
+`yellowstone-block-machine` (AGPL-3.0).
+
 ## Optional Pyroscope profiling (`pyroscope`)
 
 When compiled with `--features pyroscope` and enabled at runtime, superbank-rpc captures CPU

--- a/crates/superbank-rpc/README.md
+++ b/crates/superbank-rpc/README.md
@@ -215,6 +215,19 @@ k6 run tests/k6/scenarios/validation/superbank-rpc-disk-cache-parity.js \
   -e ADDRESS_FILE=tests/k6/data/pools/addresses.txt
 ```
 
+Performance comparison against the same build without disk cache:
+
+```bash
+k6 run tests/k6/scenarios/performance/superbank-rpc-disk-cache-compare.js \
+  -e RPC_URL=http://disk-enabled:8899 -e REFERENCE_RPC_URL=http://disk-disabled:8899 \
+  -e ADDRESS_FILE=tests/k6/data/pools/addresses.txt \
+  -e VUS=10 -e DURATION=60s
+```
+
+The performance scenario pre-probes the target and only keeps workload items whose
+`X-Superbank-Sources` header reports a disk-cache hit, then reports per-method latency deltas and
+speedup ratios versus the reference.
+
 License note: the `disk-cache` feature implies `grpc-head-cache` and therefore also pulls in
 `yellowstone-block-machine` (AGPL-3.0).
 

--- a/crates/superbank-rpc/src/clickhouse/blocks.rs
+++ b/crates/superbank-rpc/src/clickhouse/blocks.rs
@@ -74,6 +74,51 @@ where
     shard_indices
 }
 
+#[cfg(feature = "disk-cache")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ShardSlotRange {
+    shard_index: usize,
+    start_slot: u64,
+    end_slot: u64,
+}
+
+#[cfg(feature = "disk-cache")]
+fn shard_slot_ranges_for_slot_range<F>(
+    start_slot: u64,
+    end_slot: u64,
+    mut shard_index_for_bucket: F,
+) -> Vec<ShardSlotRange>
+where
+    F: FnMut(u64) -> usize,
+{
+    if end_slot < start_slot {
+        return Vec::new();
+    }
+
+    let mut ranges = Vec::new();
+    let mut segment_start = start_slot;
+    loop {
+        let bucket = segment_start / SLOT_SHARD_DIVISOR;
+        let next_bucket_start = bucket
+            .checked_add(1)
+            .and_then(|next_bucket| next_bucket.checked_mul(SLOT_SHARD_DIVISOR))
+            .unwrap_or(u64::MAX);
+        let segment_end = next_bucket_start.saturating_sub(1).min(end_slot);
+        ranges.push(ShardSlotRange {
+            shard_index: shard_index_for_bucket(bucket),
+            start_slot: segment_start,
+            end_slot: segment_end,
+        });
+
+        if segment_end == end_slot {
+            break;
+        }
+        segment_start = segment_end + 1;
+    }
+
+    ranges
+}
+
 fn normalize_slots(mut slots: Vec<u64>) -> Vec<u64> {
     if slots.len() <= 1 {
         return slots;
@@ -192,17 +237,24 @@ fn build_block_metadata_range_query(
 ) -> String {
     let mut columns = BLOCK_METADATA_BASE_COLUMNS.to_vec();
     columns.extend_from_slice(BLOCK_METADATA_REWARD_COLUMNS);
+    let start_bucket = start_slot / SLOT_SHARD_DIVISOR;
+    let end_bucket = end_slot / SLOT_SHARD_DIVISOR;
 
     format!(
         "SELECT
                 {columns}
              FROM {blocks_metadata_table}
-             PREWHERE slot BETWEEN {start_slot} AND {end_slot}
+             PREWHERE
+                intDiv(slot, {slot_shard_divisor}) BETWEEN {start_bucket} AND {end_bucket}
+                AND slot BETWEEN {start_slot} AND {end_slot}
              ORDER BY slot ASC
              LIMIT 1 BY slot
              {settings_clause}",
         columns = format_select_columns(&columns),
         blocks_metadata_table = table,
+        slot_shard_divisor = SLOT_SHARD_DIVISOR,
+        start_bucket = start_bucket,
+        end_bucket = end_bucket,
         start_slot = start_slot,
         end_slot = end_slot,
         settings_clause = settings_clause
@@ -273,6 +325,64 @@ async fn fetch_block_metadata_projection(
         };
         Ok((row_opt.map(map_block_metadata_base_row), timings))
     }
+}
+
+#[cfg(feature = "disk-cache")]
+async fn fetch_block_metadata_range(
+    client: &clickhouse::Client,
+    query: &str,
+) -> ProcessingResult<(Vec<BlockMetadataRecord>, QueryTimings)> {
+    let start = Instant::now();
+    let mut cursor = client
+        .query(query)
+        .fetch::<BlockMetadataRow>()
+        .map_err(|e| ProcessingError::database(e.to_string(), e))?;
+    let mut records = Vec::new();
+    while let Some(row) = cursor
+        .next()
+        .await
+        .map_err(|e| ProcessingError::database(e.to_string(), e))?
+    {
+        records.push(map_block_metadata_row(row));
+    }
+    let timings = QueryTimings {
+        elapsed_ms: start.elapsed().as_millis() as u64,
+        received_bytes: cursor.received_bytes(),
+        decoded_bytes: cursor.decoded_bytes(),
+        rows_read: Some(0),
+        rows_read_unknown: true,
+        rows_returned: records.len() as u64,
+    };
+    Ok((records, timings))
+}
+
+#[cfg(feature = "disk-cache")]
+async fn fetch_transaction_range(
+    client: &clickhouse::Client,
+    query: &str,
+) -> ProcessingResult<(Vec<StoredTransactionRecord>, QueryTimings)> {
+    let start = Instant::now();
+    let mut cursor = client
+        .query(query)
+        .fetch::<TransactionRow>()
+        .map_err(|e| ProcessingError::database(e.to_string(), e))?;
+    let mut records = Vec::new();
+    while let Some(row) = cursor
+        .next()
+        .await
+        .map_err(|e| ProcessingError::database(e.to_string(), e))?
+    {
+        records.push(map_transaction_row(row));
+    }
+    let timings = QueryTimings {
+        elapsed_ms: start.elapsed().as_millis() as u64,
+        received_bytes: cursor.received_bytes(),
+        decoded_bytes: cursor.decoded_bytes(),
+        rows_read: Some(0),
+        rows_read_unknown: true,
+        rows_returned: records.len() as u64,
+    };
+    Ok((records, timings))
 }
 
 async fn fetch_block_signatures_projection(
@@ -1382,9 +1492,9 @@ impl ClickHouseClient {
     }
 
     /// All block metadata in `[start_slot, end_slot]`, ascending, rewards
-    /// included. Disk-cache backfill only: always uses the distributed table
-    /// (slot ranges can straddle shard buckets, mirroring
-    /// `get_block_slots_by_range`) and a caller-provided timeout sized for
+    /// included. Disk-cache backfill only: shard-direct deployments use the
+    /// shard-local table for each covered slot bucket; distributed deployments
+    /// use the distributed table. The caller-provided timeout is sized for
     /// range scans rather than interactive reads.
     #[cfg(feature = "disk-cache")]
     pub(crate) async fn get_block_metadata_by_slot_range(
@@ -1394,9 +1504,61 @@ impl ClickHouseClient {
         timeout: std::time::Duration,
     ) -> ProcessingResult<(Vec<BlockMetadataRecord>, QueryTimings)> {
         self.with_timeout_duration("get_block_metadata_by_slot_range", timeout, async {
-            let settings_clause = self.select_settings_clause(
+            if self.scope_shard_direct()
+                && let (Some(topology), Some(local_table)) =
+                    (&self.shard_topology, &self.blocks_metadata_local_table)
+            {
+                let settings_clause = self.select_settings_clause_with_timeout(
+                    "get_block_metadata_by_slot_range_local_http",
+                    QueryFreshnessClass::Historical,
+                    timeout,
+                );
+                let ranges = shard_slot_ranges_for_slot_range(start_slot, end_slot, |bucket| {
+                    topology.shard_index_for_hash(bucket)
+                });
+                let mut records = Vec::new();
+                let mut timings = QueryTimings::zero();
+                let mut local_failed = false;
+                for range in ranges {
+                    let Some(shard) = topology.shards.get(range.shard_index) else {
+                        local_failed = true;
+                        continue;
+                    };
+                    let query = build_block_metadata_range_query(
+                        local_table,
+                        range.start_slot,
+                        range.end_slot,
+                        &settings_clause,
+                    );
+                    match fetch_block_metadata_range(&shard.http_client, &query).await {
+                        Ok((mut local_records, local_timings)) => {
+                            timings.add(local_timings);
+                            records.append(&mut local_records);
+                        }
+                        Err(err) => {
+                            tracing::warn!(
+                                "Shard {}:{} HTTP range query failed; falling back to distributed table: {}",
+                                shard.host,
+                                shard.tcp_port,
+                                err
+                            );
+                            records.clear();
+                            timings = QueryTimings::zero();
+                            local_failed = true;
+                            break;
+                        }
+                    }
+                }
+
+                if !local_failed {
+                    return Ok((records, timings));
+                }
+            }
+
+            let settings_clause = self.select_settings_clause_with_timeout(
                 "get_block_metadata_by_slot_range",
                 QueryFreshnessClass::Historical,
+                timeout,
             );
             let query = build_block_metadata_range_query(
                 &self.blocks_metadata_table,
@@ -1405,29 +1567,7 @@ impl ClickHouseClient {
                 &settings_clause,
             );
 
-            let start = Instant::now();
-            let mut cursor = self
-                .client
-                .query(&query)
-                .fetch::<BlockMetadataRow>()
-                .map_err(|e| ProcessingError::database(e.to_string(), e))?;
-            let mut records = Vec::new();
-            while let Some(row) = cursor
-                .next()
-                .await
-                .map_err(|e| ProcessingError::database(e.to_string(), e))?
-            {
-                records.push(map_block_metadata_row(row));
-            }
-            let timings = QueryTimings {
-                elapsed_ms: start.elapsed().as_millis() as u64,
-                received_bytes: cursor.received_bytes(),
-                decoded_bytes: cursor.decoded_bytes(),
-                rows_read: Some(0),
-                rows_read_unknown: true,
-                rows_returned: records.len() as u64,
-            };
-            Ok((records, timings))
+            fetch_block_metadata_range(&self.client, &query).await
         })
         .await
     }
@@ -1446,9 +1586,61 @@ impl ClickHouseClient {
             "get_block_full_transactions_by_slot_range",
             timeout,
             async {
-                let settings_clause = self.select_settings_clause(
+                if self.scope_shard_direct()
+                    && let (Some(topology), Some(local_table)) =
+                        (&self.shard_topology, &self.transactions_local_table)
+                {
+                    let settings_clause = self.select_settings_clause_with_timeout(
+                        "get_block_full_transactions_by_slot_range_local_http",
+                        QueryFreshnessClass::Historical,
+                        timeout,
+                    );
+                    let ranges = shard_slot_ranges_for_slot_range(start_slot, end_slot, |bucket| {
+                        topology.shard_index_for_hash(bucket)
+                    });
+                    let mut records = Vec::new();
+                    let mut timings = QueryTimings::zero();
+                    let mut local_failed = false;
+                    for range in ranges {
+                        let Some(shard) = topology.shards.get(range.shard_index) else {
+                            local_failed = true;
+                            continue;
+                        };
+                        let query = build_transactions_by_slot_range_query(
+                            local_table,
+                            range.start_slot,
+                            range.end_slot,
+                            &settings_clause,
+                        );
+                        match fetch_transaction_range(&shard.http_client, &query).await {
+                            Ok((mut local_records, local_timings)) => {
+                                timings.add(local_timings);
+                                records.append(&mut local_records);
+                            }
+                            Err(err) => {
+                                tracing::warn!(
+                                    "Shard {}:{} HTTP transaction range query failed; falling back to distributed table: {}",
+                                    shard.host,
+                                    shard.tcp_port,
+                                    err
+                                );
+                                records.clear();
+                                timings = QueryTimings::zero();
+                                local_failed = true;
+                                break;
+                            }
+                        }
+                    }
+
+                    if !local_failed {
+                        return Ok((records, timings));
+                    }
+                }
+
+                let settings_clause = self.select_settings_clause_with_timeout(
                     "get_block_full_transactions_by_slot_range",
                     QueryFreshnessClass::Historical,
+                    timeout,
                 );
                 let query = build_transactions_by_slot_range_query(
                     &self.transaction_table,
@@ -1457,29 +1649,7 @@ impl ClickHouseClient {
                     &settings_clause,
                 );
 
-                let start = Instant::now();
-                let mut cursor = self
-                    .client
-                    .query(&query)
-                    .fetch::<TransactionRow>()
-                    .map_err(|e| ProcessingError::database(e.to_string(), e))?;
-                let mut records = Vec::new();
-                while let Some(row) = cursor
-                    .next()
-                    .await
-                    .map_err(|e| ProcessingError::database(e.to_string(), e))?
-                {
-                    records.push(map_transaction_row(row));
-                }
-                let timings = QueryTimings {
-                    elapsed_ms: start.elapsed().as_millis() as u64,
-                    received_bytes: cursor.received_bytes(),
-                    decoded_bytes: cursor.decoded_bytes(),
-                    rows_read: Some(0),
-                    rows_read_unknown: true,
-                    rows_returned: records.len() as u64,
-                };
-                Ok((records, timings))
+                fetch_transaction_range(&self.client, &query).await
             },
         )
         .await
@@ -1492,6 +1662,10 @@ mod tests {
         BlockTransactionProjection, SLOT_SHARD_DIVISOR, build_block_metadata_query,
         build_block_transactions_query, build_transaction_count_query, normalize_slots,
         shard_indices_for_slot_range,
+    };
+    #[cfg(feature = "disk-cache")]
+    use super::{
+        ShardSlotRange, build_block_metadata_range_query, shard_slot_ranges_for_slot_range,
     };
 
     #[test]
@@ -1522,6 +1696,44 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "disk-cache")]
+    fn shard_slot_ranges_for_slot_range_keeps_single_bucket_together() {
+        let ranges = shard_slot_ranges_for_slot_range(10, 100, |bucket| (bucket % 3) as usize);
+        assert_eq!(
+            ranges,
+            vec![ShardSlotRange {
+                shard_index: 0,
+                start_slot: 10,
+                end_slot: 100,
+            }]
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "disk-cache")]
+    fn shard_slot_ranges_for_slot_range_splits_at_bucket_boundaries() {
+        let start_slot = SLOT_SHARD_DIVISOR - 2;
+        let end_slot = SLOT_SHARD_DIVISOR + 2;
+        let ranges =
+            shard_slot_ranges_for_slot_range(start_slot, end_slot, |bucket| bucket as usize);
+        assert_eq!(
+            ranges,
+            vec![
+                ShardSlotRange {
+                    shard_index: 0,
+                    start_slot,
+                    end_slot: SLOT_SHARD_DIVISOR - 1,
+                },
+                ShardSlotRange {
+                    shard_index: 1,
+                    start_slot: SLOT_SHARD_DIVISOR,
+                    end_slot,
+                },
+            ]
+        );
+    }
+
+    #[test]
     fn normalize_slots_handles_empty_and_singleton() {
         assert_eq!(normalize_slots(Vec::new()), Vec::<u64>::new());
         assert_eq!(normalize_slots(vec![42]), vec![42]);
@@ -1540,6 +1752,20 @@ mod tests {
         assert!(query.contains("executed_transaction_count"));
         assert!(!query.contains("rewards_present"));
         assert!(!query.contains("rewards_pubkey"));
+    }
+
+    #[test]
+    #[cfg(feature = "disk-cache")]
+    fn block_metadata_range_query_includes_bucket_predicate_for_shard_pruning() {
+        let query = build_block_metadata_range_query(
+            "default.blocks_metadata",
+            SLOT_SHARD_DIVISOR + 1,
+            SLOT_SHARD_DIVISOR + 10,
+            "",
+        );
+
+        assert!(query.contains("intDiv(slot, 432000) BETWEEN 1 AND 1"));
+        assert!(query.contains("AND slot BETWEEN 432001 AND 432010"));
     }
 
     #[test]

--- a/crates/superbank-rpc/src/clickhouse/blocks.rs
+++ b/crates/superbank-rpc/src/clickhouse/blocks.rs
@@ -15,6 +15,8 @@ use crate::processing::{ProcessingError, ProcessingResult};
 use super::QueryFreshnessClass;
 use super::client::ClickHouseClient;
 use super::constants::SLOT_SHARD_DIVISOR;
+#[cfg(feature = "disk-cache")]
+use super::queries::build_transactions_by_slot_range_query;
 use super::queries::{
     BLOCK_ACCOUNTS_BASE_COLUMNS, BLOCK_FULL_BASE_COLUMNS, BLOCK_METADATA_BASE_COLUMNS,
     BLOCK_METADATA_REWARD_COLUMNS, BLOCK_SIGNATURE_COLUMNS, BLOCK_TRANSACTION_REWARD_COLUMNS,
@@ -26,6 +28,8 @@ use super::rows::{
     map_block_full_transaction_row, map_block_metadata_base_row, map_block_metadata_row,
     map_block_signature_row,
 };
+#[cfg(feature = "disk-cache")]
+use super::rows::{TransactionRow, map_transaction_row};
 use super::types::{
     BlockMetadataRecord, InflationRewardRecord, QueryTimings, StoredAccountsTransactionRecord,
     StoredTransactionRecord,
@@ -172,6 +176,35 @@ fn build_block_transactions_query(
         columns = format_select_columns(&columns),
         transaction_table = table,
         slot = slot,
+        settings_clause = settings_clause
+    )
+}
+
+/// Range variant for disk-cache backfill: every block in `[start, end]`,
+/// rewards included, ascending. Always routed via the distributed table because
+/// slot ranges can straddle shard buckets.
+#[cfg(feature = "disk-cache")]
+fn build_block_metadata_range_query(
+    table: &str,
+    start_slot: u64,
+    end_slot: u64,
+    settings_clause: &str,
+) -> String {
+    let mut columns = BLOCK_METADATA_BASE_COLUMNS.to_vec();
+    columns.extend_from_slice(BLOCK_METADATA_REWARD_COLUMNS);
+
+    format!(
+        "SELECT
+                {columns}
+             FROM {blocks_metadata_table}
+             PREWHERE slot BETWEEN {start_slot} AND {end_slot}
+             ORDER BY slot ASC
+             LIMIT 1 BY slot
+             {settings_clause}",
+        columns = format_select_columns(&columns),
+        blocks_metadata_table = table,
+        start_slot = start_slot,
+        end_slot = end_slot,
         settings_clause = settings_clause
     )
 }
@@ -1345,6 +1378,110 @@ impl ClickHouseClient {
 
             Ok((records, timings))
         })
+        .await
+    }
+
+    /// All block metadata in `[start_slot, end_slot]`, ascending, rewards
+    /// included. Disk-cache backfill only: always uses the distributed table
+    /// (slot ranges can straddle shard buckets, mirroring
+    /// `get_block_slots_by_range`) and a caller-provided timeout sized for
+    /// range scans rather than interactive reads.
+    #[cfg(feature = "disk-cache")]
+    pub(crate) async fn get_block_metadata_by_slot_range(
+        &self,
+        start_slot: u64,
+        end_slot: u64,
+        timeout: std::time::Duration,
+    ) -> ProcessingResult<(Vec<BlockMetadataRecord>, QueryTimings)> {
+        self.with_timeout_duration("get_block_metadata_by_slot_range", timeout, async {
+            let settings_clause = self.select_settings_clause(
+                "get_block_metadata_by_slot_range",
+                QueryFreshnessClass::Historical,
+            );
+            let query = build_block_metadata_range_query(
+                &self.blocks_metadata_table,
+                start_slot,
+                end_slot,
+                &settings_clause,
+            );
+
+            let start = Instant::now();
+            let mut cursor = self
+                .client
+                .query(&query)
+                .fetch::<BlockMetadataRow>()
+                .map_err(|e| ProcessingError::database(e.to_string(), e))?;
+            let mut records = Vec::new();
+            while let Some(row) = cursor
+                .next()
+                .await
+                .map_err(|e| ProcessingError::database(e.to_string(), e))?
+            {
+                records.push(map_block_metadata_row(row));
+            }
+            let timings = QueryTimings {
+                elapsed_ms: start.elapsed().as_millis() as u64,
+                received_bytes: cursor.received_bytes(),
+                decoded_bytes: cursor.decoded_bytes(),
+                rows_read: Some(0),
+                rows_read_unknown: true,
+                rows_returned: records.len() as u64,
+            };
+            Ok((records, timings))
+        })
+        .await
+    }
+
+    /// All transactions in `[start_slot, end_slot]`, ordered by
+    /// `(slot, slot_idx)` ascending. Disk-cache backfill only; see
+    /// [`Self::get_block_metadata_by_slot_range`] for the routing rationale.
+    #[cfg(feature = "disk-cache")]
+    pub(crate) async fn get_block_full_transactions_by_slot_range(
+        &self,
+        start_slot: u64,
+        end_slot: u64,
+        timeout: std::time::Duration,
+    ) -> ProcessingResult<(Vec<StoredTransactionRecord>, QueryTimings)> {
+        self.with_timeout_duration(
+            "get_block_full_transactions_by_slot_range",
+            timeout,
+            async {
+                let settings_clause = self.select_settings_clause(
+                    "get_block_full_transactions_by_slot_range",
+                    QueryFreshnessClass::Historical,
+                );
+                let query = build_transactions_by_slot_range_query(
+                    &self.transaction_table,
+                    start_slot,
+                    end_slot,
+                    &settings_clause,
+                );
+
+                let start = Instant::now();
+                let mut cursor = self
+                    .client
+                    .query(&query)
+                    .fetch::<TransactionRow>()
+                    .map_err(|e| ProcessingError::database(e.to_string(), e))?;
+                let mut records = Vec::new();
+                while let Some(row) = cursor
+                    .next()
+                    .await
+                    .map_err(|e| ProcessingError::database(e.to_string(), e))?
+                {
+                    records.push(map_transaction_row(row));
+                }
+                let timings = QueryTimings {
+                    elapsed_ms: start.elapsed().as_millis() as u64,
+                    received_bytes: cursor.received_bytes(),
+                    decoded_bytes: cursor.decoded_bytes(),
+                    rows_read: Some(0),
+                    rows_read_unknown: true,
+                    rows_returned: records.len() as u64,
+                };
+                Ok((records, timings))
+            },
+        )
         .await
     }
 }

--- a/crates/superbank-rpc/src/clickhouse/client.rs
+++ b/crates/superbank-rpc/src/clickhouse/client.rs
@@ -851,6 +851,19 @@ impl ClickHouseClient {
         operation: &'static str,
         fut: impl std::future::Future<Output = ProcessingResult<T>>,
     ) -> ProcessingResult<T> {
+        self.with_timeout_duration(operation, self.query_timeout, fut)
+            .await
+    }
+
+    /// [`Self::with_timeout`] with an explicit deadline, for operations whose
+    /// budget differs from the interactive query timeout (e.g. disk-cache
+    /// backfill range scans).
+    pub(crate) async fn with_timeout_duration<T>(
+        &self,
+        operation: &'static str,
+        timeout: std::time::Duration,
+        fut: impl std::future::Future<Output = ProcessingResult<T>>,
+    ) -> ProcessingResult<T> {
         // Gate every direct (non-fanout) ClickHouse HTTP query on a global permit so concurrent
         // HTTP connections do not track raw request/batch concurrency. Fanout paths use
         // `fanout_sem` and are not gated here; the surrounding request timeout bounds the wait for
@@ -863,13 +876,12 @@ impl ClickHouseClient {
         // the call tree and overflow the (2 MiB) worker/test thread stack; boxing keeps each
         // `with_timeout` future pointer-sized in its caller.
         let fut = Box::pin(fut);
-        match tokio::time::timeout(self.query_timeout, fut).await {
+        match tokio::time::timeout(timeout, fut).await {
             Ok(result) => result,
             Err(_) => {
                 crate::metrics::clickhouse_timeout(operation);
                 Err(ProcessingError::timeout_msg(format!(
-                    "ClickHouse operation '{operation}' timed out after {:?}",
-                    self.query_timeout
+                    "ClickHouse operation '{operation}' timed out after {timeout:?}"
                 )))
             }
         }

--- a/crates/superbank-rpc/src/clickhouse/client.rs
+++ b/crates/superbank-rpc/src/clickhouse/client.rs
@@ -797,6 +797,15 @@ impl ClickHouseClient {
         operation: &'static str,
         freshness: QueryFreshnessClass,
     ) -> String {
+        self.select_settings_clause_with_timeout(operation, freshness, self.query_timeout)
+    }
+
+    pub(crate) fn select_settings_clause_with_timeout(
+        &self,
+        operation: &'static str,
+        freshness: QueryFreshnessClass,
+        timeout: Duration,
+    ) -> String {
         // Bound the server-side query lifetime so a query ClickHouse keeps running after
         // `with_timeout` drops the HTTP future does not linger and hold a connection.
         append_max_execution_time_setting(
@@ -807,7 +816,7 @@ impl ClickHouseClient {
                 false,
                 operation,
             ),
-            self.query_timeout,
+            timeout,
         )
     }
 
@@ -1950,7 +1959,7 @@ fn split_table_reference<'a>(default_database: &'a str, table: &'a str) -> (&'a 
 #[cfg(test)]
 mod tests {
     use std::path::{Path, PathBuf};
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     use super::{
         ClickHouseClient, ClickHouseClientOptions, kill_query_sql, shard_tcp_query_timeout_for,
@@ -2081,6 +2090,22 @@ mod tests {
         assert!(clause.contains("query_cache_ttl=10"));
         assert!(!clause.contains("query_cache_min_query_runs"));
         assert!(clause.contains("max_execution_time=8"));
+    }
+
+    #[test]
+    fn settings_clause_can_use_explicit_timeout() {
+        let client = test_client_with_query_cache();
+
+        let clause = client.select_settings_clause_with_timeout(
+            "get_block_full_transactions_by_slot_range",
+            QueryFreshnessClass::Historical,
+            Duration::from_millis(30_000),
+        );
+
+        assert!(clause.contains("query_cache_ttl=10"));
+        assert!(!clause.contains("query_cache_min_query_runs"));
+        assert!(clause.contains("max_execution_time=30"));
+        assert!(!clause.contains("max_execution_time=8"));
     }
 
     #[tokio::test]

--- a/crates/superbank-rpc/src/clickhouse/gsfa.rs
+++ b/crates/superbank-rpc/src/clickhouse/gsfa.rs
@@ -18,7 +18,7 @@ use crate::processing::{ProcessingError, ProcessingResult};
 
 use super::QueryFreshnessClass;
 use super::client::{ClickHouseClient, execute_shard_tcp_query_block};
-use super::queries::build_pagination_clauses;
+use super::queries::{build_hot_position_pagination_clauses, build_pagination_clauses};
 use super::sharding::{ShardTarget, ShardTopology};
 use super::types::{QueryTimings, SignatureRecord, SlotBoundary};
 use super::util::{
@@ -143,6 +143,10 @@ fn merge_hot_signature_records(
 impl ClickHouseClient {
     pub(crate) fn is_gsfa_hot_address(&self, pubkey: &Pubkey) -> bool {
         self.gsfa_hot_pubkeys.contains(pubkey)
+    }
+
+    pub(crate) fn should_use_gsfa_hot_fanout(&self, pubkey: &Pubkey) -> bool {
+        self.is_gsfa_hot_address(pubkey) && self.shard_topology.is_some()
     }
 
     pub(crate) fn should_use_gsfa_shard_routing(&self, pubkey: &Pubkey) -> bool {
@@ -304,7 +308,8 @@ impl ClickHouseClient {
         let hot_table = self.gsfa_hot_local_table.clone();
         let addr_bucket = cityhash64(pubkey.as_ref()) % self.bucket_moduli.gsfa_hot;
         let address_literal = pubkey_literal(pubkey);
-        let (with_clause, where_clause) = build_pagination_clauses(before_pos, until_pos);
+        let (with_clause, where_clause) =
+            build_hot_position_pagination_clauses(before_pos, until_pos);
         let spec = HotGsfaQuerySpec {
             local_table: hot_table,
             addr_bucket,
@@ -605,7 +610,7 @@ impl ClickHouseClient {
             let pubkey = Pubkey::from_str(address)
                 .map_err(|e| ProcessingError::deserialization("Invalid address", e))?;
 
-            if self.is_gsfa_hot_address(&pubkey) {
+            if self.should_use_gsfa_hot_fanout(&pubkey) {
                 return self
                     .get_hot_signatures_for_address_with_positions(
                         address, &pubkey, limit, before_pos, until_pos,
@@ -1232,6 +1237,20 @@ mod tests {
             client.gsfa_table_for_address(&hot_pubkey),
             "default.gsfa_hot"
         );
+        assert!(!client.should_use_gsfa_shard_routing(&hot_pubkey));
+    }
+
+    #[test]
+    fn hot_addresses_without_topology_use_distributed_hot_table_not_fanout() {
+        let mut client = test_client();
+        let hot_pubkey = Pubkey::new_from_array([7; 32]);
+        client.gsfa_hot_pubkeys.insert(hot_pubkey);
+
+        assert_eq!(
+            client.gsfa_table_for_address(&hot_pubkey),
+            "default.gsfa_hot"
+        );
+        assert!(!client.should_use_gsfa_hot_fanout(&hot_pubkey));
         assert!(!client.should_use_gsfa_shard_routing(&hot_pubkey));
     }
 

--- a/crates/superbank-rpc/src/clickhouse/mod.rs
+++ b/crates/superbank-rpc/src/clickhouse/mod.rs
@@ -30,3 +30,8 @@ pub(crate) use types::{ResolvedSignatureFilter, SignatureSlot, SlotBoundary};
 
 pub(crate) use sharding::{RoutingPolicy, RoutingScope, RoutingTransport, ShardRoutingConfig};
 pub(crate) use util::{QueryCacheConfig, QueryFreshnessClass};
+
+#[cfg(feature = "grpc-head-cache")]
+pub(crate) use util::extract_memo;
+#[cfg(feature = "disk-cache")]
+pub(crate) use util::parse_err_json;

--- a/crates/superbank-rpc/src/clickhouse/queries.rs
+++ b/crates/superbank-rpc/src/clickhouse/queries.rs
@@ -832,6 +832,32 @@ pub(crate) fn build_transactions_by_slot_signatures_query(
     )
 }
 
+/// Range scan for disk-cache backfill: every transaction in
+/// `[start_slot, end_slot]` in `(slot, slot_idx)` order. `LIMIT 1 BY signature`
+/// mirrors the per-slot block query's ReplacingMergeTree dedup.
+#[cfg(feature = "disk-cache")]
+pub(crate) fn build_transactions_by_slot_range_query(
+    transaction_table: &str,
+    start_slot: u64,
+    end_slot: u64,
+    settings_clause: &str,
+) -> String {
+    format!(
+        "SELECT
+            {columns}
+         FROM {transaction_table}
+         PREWHERE slot BETWEEN {start_slot} AND {end_slot}
+         ORDER BY slot ASC, slot_idx ASC, signature ASC
+         LIMIT 1 BY signature
+         {settings_clause}",
+        columns = TRANSACTION_SELECT_COLUMNS,
+        transaction_table = transaction_table,
+        start_slot = start_slot,
+        end_slot = end_slot,
+        settings_clause = settings_clause
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use ch_cityhash102::cityhash64;

--- a/crates/superbank-rpc/src/clickhouse/queries.rs
+++ b/crates/superbank-rpc/src/clickhouse/queries.rs
@@ -9,6 +9,7 @@ use ch_cityhash102::cityhash64;
 
 use crate::processing::{ProcessingError, ProcessingResult};
 
+#[cfg(feature = "disk-cache")]
 use super::constants::SLOT_SHARD_DIVISOR;
 use super::types::{
     NumericFilter, PaginationToken, ResolvedSignatureFilter, SignatureFilter, SignatureSlot,
@@ -405,6 +406,28 @@ fn slot_idx_condition(expr: &SignaturePositionExpr, comparison: SlotIdxCompariso
     }
 }
 
+fn slot_idx_condition_for_position(
+    position: SignatureSlot,
+    comparison: SlotIdxComparison,
+) -> String {
+    let slot = position.slot;
+    let idx = position.slot_idx;
+    match comparison {
+        SlotIdxComparison::Lt => {
+            format!("(slot < {slot} OR (slot = {slot} AND slot_idx < {idx}))")
+        }
+        SlotIdxComparison::Lte => {
+            format!("(slot < {slot} OR (slot = {slot} AND slot_idx <= {idx}))")
+        }
+        SlotIdxComparison::Gt => {
+            format!("(slot > {slot} OR (slot = {slot} AND slot_idx > {idx}))")
+        }
+        SlotIdxComparison::Gte => {
+            format!("(slot > {slot} OR (slot = {slot} AND slot_idx >= {idx}))")
+        }
+    }
+}
+
 fn apply_signature_filter(
     signatures_table: &str,
     signature_bucket_modulus: u64,
@@ -489,34 +512,37 @@ fn apply_pagination_token(
     Ok(())
 }
 
-fn apply_resolved_signature_filter(filter: &ResolvedSignatureFilter, conditions: &mut Vec<String>) {
+fn apply_hot_resolved_signature_filter(
+    filter: &ResolvedSignatureFilter,
+    conditions: &mut Vec<String>,
+) {
     if let Some(position) = filter.gte {
-        conditions.push(slot_idx_condition(
-            &signature_position_for_token(position.slot, position.slot_idx),
+        conditions.push(slot_idx_condition_for_position(
+            position,
             SlotIdxComparison::Gte,
         ));
     }
     if let Some(position) = filter.gt {
-        conditions.push(slot_idx_condition(
-            &signature_position_for_token(position.slot, position.slot_idx),
+        conditions.push(slot_idx_condition_for_position(
+            position,
             SlotIdxComparison::Gt,
         ));
     }
     if let Some(position) = filter.lte {
-        conditions.push(slot_idx_condition(
-            &signature_position_for_token(position.slot, position.slot_idx),
+        conditions.push(slot_idx_condition_for_position(
+            position,
             SlotIdxComparison::Lte,
         ));
     }
     if let Some(position) = filter.lt {
-        conditions.push(slot_idx_condition(
-            &signature_position_for_token(position.slot, position.slot_idx),
+        conditions.push(slot_idx_condition_for_position(
+            position,
             SlotIdxComparison::Lt,
         ));
     }
 }
 
-fn apply_resolved_pagination_token(
+fn apply_hot_resolved_pagination_token(
     pagination: SignatureSlot,
     sort_order: SortOrder,
     conditions: &mut Vec<String>,
@@ -525,10 +551,7 @@ fn apply_resolved_pagination_token(
         SortOrder::Desc => SlotIdxComparison::Lt,
         SortOrder::Asc => SlotIdxComparison::Gt,
     };
-    conditions.push(slot_idx_condition(
-        &signature_position_for_token(pagination.slot, pagination.slot_idx),
-        comparison,
-    ));
+    conditions.push(slot_idx_condition_for_position(pagination, comparison));
 }
 
 pub(crate) fn build_pagination_clauses(
@@ -564,6 +587,41 @@ pub(crate) fn build_pagination_clauses(
                     slot = until_pos.slot,
                     idx = until_pos.slot_idx
                 )
+            }
+            SlotBoundary::Slot(slot) => format!("slot > {slot}"),
+        };
+        conditions.push(condition);
+    }
+
+    let where_clause = if conditions.is_empty() {
+        "1".to_string()
+    } else {
+        conditions.join(" AND ")
+    };
+
+    (String::new(), where_clause)
+}
+
+pub(crate) fn build_hot_position_pagination_clauses(
+    before: Option<SlotBoundary>,
+    until: Option<SlotBoundary>,
+) -> (String, String) {
+    let mut conditions = Vec::new();
+
+    if let Some(before) = before {
+        let condition = match before {
+            SlotBoundary::Position(position) => {
+                slot_idx_condition_for_position(position, SlotIdxComparison::Lt)
+            }
+            SlotBoundary::Slot(slot) => format!("slot < {slot}"),
+        };
+        conditions.push(condition);
+    }
+
+    if let Some(until) = until {
+        let condition = match until {
+            SlotBoundary::Position(position) => {
+                slot_idx_condition_for_position(position, SlotIdxComparison::Gt)
             }
             SlotBoundary::Slot(slot) => format!("slot > {slot}"),
         };
@@ -741,7 +799,7 @@ pub(crate) fn build_transactions_for_address_hot_query(
     }
 
     if let Some(slot_filter) = &query.slot_filter {
-        append_transactions_for_address_slot_filter_conditions(slot_filter, &mut conditions);
+        append_numeric_filter_conditions("slot", slot_filter, &mut conditions);
     }
 
     if let Some(block_time_filter) = &query.block_time_filter {
@@ -749,11 +807,11 @@ pub(crate) fn build_transactions_for_address_hot_query(
     }
 
     if let Some(signature_filter) = query.resolved_signature_filter.as_ref() {
-        apply_resolved_signature_filter(signature_filter, &mut conditions);
+        apply_hot_resolved_signature_filter(signature_filter, &mut conditions);
     }
 
     if let Some(pagination) = query.resolved_pagination {
-        apply_resolved_pagination_token(pagination, query.sort_order, &mut conditions);
+        apply_hot_resolved_pagination_token(pagination, query.sort_order, &mut conditions);
     }
 
     let where_clause = if conditions.is_empty() {
@@ -874,14 +932,14 @@ mod tests {
     #[cfg(feature = "disk-cache")]
     use super::build_transactions_by_slot_range_query;
     use super::{
-        TransactionsForAddressTables, build_transactions_for_address_hot_query,
-        build_transactions_for_address_query,
+        TransactionsForAddressTables, build_hot_position_pagination_clauses,
+        build_transactions_for_address_hot_query, build_transactions_for_address_query,
     };
     #[cfg(feature = "disk-cache")]
     use crate::clickhouse::constants::SLOT_SHARD_DIVISOR;
     use crate::clickhouse::types::{
-        NumericFilter, ResolvedSignatureFilter, SignatureFilter, SignatureSlot, SortOrder,
-        TokenAccountsFilter, TransactionStatusFilter, TransactionsForAddressQuery,
+        NumericFilter, ResolvedSignatureFilter, SignatureFilter, SignatureSlot, SlotBoundary,
+        SortOrder, TokenAccountsFilter, TransactionStatusFilter, TransactionsForAddressQuery,
     };
 
     fn normalize_sql(sql: &str) -> String {
@@ -1036,18 +1094,35 @@ mod tests {
         let sql = normalize_sql(&sql);
 
         assert!(sql.contains("FROM default.gsfa_hot_local"));
-        assert!(sql.contains(
-            "(slot + toUInt64(0) > 400179100 OR (slot + toUInt64(0) = 400179100 AND slot_idx + toUInt32(0) >= 42))"
-        ));
-        assert!(sql.contains(
-            "(slot + toUInt64(0) < 400179920 OR (slot + toUInt64(0) = 400179920 AND slot_idx + toUInt32(0) < 678))"
-        ));
+        assert!(sql.contains("(slot > 400179100 OR (slot = 400179100 AND slot_idx >= 42))"));
+        assert!(sql.contains("(slot < 400179920 OR (slot = 400179920 AND slot_idx < 678))"));
+        assert!(!sql.contains("slot + toUInt64(0) > 400179100"));
+        assert!(!sql.contains("slot_idx + toUInt32(0) < 678"));
         assert!(!sql.contains("FROM default.signatures"));
         assert!(!sql.contains("ignored"));
     }
 
     #[test]
-    fn hot_transactions_for_address_query_uses_computed_slot_filter_bounds() {
+    fn hot_position_pagination_clauses_use_raw_reverse_key_predicates() {
+        let (_, where_clause) = build_hot_position_pagination_clauses(
+            Some(SlotBoundary::Position(SignatureSlot {
+                slot: 400_179_920,
+                slot_idx: 678,
+            })),
+            Some(SlotBoundary::Position(SignatureSlot {
+                slot: 400_179_100,
+                slot_idx: 42,
+            })),
+        );
+
+        assert_eq!(
+            where_clause,
+            "(slot < 400179920 OR (slot = 400179920 AND slot_idx < 678)) AND (slot > 400179100 OR (slot = 400179100 AND slot_idx > 42))"
+        );
+    }
+
+    #[test]
+    fn hot_transactions_for_address_query_uses_raw_slot_filter_bounds() {
         let query = TransactionsForAddressQuery {
             address: bs58::encode([9_u8; 32]).into_string(),
             limit: 100,
@@ -1070,7 +1145,7 @@ mod tests {
                 .expect("query");
         let sql = normalize_sql(&sql);
 
-        assert!(sql.contains("WHERE slot + toUInt64(0) <= 420051754"));
-        assert!(!sql.contains("WHERE slot <= 420051754"));
+        assert!(sql.contains("WHERE slot <= 420051754"));
+        assert!(!sql.contains("slot + toUInt64(0) <= 420051754"));
     }
 }

--- a/crates/superbank-rpc/src/clickhouse/queries.rs
+++ b/crates/superbank-rpc/src/clickhouse/queries.rs
@@ -9,6 +9,7 @@ use ch_cityhash102::cityhash64;
 
 use crate::processing::{ProcessingError, ProcessingResult};
 
+use super::constants::SLOT_SHARD_DIVISOR;
 use super::types::{
     NumericFilter, PaginationToken, ResolvedSignatureFilter, SignatureFilter, SignatureSlot,
     SlotBoundary, SortOrder, TokenAccountsFilter, TransactionStatusFilter,
@@ -842,16 +843,24 @@ pub(crate) fn build_transactions_by_slot_range_query(
     end_slot: u64,
     settings_clause: &str,
 ) -> String {
+    let start_bucket = start_slot / SLOT_SHARD_DIVISOR;
+    let end_bucket = end_slot / SLOT_SHARD_DIVISOR;
+
     format!(
         "SELECT
             {columns}
          FROM {transaction_table}
-         PREWHERE slot BETWEEN {start_slot} AND {end_slot}
+         PREWHERE
+            intDiv(slot, {slot_shard_divisor}) BETWEEN {start_bucket} AND {end_bucket}
+            AND slot BETWEEN {start_slot} AND {end_slot}
          ORDER BY slot ASC, slot_idx ASC, signature ASC
          LIMIT 1 BY signature
          {settings_clause}",
         columns = TRANSACTION_SELECT_COLUMNS,
         transaction_table = transaction_table,
+        slot_shard_divisor = SLOT_SHARD_DIVISOR,
+        start_bucket = start_bucket,
+        end_bucket = end_bucket,
         start_slot = start_slot,
         end_slot = end_slot,
         settings_clause = settings_clause
@@ -862,10 +871,14 @@ pub(crate) fn build_transactions_by_slot_range_query(
 mod tests {
     use ch_cityhash102::cityhash64;
 
+    #[cfg(feature = "disk-cache")]
+    use super::build_transactions_by_slot_range_query;
     use super::{
         TransactionsForAddressTables, build_transactions_for_address_hot_query,
         build_transactions_for_address_query,
     };
+    #[cfg(feature = "disk-cache")]
+    use crate::clickhouse::constants::SLOT_SHARD_DIVISOR;
     use crate::clickhouse::types::{
         NumericFilter, ResolvedSignatureFilter, SignatureFilter, SignatureSlot, SortOrder,
         TokenAccountsFilter, TransactionStatusFilter, TransactionsForAddressQuery,
@@ -923,6 +936,21 @@ mod tests {
         assert!(sql.contains(
             "slot + toUInt64(0) > sig_gte_slot OR (slot + toUInt64(0) = sig_gte_slot AND slot_idx + toUInt32(0) >= sig_gte_idx)"
         ));
+    }
+
+    #[test]
+    #[cfg(feature = "disk-cache")]
+    fn transactions_by_slot_range_query_includes_bucket_predicate_for_shard_pruning() {
+        let query = build_transactions_by_slot_range_query(
+            "default.transactions",
+            SLOT_SHARD_DIVISOR + 1,
+            SLOT_SHARD_DIVISOR + 10,
+            "",
+        );
+        let sql = normalize_sql(&query);
+
+        assert!(sql.contains("intDiv(slot, 432000) BETWEEN 1 AND 1"));
+        assert!(sql.contains("AND slot BETWEEN 432001 AND 432010"));
     }
 
     #[test]

--- a/crates/superbank-rpc/src/clickhouse/transactions.rs
+++ b/crates/superbank-rpc/src/clickhouse/transactions.rs
@@ -186,7 +186,7 @@ impl ClickHouseClient {
                 )));
             }
 
-            if self.is_gsfa_hot_address(&pubkey)
+            if self.should_use_gsfa_hot_fanout(&pubkey)
                 && query.token_accounts == TokenAccountsFilter::None
             {
                 return self

--- a/crates/superbank-rpc/src/clickhouse/types.rs
+++ b/crates/superbank-rpc/src/clickhouse/types.rs
@@ -237,6 +237,7 @@ pub struct TransactionsForAddressRecord {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "disk-cache", derive(serde::Serialize, serde::Deserialize))]
 pub struct BlockMetadataRecord {
     pub slot: u64,
     pub parent_slot: u64,
@@ -399,12 +400,15 @@ pub struct SignatureStatusRecord {
 }
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "disk-cache", derive(serde::Serialize, serde::Deserialize))]
 pub struct StoredTransactionRecord {
+    #[cfg_attr(feature = "disk-cache", serde(with = "serde_big_array::BigArray"))]
     pub signature: [u8; 64],
     pub slot: u64,
     pub slot_idx: u32,
     pub block_time: Option<i64>,
     pub tx_version: Option<u8>,
+    #[cfg_attr(feature = "disk-cache", serde(with = "serde_sig_vec"))]
     pub tx_signatures: Vec<[u8; 64]>,
     pub tx_num_required_signatures: u8,
     pub tx_num_readonly_signed_accounts: u8,
@@ -462,4 +466,28 @@ pub struct StoredTransactionRecord {
     pub meta_return_data_data: Option<Vec<u8>>,
     pub meta_compute_units_consumed: Option<u64>,
     pub meta_cost_units: Option<u64>,
+}
+
+/// Serde support for `Vec<[u8; 64]>` (serde's built-in array impls stop at 32 elements).
+#[cfg(feature = "disk-cache")]
+pub(crate) mod serde_sig_vec {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use serde_big_array::BigArray;
+
+    #[derive(Serialize, Deserialize)]
+    struct Sig(#[serde(with = "BigArray")] [u8; 64]);
+
+    pub(crate) fn serialize<S: Serializer>(
+        value: &[[u8; 64]],
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        serializer.collect_seq(value.iter().map(|bytes| Sig(*bytes)))
+    }
+
+    pub(crate) fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Vec<[u8; 64]>, D::Error> {
+        let sigs = Vec::<Sig>::deserialize(deserializer)?;
+        Ok(sigs.into_iter().map(|sig| sig.0).collect())
+    }
 }

--- a/crates/superbank-rpc/src/clickhouse/util.rs
+++ b/crates/superbank-rpc/src/clickhouse/util.rs
@@ -13,6 +13,8 @@ use clickhouse::Client as HttpClient;
 use clickhouse_rs::errors::{DriverError as TcpDriverError, Error as TcpError};
 use solana_sdk::pubkey::Pubkey;
 
+#[cfg(feature = "grpc-head-cache")]
+use crate::clickhouse::StoredTransactionRecord;
 use crate::hydration::parse_transaction_error_display;
 use crate::processing::ProcessingError;
 
@@ -318,6 +320,74 @@ pub(crate) fn parse_err_json(signature: &str, err_str: String) -> Option<serde_j
         "Failed to parse err JSON stored in gSFA table; returning raw string"
     );
     Some(serde_json::Value::String(trimmed.to_string()))
+}
+
+/// Extract gSFA-style memos from a stored transaction: every memo-program
+/// instruction's UTF-8 data, formatted `"[len] text"` and joined by `"; "`.
+///
+/// This matches what [`format_gsfa_memo`] produces from the raw memos stored by
+/// the gsfa/token_owner_activity materialized views, so values built here and
+/// values read from ClickHouse render identically.
+#[cfg(feature = "grpc-head-cache")]
+pub(crate) fn extract_memo(record: &StoredTransactionRecord) -> Option<String> {
+    static MEMO_PROGRAM_IDS: once_cell::sync::Lazy<[Pubkey; 2]> =
+        once_cell::sync::Lazy::new(|| {
+            use std::str::FromStr;
+            [
+                Pubkey::from_str("Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo")
+                    .expect("memo program id"),
+                Pubkey::from_str("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr")
+                    .expect("memo program id"),
+            ]
+        });
+
+    let mut memos = Vec::new();
+    for (program_id_index, data) in record
+        .tx_instructions_program_id_index
+        .iter()
+        .zip(record.tx_instructions_data.iter())
+    {
+        let idx = usize::from(*program_id_index);
+        let Some(program_id) = account_key_at(record, idx) else {
+            continue;
+        };
+        if !MEMO_PROGRAM_IDS.contains(&program_id) {
+            continue;
+        }
+        let Ok(text) = std::str::from_utf8(data) else {
+            continue;
+        };
+        if text.is_empty() {
+            continue;
+        }
+        memos.push(format!("[{}] {}", text.len(), text));
+    }
+
+    if memos.is_empty() {
+        None
+    } else {
+        Some(memos.join("; "))
+    }
+}
+
+/// Resolve an instruction account index against the transaction's combined key
+/// list: static keys, then loaded writable, then loaded readonly addresses.
+#[cfg(feature = "grpc-head-cache")]
+pub(crate) fn account_key_at(record: &StoredTransactionRecord, idx: usize) -> Option<Pubkey> {
+    let static_len = record.tx_account_keys.len();
+    if idx < static_len {
+        return Some(Pubkey::from(record.tx_account_keys[idx]));
+    }
+    let idx = idx - static_len;
+    let w_len = record.meta_loaded_addresses_writable.len();
+    if idx < w_len {
+        return Some(Pubkey::from(record.meta_loaded_addresses_writable[idx]));
+    }
+    let idx = idx - w_len;
+    if idx < record.meta_loaded_addresses_readonly.len() {
+        return Some(Pubkey::from(record.meta_loaded_addresses_readonly[idx]));
+    }
+    None
 }
 
 pub(crate) fn format_gsfa_memo(memo: Option<String>) -> Option<String> {

--- a/crates/superbank-rpc/src/config.rs
+++ b/crates/superbank-rpc/src/config.rs
@@ -320,6 +320,104 @@ pub struct RpcConfig {
     #[arg(long, env = "GRPC_MAX_DECODING_BYTES", default_value_t = 67_108_864)]
     pub(crate) grpc_max_decoding_bytes: usize,
 
+    // --- Optional RocksDB disk cache of recent finalized slots ---
+    #[cfg(feature = "disk-cache")]
+    /// Enable the RocksDB-backed disk cache of recent finalized slots, served in
+    /// place of ClickHouse. Requires the gRPC head cache (its DragonsMouth
+    /// stream is the live ingestion source) and DISK_CACHE_PATH.
+    #[arg(long, env = "DISK_CACHE_ENABLED", default_value_t = false)]
+    pub(crate) disk_cache_enabled: bool,
+
+    #[cfg(feature = "disk-cache")]
+    /// Filesystem path for the disk cache database (required when enabled).
+    #[arg(long, env = "DISK_CACHE_PATH")]
+    pub(crate) disk_cache_path: Option<String>,
+
+    #[cfg(feature = "disk-cache")]
+    /// How many finalized slots to retain on disk (default ~10 epochs). At
+    /// mainnet volume the full window needs tens of TB; the tighter of this
+    /// window and DISK_CACHE_MAX_BYTES wins.
+    #[arg(long, env = "DISK_CACHE_RETAIN_SLOTS", default_value_t = 4_320_000)]
+    pub(crate) disk_cache_retain_slots: u64,
+
+    #[cfg(feature = "disk-cache")]
+    /// Disk byte budget; 0 = unlimited. When live data exceeds it, the slot
+    /// window shrinks until usage fits.
+    #[arg(long, env = "DISK_CACHE_MAX_BYTES", default_value_t = 0)]
+    pub(crate) disk_cache_max_bytes: u64,
+
+    #[cfg(feature = "disk-cache")]
+    /// RocksDB block-cache size (bytes) shared across column families.
+    #[arg(
+        long,
+        env = "DISK_CACHE_BLOCK_CACHE_BYTES",
+        default_value_t = 4_294_967_296
+    )]
+    pub(crate) disk_cache_block_cache_bytes: usize,
+
+    #[cfg(feature = "disk-cache")]
+    /// Live write queue capacity in slots (overflow defers slots to repair).
+    #[arg(long, env = "DISK_CACHE_WRITE_QUEUE_SLOTS", default_value_t = 64)]
+    pub(crate) disk_cache_write_queue_slots: usize,
+
+    #[cfg(feature = "disk-cache")]
+    /// Max concurrent blocking disk-cache reads.
+    #[arg(long, env = "DISK_CACHE_READ_CONCURRENCY", default_value_t = 64)]
+    pub(crate) disk_cache_read_concurrency: usize,
+
+    #[cfg(feature = "disk-cache")]
+    /// Enable the ClickHouse->disk backfill/repair task (disable for debugging only).
+    #[arg(long, env = "DISK_CACHE_BACKFILL_ENABLED", default_value_t = true)]
+    pub(crate) disk_cache_backfill_enabled: bool,
+
+    #[cfg(feature = "disk-cache")]
+    /// Slots fetched per ClickHouse backfill range query.
+    #[arg(
+        long,
+        env = "DISK_CACHE_BACKFILL_SLOTS_PER_QUERY",
+        default_value_t = 8,
+        value_parser = clap::value_parser!(u64).range(1..)
+    )]
+    pub(crate) disk_cache_backfill_slots_per_query: u64,
+
+    #[cfg(feature = "disk-cache")]
+    /// Backfill rate limit (slots per second). The default fills the full
+    /// 10-epoch window in roughly a day.
+    #[arg(
+        long,
+        env = "DISK_CACHE_BACKFILL_MAX_SLOTS_PER_SEC",
+        default_value_t = 50,
+        value_parser = clap::value_parser!(u64).range(1..)
+    )]
+    pub(crate) disk_cache_backfill_max_slots_per_sec: u64,
+
+    #[cfg(feature = "disk-cache")]
+    /// Timeout for backfill range queries (milliseconds); range scans need more
+    /// than the interactive CLICKHOUSE_QUERY_TIMEOUT_MS.
+    #[arg(
+        long,
+        env = "DISK_CACHE_BACKFILL_QUERY_TIMEOUT_MS",
+        default_value_t = 30_000,
+        value_parser = clap::value_parser!(u64).range(1..)
+    )]
+    pub(crate) disk_cache_backfill_query_timeout_ms: u64,
+
+    #[cfg(feature = "disk-cache")]
+    /// Idle wait between repair/backfill planning rounds (milliseconds).
+    #[arg(
+        long,
+        env = "DISK_CACHE_REPAIR_INTERVAL_MS",
+        default_value_t = 5_000,
+        value_parser = clap::value_parser!(u64).range(1..)
+    )]
+    pub(crate) disk_cache_repair_interval_ms: u64,
+
+    #[cfg(feature = "disk-cache")]
+    /// Never backfill slots within this distance of the finalized tip, so
+    /// ClickHouse ingestion has had time to land them.
+    #[arg(long, env = "DISK_CACHE_REPAIR_MIN_LAG_SLOTS", default_value_t = 75)]
+    pub(crate) disk_cache_repair_min_lag_slots: u64,
+
     // --- Optional Pyroscope continuous profiling ---
     #[cfg(feature = "pyroscope")]
     /// Enable Pyroscope continuous profiling (requires `PYROSCOPE_URL` / `--pyroscope-url`).
@@ -635,6 +733,77 @@ mod config_tests {
         assert!(!cfg.metrics_capture_x_rpc_node());
         assert!(!cfg.metrics_capture_x_subscription_id());
         assert!(!cfg.metrics_capture_x_account_id());
+    }
+}
+
+#[cfg(all(test, feature = "disk-cache"))]
+mod disk_cache_config_tests {
+    use clap::Parser;
+
+    use super::RpcConfig;
+
+    #[test]
+    fn disk_cache_defaults() {
+        let cfg = RpcConfig::parse_from(["superbank-rpc"]);
+
+        assert!(!cfg.disk_cache_enabled);
+        assert_eq!(cfg.disk_cache_path, None);
+        assert_eq!(cfg.disk_cache_retain_slots, 4_320_000);
+        assert_eq!(cfg.disk_cache_max_bytes, 0);
+        assert_eq!(cfg.disk_cache_block_cache_bytes, 4_294_967_296);
+        assert_eq!(cfg.disk_cache_write_queue_slots, 64);
+        assert_eq!(cfg.disk_cache_read_concurrency, 64);
+        assert!(cfg.disk_cache_backfill_enabled);
+        assert_eq!(cfg.disk_cache_backfill_slots_per_query, 8);
+        assert_eq!(cfg.disk_cache_backfill_max_slots_per_sec, 50);
+        assert_eq!(cfg.disk_cache_backfill_query_timeout_ms, 30_000);
+        assert_eq!(cfg.disk_cache_repair_interval_ms, 5_000);
+        assert_eq!(cfg.disk_cache_repair_min_lag_slots, 75);
+    }
+
+    #[test]
+    fn disk_cache_flags_parse() {
+        let cfg = RpcConfig::parse_from([
+            "superbank-rpc",
+            "--disk-cache-enabled",
+            "--disk-cache-path",
+            "/var/lib/superbank/disk-cache",
+            "--disk-cache-retain-slots",
+            "432000",
+            "--disk-cache-max-bytes",
+            "2199023255552",
+            "--disk-cache-backfill-max-slots-per-sec",
+            "200",
+        ]);
+
+        assert!(cfg.disk_cache_enabled);
+        assert_eq!(
+            cfg.disk_cache_path.as_deref(),
+            Some("/var/lib/superbank/disk-cache")
+        );
+        assert_eq!(cfg.disk_cache_retain_slots, 432_000);
+        assert_eq!(cfg.disk_cache_max_bytes, 2_199_023_255_552);
+        assert_eq!(cfg.disk_cache_backfill_max_slots_per_sec, 200);
+    }
+
+    #[test]
+    fn disk_cache_rejects_zero_rate_limits() {
+        assert!(
+            RpcConfig::try_parse_from([
+                "superbank-rpc",
+                "--disk-cache-backfill-slots-per-query",
+                "0",
+            ])
+            .is_err()
+        );
+        assert!(
+            RpcConfig::try_parse_from([
+                "superbank-rpc",
+                "--disk-cache-backfill-max-slots-per-sec",
+                "0",
+            ])
+            .is_err()
+        );
     }
 }
 

--- a/crates/superbank-rpc/src/disk_cache/codec.rs
+++ b/crates/superbank-rpc/src/disk_cache/codec.rs
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+/*
+ * Copyright 2025-2026 Triton One Limited. All rights reserved.
+ */
+
+//! Value encodings for the disk cache.
+//!
+//! Record values (`block_meta`, `tx` CFs) are bincode wrapped in a 1-byte version
+//! envelope. Index values (`sig`, `addr_sig`, `token_owner` CFs) are hand-rolled so
+//! the compaction filters and hot lookups never run serde. Any decode failure is a
+//! cache miss, never an error surfaced to a request.
+
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+pub(crate) const VALUE_VERSION_V1: u8 = 1;
+
+pub(crate) fn encode_record<T: Serialize>(value: &T) -> Result<Vec<u8>, bincode::Error> {
+    let mut out = Vec::with_capacity(128);
+    out.push(VALUE_VERSION_V1);
+    bincode::serialize_into(&mut out, value)?;
+    Ok(out)
+}
+
+pub(crate) fn decode_record<T: DeserializeOwned>(bytes: &[u8]) -> Option<T> {
+    let (&version, payload) = bytes.split_first()?;
+    if version != VALUE_VERSION_V1 {
+        return None;
+    }
+    bincode::deserialize(payload).ok()
+}
+
+/// `sig` CF value: `[ver][slot u64 BE][idx u32 BE][err_len u32 BE][err bytes]`.
+/// `err_len == 0` means the transaction succeeded (matches the gsfa.sql
+/// `if(meta_status_ok = 1, NULL, meta_err)` convention).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SigValue {
+    pub(crate) slot: u64,
+    pub(crate) idx: u32,
+    pub(crate) err: Option<String>,
+}
+
+pub(crate) fn encode_sig_value(slot: u64, idx: u32, err: Option<&str>) -> Vec<u8> {
+    let err_bytes = err.map(str::as_bytes).unwrap_or_default();
+    let mut out = Vec::with_capacity(1 + 8 + 4 + 4 + err_bytes.len());
+    out.push(VALUE_VERSION_V1);
+    out.extend_from_slice(&slot.to_be_bytes());
+    out.extend_from_slice(&idx.to_be_bytes());
+    out.extend_from_slice(&(err_bytes.len() as u32).to_be_bytes());
+    out.extend_from_slice(err_bytes);
+    out
+}
+
+pub(crate) fn decode_sig_value(bytes: &[u8]) -> Option<SigValue> {
+    if bytes.len() < 17 || bytes[0] != VALUE_VERSION_V1 {
+        return None;
+    }
+    let slot = u64::from_be_bytes(bytes[1..9].try_into().ok()?);
+    let idx = u32::from_be_bytes(bytes[9..13].try_into().ok()?);
+    let err_len = u32::from_be_bytes(bytes[13..17].try_into().ok()?) as usize;
+    let err_bytes = bytes.get(17..17 + err_len)?;
+    let err = if err_len == 0 {
+        None
+    } else {
+        Some(String::from_utf8(err_bytes.to_vec()).ok()?)
+    };
+    Some(SigValue { slot, idx, err })
+}
+
+/// Slot extraction for the `sig` CF compaction filter — no allocation, no serde.
+pub(crate) fn sig_value_slot(bytes: &[u8]) -> Option<u64> {
+    if bytes.first() != Some(&VALUE_VERSION_V1) {
+        return None;
+    }
+    Some(u64::from_be_bytes(bytes.get(1..9)?.try_into().ok()?))
+}
+
+/// `slot_coverage` CF value: `[ver][tag]` plus, for Covered, `[tx_count u32 BE][source]`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CoverageValue {
+    Covered { tx_count: u32, source: u8 },
+    Skipped,
+}
+
+pub(crate) fn encode_coverage_value(value: CoverageValue) -> Vec<u8> {
+    match value {
+        CoverageValue::Covered { tx_count, source } => {
+            let mut out = Vec::with_capacity(7);
+            out.push(VALUE_VERSION_V1);
+            out.push(super::schema::COVERAGE_TAG_COVERED);
+            out.extend_from_slice(&tx_count.to_be_bytes());
+            out.push(source);
+            out
+        }
+        CoverageValue::Skipped => vec![VALUE_VERSION_V1, super::schema::COVERAGE_TAG_SKIPPED],
+    }
+}
+
+pub(crate) fn decode_coverage_value(bytes: &[u8]) -> Option<CoverageValue> {
+    if bytes.len() < 2 || bytes[0] != VALUE_VERSION_V1 {
+        return None;
+    }
+    match bytes[1] {
+        tag if tag == super::schema::COVERAGE_TAG_COVERED => {
+            let tx_count = u32::from_be_bytes(bytes.get(2..6)?.try_into().ok()?);
+            let source = *bytes.get(6)?;
+            Some(CoverageValue::Covered { tx_count, source })
+        }
+        tag if tag == super::schema::COVERAGE_TAG_SKIPPED => Some(CoverageValue::Skipped),
+        _ => None,
+    }
+}
+
+const FLAG_ERR: u8 = 1 << 0;
+const FLAG_MEMO: u8 = 1 << 1;
+const FLAG_BLOCK_TIME: u8 = 1 << 2;
+const FLAG_BALANCE_CHANGED: u8 = 1 << 3;
+
+/// `addr_sig` / `token_owner` CF value: `[ver][signature 64][flags]` followed by the
+/// optional fields in flag order: err (`u32 BE` length + bytes), memo (same), and
+/// block_time (`i64 BE`). `token_owner` additionally uses the balance-changed flag bit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AddrSigValue {
+    pub(crate) signature: [u8; 64],
+    pub(crate) err: Option<String>,
+    pub(crate) memo: Option<String>,
+    pub(crate) block_time: Option<i64>,
+    pub(crate) balance_changed: bool,
+}
+
+pub(crate) fn encode_addr_sig_value(value: &AddrSigValue) -> Vec<u8> {
+    let err_bytes = value.err.as_deref().map(str::as_bytes).unwrap_or_default();
+    let memo_bytes = value.memo.as_deref().map(str::as_bytes).unwrap_or_default();
+    let mut out = Vec::with_capacity(1 + 64 + 1 + 8 + err_bytes.len() + memo_bytes.len() + 8 + 8);
+
+    let mut flags = 0u8;
+    if value.err.is_some() {
+        flags |= FLAG_ERR;
+    }
+    if value.memo.is_some() {
+        flags |= FLAG_MEMO;
+    }
+    if value.block_time.is_some() {
+        flags |= FLAG_BLOCK_TIME;
+    }
+    if value.balance_changed {
+        flags |= FLAG_BALANCE_CHANGED;
+    }
+
+    out.push(VALUE_VERSION_V1);
+    out.extend_from_slice(&value.signature);
+    out.push(flags);
+    if value.err.is_some() {
+        out.extend_from_slice(&(err_bytes.len() as u32).to_be_bytes());
+        out.extend_from_slice(err_bytes);
+    }
+    if value.memo.is_some() {
+        out.extend_from_slice(&(memo_bytes.len() as u32).to_be_bytes());
+        out.extend_from_slice(memo_bytes);
+    }
+    if let Some(block_time) = value.block_time {
+        out.extend_from_slice(&block_time.to_be_bytes());
+    }
+    out
+}
+
+pub(crate) fn decode_addr_sig_value(bytes: &[u8]) -> Option<AddrSigValue> {
+    if bytes.len() < 66 || bytes[0] != VALUE_VERSION_V1 {
+        return None;
+    }
+    let signature: [u8; 64] = bytes[1..65].try_into().ok()?;
+    let flags = bytes[65];
+    let mut cursor = 66usize;
+
+    let read_string = |bytes: &[u8], cursor: &mut usize| -> Option<String> {
+        let len = u32::from_be_bytes(bytes.get(*cursor..*cursor + 4)?.try_into().ok()?) as usize;
+        *cursor += 4;
+        let raw = bytes.get(*cursor..*cursor + len)?;
+        *cursor += len;
+        String::from_utf8(raw.to_vec()).ok()
+    };
+
+    let err = if flags & FLAG_ERR != 0 {
+        Some(read_string(bytes, &mut cursor)?)
+    } else {
+        None
+    };
+    let memo = if flags & FLAG_MEMO != 0 {
+        Some(read_string(bytes, &mut cursor)?)
+    } else {
+        None
+    };
+    let block_time = if flags & FLAG_BLOCK_TIME != 0 {
+        let raw = bytes.get(cursor..cursor + 8)?;
+        cursor += 8;
+        Some(i64::from_be_bytes(raw.try_into().ok()?))
+    } else {
+        None
+    };
+    let _ = cursor;
+
+    Some(AddrSigValue {
+        signature,
+        err,
+        memo,
+        block_time,
+        balance_changed: flags & FLAG_BALANCE_CHANGED != 0,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sig_value_round_trip() {
+        for err in [None, Some("{\"InstructionError\":[0,\"Custom\"]}")] {
+            let encoded = encode_sig_value(123_456_789, 42, err);
+            let decoded = decode_sig_value(&encoded).expect("decode");
+            assert_eq!(decoded.slot, 123_456_789);
+            assert_eq!(decoded.idx, 42);
+            assert_eq!(decoded.err.as_deref(), err);
+            assert_eq!(sig_value_slot(&encoded), Some(123_456_789));
+        }
+    }
+
+    #[test]
+    fn sig_value_rejects_unknown_version_and_truncation() {
+        let mut encoded = encode_sig_value(7, 1, Some("err"));
+        encoded[0] = 99;
+        assert!(decode_sig_value(&encoded).is_none());
+        assert!(sig_value_slot(&encoded).is_none());
+
+        let encoded = encode_sig_value(7, 1, Some("err"));
+        assert!(decode_sig_value(&encoded[..encoded.len() - 1]).is_none());
+        assert!(decode_sig_value(&[]).is_none());
+    }
+
+    #[test]
+    fn addr_sig_value_round_trip_all_field_combinations() {
+        let mut signature = [0u8; 64];
+        signature[0] = 0xAB;
+        signature[63] = 0xCD;
+
+        for err in [None, Some("{\"err\":1}".to_string())] {
+            for memo in [None, Some("[5] hello".to_string())] {
+                for block_time in [None, Some(1_700_000_000i64), Some(-1i64)] {
+                    for balance_changed in [false, true] {
+                        let value = AddrSigValue {
+                            signature,
+                            err: err.clone(),
+                            memo: memo.clone(),
+                            block_time,
+                            balance_changed,
+                        };
+                        let encoded = encode_addr_sig_value(&value);
+                        let decoded = decode_addr_sig_value(&encoded).expect("decode");
+                        assert_eq!(decoded, value);
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn addr_sig_value_rejects_truncation() {
+        let value = AddrSigValue {
+            signature: [7u8; 64],
+            err: Some("e".to_string()),
+            memo: Some("m".to_string()),
+            block_time: Some(5),
+            balance_changed: true,
+        };
+        let encoded = encode_addr_sig_value(&value);
+        for len in 0..encoded.len() {
+            assert!(
+                decode_addr_sig_value(&encoded[..len]).is_none(),
+                "truncated to {len} bytes should not decode"
+            );
+        }
+    }
+
+    #[test]
+    fn coverage_value_round_trip() {
+        let covered = CoverageValue::Covered {
+            tx_count: 3210,
+            source: crate::disk_cache::schema::COVERAGE_SOURCE_LIVE,
+        };
+        assert_eq!(
+            decode_coverage_value(&encode_coverage_value(covered)),
+            Some(covered)
+        );
+        assert_eq!(
+            decode_coverage_value(&encode_coverage_value(CoverageValue::Skipped)),
+            Some(CoverageValue::Skipped)
+        );
+        assert_eq!(decode_coverage_value(&[VALUE_VERSION_V1, 9]), None);
+        assert_eq!(decode_coverage_value(&[]), None);
+    }
+
+    #[test]
+    fn record_envelope_round_trip() {
+        let value = vec![1u64, 2, 3];
+        let encoded = encode_record(&value).expect("encode");
+        assert_eq!(encoded[0], VALUE_VERSION_V1);
+        assert_eq!(decode_record::<Vec<u64>>(&encoded), Some(value));
+
+        let mut wrong_version = encoded.clone();
+        wrong_version[0] = 2;
+        assert_eq!(decode_record::<Vec<u64>>(&wrong_version), None);
+        assert_eq!(decode_record::<Vec<u64>>(&[]), None);
+    }
+}

--- a/crates/superbank-rpc/src/disk_cache/coverage.rs
+++ b/crates/superbank-rpc/src/disk_cache/coverage.rs
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+/*
+ * Copyright 2025-2026 Triton One Limited. All rights reserved.
+ */
+
+//! In-memory coverage tracking for the disk cache.
+//!
+//! `CoverageMap` mirrors the persisted `slot_coverage` CF as a set of inclusive,
+//! merged slot ranges. A slot is "covered" when the cache holds complete knowledge
+//! of it: either the full block landed atomically or the slot is proven skipped.
+//! Address-index scans may only be served from the contiguous range ending at the
+//! tip; slot-keyed reads may be served from any covered slot.
+
+use std::collections::BTreeMap;
+
+#[derive(Debug, Default)]
+pub(crate) struct CoverageMap {
+    /// start -> end (inclusive); ranges are disjoint and non-adjacent.
+    ranges: BTreeMap<u64, u64>,
+}
+
+impl CoverageMap {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn insert(&mut self, slot: u64) {
+        self.insert_range(slot, slot);
+    }
+
+    pub(crate) fn insert_range(&mut self, start: u64, end: u64) {
+        if end < start {
+            return;
+        }
+        let mut new_start = start;
+        let mut new_end = end;
+
+        // Absorb a range that starts before us and overlaps or touches `start`.
+        if let Some((&prev_start, &prev_end)) = self.ranges.range(..=start).next_back()
+            && prev_end.saturating_add(1) >= start
+        {
+            new_start = prev_start;
+            new_end = new_end.max(prev_end);
+            self.ranges.remove(&prev_start);
+        }
+
+        // Absorb every range that starts within or adjacent to the new range.
+        let absorbed: Vec<u64> = self
+            .ranges
+            .range(new_start..=new_end.saturating_add(1))
+            .map(|(&range_start, _)| range_start)
+            .collect();
+        for range_start in absorbed {
+            if let Some(range_end) = self.ranges.remove(&range_start) {
+                new_end = new_end.max(range_end);
+            }
+        }
+
+        self.ranges.insert(new_start, new_end);
+    }
+
+    /// Remove a single slot, splitting its range (poisoned slot).
+    pub(crate) fn remove(&mut self, slot: u64) {
+        let Some((&start, &end)) = self.ranges.range(..=slot).next_back() else {
+            return;
+        };
+        if slot > end {
+            return;
+        }
+        self.ranges.remove(&start);
+        if start < slot {
+            self.ranges.insert(start, slot - 1);
+        }
+        if slot < end {
+            self.ranges.insert(slot + 1, end);
+        }
+    }
+
+    /// Drop all coverage below `floor` (eviction).
+    pub(crate) fn remove_below(&mut self, floor: u64) {
+        let starts: Vec<u64> = self
+            .ranges
+            .range(..floor)
+            .map(|(&start, _)| start)
+            .collect();
+        for start in starts {
+            if let Some(end) = self.ranges.remove(&start)
+                && end >= floor
+            {
+                self.ranges.insert(floor, end);
+            }
+        }
+    }
+
+    pub(crate) fn contains(&self, slot: u64) -> bool {
+        self.ranges
+            .range(..=slot)
+            .next_back()
+            .is_some_and(|(_, &end)| slot <= end)
+    }
+
+    /// `(min covered, max covered)` across all ranges.
+    pub(crate) fn covered_span(&self) -> Option<(u64, u64)> {
+        let (&first_start, _) = self.ranges.first_key_value()?;
+        let (_, &last_end) = self.ranges.last_key_value()?;
+        Some((first_start, last_end))
+    }
+
+    /// The contiguous range ending at the maximum covered slot — the only span
+    /// address-index scans may be answered from.
+    pub(crate) fn contiguous_tip_span(&self) -> Option<(u64, u64)> {
+        self.ranges
+            .last_key_value()
+            .map(|(&start, &end)| (start, end))
+    }
+
+    /// Inclusive sub-ranges of `[start, end]` not covered by the map.
+    pub(crate) fn holes_in(&self, start: u64, end: u64) -> Vec<(u64, u64)> {
+        if end < start {
+            return Vec::new();
+        }
+        let mut holes = Vec::new();
+        let mut cursor = start;
+
+        // A range beginning before `start` may swallow the beginning of the window.
+        if let Some((_, &prev_end)) = self.ranges.range(..=start).next_back()
+            && prev_end >= cursor
+        {
+            if prev_end >= end {
+                return Vec::new();
+            }
+            cursor = prev_end + 1;
+        }
+
+        for (&range_start, &range_end) in self.ranges.range(cursor..=end) {
+            if range_start > cursor {
+                holes.push((cursor, range_start - 1));
+            }
+            if range_end >= end {
+                return holes;
+            }
+            cursor = range_end + 1;
+        }
+
+        if cursor <= end {
+            holes.push((cursor, end));
+        }
+        holes
+    }
+
+    pub(crate) fn covered_slot_count(&self) -> u64 {
+        self.ranges
+            .iter()
+            .map(|(&start, &end)| end - start + 1)
+            .sum()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn range_count(&self) -> usize {
+        self.ranges.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insert_merges_overlapping_and_adjacent_ranges() {
+        let mut map = CoverageMap::new();
+        map.insert_range(10, 20);
+        map.insert_range(30, 40);
+        assert_eq!(map.range_count(), 2);
+
+        // Adjacent on the left edge.
+        map.insert_range(21, 29);
+        assert_eq!(map.range_count(), 1);
+        assert_eq!(map.covered_span(), Some((10, 40)));
+
+        // Overlapping both sides.
+        map.insert_range(5, 45);
+        assert_eq!(map.covered_span(), Some((5, 45)));
+        assert_eq!(map.range_count(), 1);
+
+        // Contained: no change.
+        map.insert_range(7, 9);
+        assert_eq!(map.range_count(), 1);
+
+        // Single-slot adjacency.
+        map.insert(46);
+        assert_eq!(map.covered_span(), Some((5, 46)));
+        assert_eq!(map.range_count(), 1);
+    }
+
+    #[test]
+    fn contains_and_span_accessors() {
+        let mut map = CoverageMap::new();
+        assert_eq!(map.covered_span(), None);
+        assert_eq!(map.contiguous_tip_span(), None);
+        assert!(!map.contains(5));
+
+        map.insert_range(10, 20);
+        map.insert_range(40, 50);
+        assert!(map.contains(10) && map.contains(15) && map.contains(20));
+        assert!(!map.contains(9) && !map.contains(21) && !map.contains(39));
+        assert_eq!(map.covered_span(), Some((10, 50)));
+        assert_eq!(map.contiguous_tip_span(), Some((40, 50)));
+        assert_eq!(map.covered_slot_count(), 22);
+    }
+
+    #[test]
+    fn holes_in_reports_uncovered_subranges() {
+        let mut map = CoverageMap::new();
+        map.insert_range(10, 20);
+        map.insert_range(30, 40);
+
+        assert_eq!(map.holes_in(0, 50), vec![(0, 9), (21, 29), (41, 50)]);
+        assert_eq!(map.holes_in(10, 40), vec![(21, 29)]);
+        assert_eq!(map.holes_in(15, 18), Vec::<(u64, u64)>::new());
+        assert_eq!(map.holes_in(21, 29), vec![(21, 29)]);
+        assert_eq!(map.holes_in(20, 30), vec![(21, 29)]);
+        assert_eq!(map.holes_in(50, 40), Vec::<(u64, u64)>::new());
+        assert_eq!(CoverageMap::new().holes_in(1, 3), vec![(1, 3)]);
+    }
+
+    #[test]
+    fn remove_splits_ranges() {
+        let mut map = CoverageMap::new();
+        map.insert_range(10, 20);
+
+        map.remove(15);
+        assert!(!map.contains(15));
+        assert!(map.contains(14) && map.contains(16));
+        assert_eq!(map.contiguous_tip_span(), Some((16, 20)));
+
+        // Edges.
+        map.remove(10);
+        assert!(!map.contains(10));
+        map.remove(20);
+        assert!(!map.contains(20));
+        assert_eq!(map.covered_span(), Some((11, 19)));
+
+        // No-ops.
+        map.remove(5);
+        map.remove(25);
+        assert_eq!(map.covered_span(), Some((11, 19)));
+
+        // Single-slot range removal empties the map.
+        let mut single = CoverageMap::new();
+        single.insert(7);
+        single.remove(7);
+        assert_eq!(single.covered_span(), None);
+    }
+
+    #[test]
+    fn remove_below_truncates_ranges() {
+        let mut map = CoverageMap::new();
+        map.insert_range(10, 20);
+        map.insert_range(30, 40);
+
+        map.remove_below(15);
+        assert_eq!(map.covered_span(), Some((15, 40)));
+        assert!(!map.contains(14));
+
+        map.remove_below(25);
+        assert_eq!(map.covered_span(), Some((30, 40)));
+
+        map.remove_below(41);
+        assert_eq!(map.covered_span(), None);
+    }
+}

--- a/crates/superbank-rpc/src/disk_cache/filler.rs
+++ b/crates/superbank-rpc/src/disk_cache/filler.rs
@@ -42,8 +42,8 @@ pub(crate) struct FillerConfig {
     pub(crate) repair_interval: Duration,
     /// Never fetch slots ClickHouse ingestion may not have landed yet.
     pub(crate) repair_min_lag_slots: u64,
-    /// After this many failed fetches a slot stays a hole (falls through to
-    /// ClickHouse on reads) and is only logged once.
+    /// After this many incomplete or empty fill results a slot stays a hole
+    /// (falls through to ClickHouse on reads) and is only logged once.
     pub(crate) max_attempts: u32,
 }
 
@@ -148,19 +148,14 @@ pub(crate) async fn run(
             }
 
             match fill_range(&cache, &clickhouse, &bulk, &mut shutdown, &range, &cfg).await {
-                Ok(()) => {
+                Ok(outcome) => {
                     backoff = Duration::from_millis(250);
-                    for slot in range.start..=range.end {
-                        let entry = attempts.entry(slot).or_insert(0);
-                        *entry += 1;
-                        if *entry >= cfg.max_attempts && given_up.insert(slot) {
-                            warn!(
-                                slot,
-                                attempts = *entry,
-                                "disk cache: giving up on slot; it stays a ClickHouse read"
-                            );
-                        }
-                    }
+                    warn_for_given_up(record_fill_attempt_result(
+                        &mut attempts,
+                        &mut given_up,
+                        FillAttemptResult::IncompleteSlots(&outcome.incomplete_slots),
+                        cfg.max_attempts,
+                    ));
                 }
                 Err(FillError::Shutdown) => return,
                 Err(FillError::ClickHouse(err)) => {
@@ -170,6 +165,12 @@ pub(crate) async fn run(
                         end = range.end,
                         "disk cache: backfill fetch failed ({err}); backing off"
                     );
+                    warn_for_given_up(record_fill_attempt_result(
+                        &mut attempts,
+                        &mut given_up,
+                        FillAttemptResult::TransientClickHouse,
+                        cfg.max_attempts,
+                    ));
                     if sleep_or_shutdown(&mut shutdown, backoff).await {
                         return;
                     }
@@ -353,6 +354,10 @@ enum FillError {
     Shutdown,
 }
 
+struct FillOutcome {
+    incomplete_slots: Vec<u64>,
+}
+
 async fn fill_range(
     cache: &DiskCache,
     clickhouse: &ClickHouseClient,
@@ -360,7 +365,7 @@ async fn fill_range(
     shutdown: &mut tokio::sync::broadcast::Receiver<()>,
     range: &SlotRange,
     cfg: &FillerConfig,
-) -> Result<(), FillError> {
+) -> Result<FillOutcome, FillError> {
     let (metas, _) = clickhouse
         .get_block_metadata_by_slot_range(range.start, range.end, cfg.query_timeout)
         .await
@@ -368,7 +373,9 @@ async fn fill_range(
     if metas.is_empty() {
         // Either an all-skipped run (proven by a later block's parent link) or
         // ClickHouse is missing the range; attempts accounting decides.
-        return Ok(());
+        return Ok(FillOutcome {
+            incomplete_slots: uncached_slots(cache, range),
+        });
     }
     let (txs, _) = clickhouse
         .get_block_full_transactions_by_slot_range(range.start, range.end, cfg.query_timeout)
@@ -383,7 +390,9 @@ async fn fill_range(
         );
     }
     if blocks.is_empty() {
-        return Ok(());
+        return Ok(FillOutcome {
+            incomplete_slots: uncached_slots(cache, range),
+        });
     }
 
     let last_slot = blocks.last().map(|(meta, _)| meta.slot);
@@ -414,12 +423,58 @@ async fn fill_range(
             }
         }
     }
-    Ok(())
+    Ok(FillOutcome {
+        incomplete_slots: uncached_slots(cache, range),
+    })
 }
 
 fn prune_tracking(attempts: &mut HashMap<u64, u32>, given_up: &mut HashSet<u64>, floor: u64) {
     attempts.retain(|&slot, _| slot >= floor);
     given_up.retain(|&slot| slot >= floor);
+}
+
+fn uncached_slots(cache: &DiskCache, range: &SlotRange) -> Vec<u64> {
+    (range.start..=range.end)
+        .filter(|&slot| !cache.covers_slot(slot))
+        .collect()
+}
+
+enum FillAttemptResult<'a> {
+    IncompleteSlots(&'a [u64]),
+    TransientClickHouse,
+}
+
+fn record_fill_attempt_result(
+    attempts: &mut HashMap<u64, u32>,
+    given_up: &mut HashSet<u64>,
+    result: FillAttemptResult<'_>,
+    max_attempts: u32,
+) -> Vec<(u64, u32)> {
+    let FillAttemptResult::IncompleteSlots(slots) = result else {
+        return Vec::new();
+    };
+
+    let mut newly_given_up = Vec::new();
+    for &slot in slots {
+        if given_up.contains(&slot) {
+            continue;
+        }
+        let entry = attempts.entry(slot).or_insert(0);
+        *entry += 1;
+        if *entry >= max_attempts && given_up.insert(slot) {
+            newly_given_up.push((slot, *entry));
+        }
+    }
+    newly_given_up
+}
+
+fn warn_for_given_up(slots: Vec<(u64, u32)>) {
+    for (slot, attempts) in slots {
+        warn!(
+            slot,
+            attempts, "disk cache: giving up on slot; it stays a ClickHouse read"
+        );
+    }
 }
 
 /// Returns true when shutdown was requested.
@@ -524,5 +579,66 @@ mod tests {
         assert_eq!(blocks[0].1.len(), 2);
         assert_eq!(blocks[1].0.slot, 102);
         assert!(blocks[1].1.is_empty());
+    }
+
+    #[test]
+    fn incomplete_fill_attempts_give_up_once_at_limit() {
+        let mut attempts = HashMap::new();
+        let mut given_up = HashSet::new();
+        let slots = vec![10, 11];
+
+        assert!(
+            record_fill_attempt_result(
+                &mut attempts,
+                &mut given_up,
+                FillAttemptResult::IncompleteSlots(&slots),
+                2
+            )
+            .is_empty()
+        );
+
+        let newly_given_up = record_fill_attempt_result(
+            &mut attempts,
+            &mut given_up,
+            FillAttemptResult::IncompleteSlots(&slots),
+            2,
+        );
+        assert_eq!(newly_given_up, vec![(10, 2), (11, 2)]);
+        assert!(given_up.contains(&10));
+        assert!(given_up.contains(&11));
+
+        assert!(
+            record_fill_attempt_result(
+                &mut attempts,
+                &mut given_up,
+                FillAttemptResult::IncompleteSlots(&slots),
+                2
+            )
+            .is_empty()
+        );
+        assert_eq!(attempts.get(&10), Some(&2));
+        assert_eq!(attempts.get(&11), Some(&2));
+    }
+
+    #[test]
+    fn clickhouse_errors_do_not_count_toward_given_up_slots() {
+        let mut attempts = HashMap::new();
+        let mut given_up = HashSet::new();
+        let range = SlotRange { start: 10, end: 11 };
+
+        let newly_given_up = record_fill_attempt_result(
+            &mut attempts,
+            &mut given_up,
+            FillAttemptResult::TransientClickHouse,
+            1,
+        );
+        assert!(newly_given_up.is_empty());
+        assert!(attempts.is_empty());
+        assert!(given_up.is_empty());
+
+        assert_eq!(
+            plan_ranges(&[], &[(10, 11)], &given_up, 10, 11, 8, 64),
+            vec![range]
+        );
     }
 }

--- a/crates/superbank-rpc/src/disk_cache/filler.rs
+++ b/crates/superbank-rpc/src/disk_cache/filler.rs
@@ -1,0 +1,525 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+/*
+ * Copyright 2025-2026 Triton One Limited. All rights reserved.
+ */
+
+//! Unified backfill and gap repair: fills the disk cache FROM ClickHouse.
+//!
+//! One task serves three hole sources — the cold-start window, slots the live
+//! path deferred (incomplete head view, full queue, write errors), and holes
+//! found by periodic coverage scans. Work is planned newest-first (recent slots
+//! serve the most traffic), rate-limited, and resumable: coverage IS the
+//! cursor, so every committed batch is durable progress and a restart simply
+//! recomputes the remaining holes.
+//!
+//! The filler never writes RocksDB itself; it ships batches to the writer
+//! thread's bulk channel, which always yields to live slots.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::Arc;
+use std::sync::mpsc::{SyncSender, TrySendError};
+use std::time::{Duration, Instant};
+
+use tracing::{debug, info, warn};
+
+use crate::clickhouse::{BlockMetadataRecord, ClickHouseClient, StoredTransactionRecord};
+use crate::head_cache::HeadCache;
+
+use super::ingest::RepairQueue;
+use super::writer::DiskWriteJob;
+use super::{DiskCache, schema};
+
+#[derive(Debug, Clone)]
+pub(crate) struct FillerConfig {
+    pub(crate) retain_slots: u64,
+    /// Slots fetched per ClickHouse range query.
+    pub(crate) slots_per_query: u64,
+    /// Token-bucket rate limit on fetched slots.
+    pub(crate) max_slots_per_sec: u64,
+    /// Per-query deadline (range scans need more than interactive reads).
+    pub(crate) query_timeout: Duration,
+    /// Idle wait between planning rounds when there is nothing to do.
+    pub(crate) repair_interval: Duration,
+    /// Never fetch slots ClickHouse ingestion may not have landed yet.
+    pub(crate) repair_min_lag_slots: u64,
+    /// After this many failed fetches a slot stays a hole (falls through to
+    /// ClickHouse on reads) and is only logged once.
+    pub(crate) max_attempts: u32,
+}
+
+impl Default for FillerConfig {
+    fn default() -> Self {
+        Self {
+            retain_slots: 4_320_000,
+            slots_per_query: 8,
+            max_slots_per_sec: 50,
+            query_timeout: Duration::from_secs(30),
+            repair_interval: Duration::from_secs(5),
+            repair_min_lag_slots: 75,
+            max_attempts: 10,
+        }
+    }
+}
+
+/// Upper bound on slots planned per round; keeps each round's coverage
+/// re-planning cheap and the shutdown latency low.
+const MAX_SLOTS_PER_ROUND: u64 = 64;
+
+pub(crate) async fn run(
+    cache: Arc<DiskCache>,
+    clickhouse: ClickHouseClient,
+    bulk: SyncSender<DiskWriteJob>,
+    repair: Arc<RepairQueue>,
+    head: Option<Arc<HeadCache>>,
+    cfg: FillerConfig,
+    mut shutdown: tokio::sync::broadcast::Receiver<()>,
+) {
+    info!(
+        retain_slots = cfg.retain_slots,
+        slots_per_query = cfg.slots_per_query,
+        max_slots_per_sec = cfg.max_slots_per_sec,
+        "disk cache: filler started"
+    );
+
+    let mut attempts: HashMap<u64, u32> = HashMap::new();
+    let mut given_up: HashSet<u64> = HashSet::new();
+    let mut backoff = Duration::from_millis(250);
+    let max_backoff = Duration::from_secs(10);
+    let mut tokens = f64::from(u32::try_from(cfg.slots_per_query).unwrap_or(8));
+    let mut last_refill = Instant::now();
+
+    loop {
+        let window = match claimable_window(&cache, &clickhouse, head.as_deref(), &cfg).await {
+            Some(window) => window,
+            None => {
+                if wait_or_shutdown(&mut shutdown, &repair, cfg.repair_interval).await {
+                    break;
+                }
+                continue;
+            }
+        };
+
+        prune_tracking(&mut attempts, &mut given_up, window.floor);
+
+        let repair_slots = repair.drain(MAX_SLOTS_PER_ROUND as usize);
+        let holes = cache.holes_in(window.floor, window.tip);
+        let ranges = plan_ranges(
+            &repair_slots,
+            &holes,
+            &given_up,
+            window.floor,
+            window.tip,
+            cfg.slots_per_query,
+            MAX_SLOTS_PER_ROUND,
+        );
+
+        if ranges.is_empty() {
+            if wait_or_shutdown(&mut shutdown, &repair, cfg.repair_interval).await {
+                break;
+            }
+            continue;
+        }
+
+        let total: u64 = ranges.iter().map(|range| range.len_slots()).sum();
+        debug!(
+            ranges = ranges.len(),
+            slots = total,
+            floor = window.floor,
+            tip = window.tip,
+            "disk cache: filler round planned"
+        );
+
+        for range in ranges {
+            // Token-bucket rate limit on fetched slots.
+            loop {
+                let elapsed = last_refill.elapsed().as_secs_f64();
+                last_refill = Instant::now();
+                tokens = (tokens + elapsed * cfg.max_slots_per_sec as f64)
+                    .min(cfg.max_slots_per_sec.max(cfg.slots_per_query) as f64 * 2.0);
+                if tokens >= range.len_slots() as f64 {
+                    tokens -= range.len_slots() as f64;
+                    break;
+                }
+                if sleep_or_shutdown(&mut shutdown, Duration::from_millis(100)).await {
+                    return;
+                }
+            }
+
+            match fill_range(&cache, &clickhouse, &bulk, &mut shutdown, &range, &cfg).await {
+                Ok(()) => {
+                    backoff = Duration::from_millis(250);
+                    for slot in range.start..=range.end {
+                        let entry = attempts.entry(slot).or_insert(0);
+                        *entry += 1;
+                        if *entry >= cfg.max_attempts && given_up.insert(slot) {
+                            warn!(
+                                slot,
+                                attempts = *entry,
+                                "disk cache: giving up on slot; it stays a ClickHouse read"
+                            );
+                        }
+                    }
+                }
+                Err(FillError::Shutdown) => return,
+                Err(FillError::ClickHouse(err)) => {
+                    warn!(
+                        start = range.start,
+                        end = range.end,
+                        "disk cache: backfill fetch failed ({err}); backing off"
+                    );
+                    if sleep_or_shutdown(&mut shutdown, backoff).await {
+                        return;
+                    }
+                    backoff = (backoff * 2).min(max_backoff);
+                }
+            }
+        }
+
+        // Let the writer drain before re-planning, so freshly written slots
+        // are visible as coverage and are not fetched twice.
+        if sleep_or_shutdown(&mut shutdown, Duration::from_millis(50)).await {
+            break;
+        }
+    }
+
+    info!("disk cache: filler stopped");
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SlotRange {
+    pub(crate) start: u64,
+    pub(crate) end: u64,
+}
+
+impl SlotRange {
+    fn len_slots(&self) -> u64 {
+        self.end - self.start + 1
+    }
+}
+
+struct ClaimableWindow {
+    floor: u64,
+    tip: u64,
+}
+
+/// `[tip - retain + 1, tip]` where `tip` is the newest slot ClickHouse can be
+/// trusted to have fully ingested: min of the ClickHouse and head-cache
+/// finalized tips, minus the configured lag.
+async fn claimable_window(
+    cache: &DiskCache,
+    clickhouse: &ClickHouseClient,
+    head: Option<&HeadCache>,
+    cfg: &FillerConfig,
+) -> Option<ClaimableWindow> {
+    let ch_tip = match clickhouse.get_latest_finalized_slot().await {
+        Ok(Some(tip)) => tip,
+        Ok(None) => return None,
+        Err(err) => {
+            warn!("disk cache: filler could not resolve the ClickHouse tip: {err}");
+            return None;
+        }
+    };
+    let head_tip = head
+        .map(|cache| {
+            cache.latest_slot_at_least(solana_commitment_config::CommitmentLevel::Finalized)
+        })
+        .filter(|&tip| tip > 0);
+
+    let tip = head_tip
+        .map_or(ch_tip, |head_tip| ch_tip.min(head_tip))
+        .saturating_sub(cfg.repair_min_lag_slots);
+    if tip == 0 {
+        return None;
+    }
+    let floor = tip
+        .saturating_sub(cfg.retain_slots.saturating_sub(1))
+        .max(cache.min_retained_slot());
+    Some(ClaimableWindow { floor, tip })
+}
+
+/// Pure planning: repair slots first, then coverage holes, both newest-first,
+/// clamped to the window, skipping given-up slots, coalesced into consecutive
+/// runs and chunked to the per-query size. Total slots bounded by `max_slots`.
+pub(crate) fn plan_ranges(
+    repair_slots: &[u64],
+    holes: &[(u64, u64)],
+    given_up: &HashSet<u64>,
+    floor: u64,
+    tip: u64,
+    slots_per_query: u64,
+    max_slots: u64,
+) -> Vec<SlotRange> {
+    let chunk = slots_per_query.max(1);
+    let mut planned: Vec<u64> = Vec::new();
+    let mut seen: HashSet<u64> = HashSet::new();
+
+    let push = |slot: u64, planned: &mut Vec<u64>, seen: &mut HashSet<u64>| {
+        if slot >= floor && slot <= tip && !given_up.contains(&slot) && seen.insert(slot) {
+            planned.push(slot);
+        }
+    };
+
+    // Repair slots arrive newest-first from RepairQueue::drain.
+    for &slot in repair_slots {
+        if planned.len() as u64 >= max_slots {
+            break;
+        }
+        push(slot, &mut planned, &mut seen);
+    }
+
+    // Holes are ascending ranges; walk them backwards, newest slots first.
+    'outer: for &(start, end) in holes.iter().rev() {
+        let mut slot = end.min(tip);
+        loop {
+            if planned.len() as u64 >= max_slots {
+                break 'outer;
+            }
+            push(slot, &mut planned, &mut seen);
+            if slot == start.max(floor) || slot == 0 {
+                break;
+            }
+            slot -= 1;
+        }
+    }
+
+    // Coalesce into consecutive ascending runs, keeping newest-first order
+    // between runs, then chunk to the query size.
+    planned.sort_unstable_by(|a, b| b.cmp(a));
+    let mut ranges: Vec<SlotRange> = Vec::new();
+    for slot in planned {
+        match ranges.last_mut() {
+            Some(range) if range.start == slot + 1 => range.start = slot,
+            _ => ranges.push(SlotRange {
+                start: slot,
+                end: slot,
+            }),
+        }
+    }
+
+    ranges
+        .into_iter()
+        .flat_map(|range| {
+            // Split a long run into chunks, newest chunk first.
+            let mut chunks = Vec::new();
+            let mut end = range.end;
+            loop {
+                let start = end.saturating_sub(chunk - 1).max(range.start);
+                chunks.push(SlotRange { start, end });
+                if start == range.start {
+                    break;
+                }
+                end = start - 1;
+            }
+            chunks
+        })
+        .collect()
+}
+
+pub(crate) type FilledBlock = (BlockMetadataRecord, Vec<Arc<StoredTransactionRecord>>);
+
+/// Group fetched blocks, dropping any slot whose transaction set does not
+/// match its metadata (ClickHouse ingestion may still be catching up).
+/// Returns ascending blocks plus the mismatched slots.
+pub(crate) fn assemble_blocks(
+    metas: Vec<BlockMetadataRecord>,
+    txs: Vec<StoredTransactionRecord>,
+) -> (Vec<FilledBlock>, Vec<u64>) {
+    let mut by_slot: BTreeMap<u64, Vec<Arc<StoredTransactionRecord>>> = BTreeMap::new();
+    for record in txs {
+        by_slot
+            .entry(record.slot)
+            .or_default()
+            .push(Arc::new(record));
+    }
+
+    let mut blocks = Vec::with_capacity(metas.len());
+    let mut mismatched = Vec::new();
+    for meta in metas {
+        let slot_txs = by_slot.remove(&meta.slot).unwrap_or_default();
+        if slot_txs.len() as u64 != meta.executed_transaction_count {
+            mismatched.push(meta.slot);
+            continue;
+        }
+        blocks.push((meta, slot_txs));
+    }
+    (blocks, mismatched)
+}
+
+enum FillError {
+    ClickHouse(crate::processing::ProcessingError),
+    Shutdown,
+}
+
+async fn fill_range(
+    cache: &DiskCache,
+    clickhouse: &ClickHouseClient,
+    bulk: &SyncSender<DiskWriteJob>,
+    shutdown: &mut tokio::sync::broadcast::Receiver<()>,
+    range: &SlotRange,
+    cfg: &FillerConfig,
+) -> Result<(), FillError> {
+    let (metas, _) = clickhouse
+        .get_block_metadata_by_slot_range(range.start, range.end, cfg.query_timeout)
+        .await
+        .map_err(FillError::ClickHouse)?;
+    if metas.is_empty() {
+        // Either an all-skipped run (proven by a later block's parent link) or
+        // ClickHouse is missing the range; attempts accounting decides.
+        return Ok(());
+    }
+    let (txs, _) = clickhouse
+        .get_block_full_transactions_by_slot_range(range.start, range.end, cfg.query_timeout)
+        .await
+        .map_err(FillError::ClickHouse)?;
+
+    let (blocks, mismatched) = assemble_blocks(metas, txs);
+    if !mismatched.is_empty() {
+        debug!(
+            slots = ?mismatched,
+            "disk cache: ClickHouse rows incomplete for slots; left as holes for retry"
+        );
+    }
+    if blocks.is_empty() {
+        return Ok(());
+    }
+
+    let last_slot = blocks.last().map(|(meta, _)| meta.slot);
+    let mut job = DiskWriteJob::FillBatch {
+        source: schema::COVERAGE_SOURCE_BACKFILL,
+        blocks,
+    };
+    loop {
+        match bulk.try_send(job) {
+            Ok(()) => break,
+            Err(TrySendError::Full(returned)) => {
+                job = returned;
+                if sleep_or_shutdown(shutdown, Duration::from_millis(50)).await {
+                    return Err(FillError::Shutdown);
+                }
+            }
+            Err(TrySendError::Disconnected(_)) => return Err(FillError::Shutdown),
+        }
+    }
+
+    // Wait briefly for the batch to land so the next planning round sees it
+    // as coverage instead of re-fetching the same range.
+    if let Some(last_slot) = last_slot {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !cache.covers_slot(last_slot) && Instant::now() < deadline {
+            if sleep_or_shutdown(shutdown, Duration::from_millis(20)).await {
+                return Err(FillError::Shutdown);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn prune_tracking(attempts: &mut HashMap<u64, u32>, given_up: &mut HashSet<u64>, floor: u64) {
+    attempts.retain(|&slot, _| slot >= floor);
+    given_up.retain(|&slot| slot >= floor);
+}
+
+/// Returns true when shutdown was requested.
+async fn wait_or_shutdown(
+    shutdown: &mut tokio::sync::broadcast::Receiver<()>,
+    repair: &RepairQueue,
+    interval: Duration,
+) -> bool {
+    tokio::select! {
+        _ = shutdown.recv() => true,
+        _ = repair.notified() => false,
+        _ = tokio::time::sleep(interval) => false,
+    }
+}
+
+/// Returns true when shutdown was requested.
+async fn sleep_or_shutdown(
+    shutdown: &mut tokio::sync::broadcast::Receiver<()>,
+    duration: Duration,
+) -> bool {
+    tokio::select! {
+        _ = shutdown.recv() => true,
+        _ = tokio::time::sleep(duration) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::disk_cache::tests::{block_metadata, transaction};
+
+    #[test]
+    fn plan_ranges_orders_newest_first_and_chunks() {
+        let holes = vec![(10, 14), (20, 21), (30, 30)];
+        let ranges = plan_ranges(&[], &holes, &HashSet::new(), 0, 100, 3, 64);
+
+        assert_eq!(
+            ranges,
+            vec![
+                SlotRange { start: 30, end: 30 },
+                SlotRange { start: 20, end: 21 },
+                SlotRange { start: 12, end: 14 },
+                SlotRange { start: 10, end: 11 },
+            ]
+        );
+    }
+
+    #[test]
+    fn plan_ranges_repair_slots_lead_and_merge() {
+        let holes = vec![(10, 12)];
+        let repair = vec![50, 49, 11];
+        let ranges = plan_ranges(&repair, &holes, &HashSet::new(), 0, 100, 8, 64);
+
+        assert_eq!(
+            ranges,
+            vec![
+                SlotRange { start: 49, end: 50 },
+                SlotRange { start: 10, end: 12 },
+            ]
+        );
+    }
+
+    #[test]
+    fn plan_ranges_respects_window_given_up_and_budget() {
+        let holes = vec![(0, 100)];
+        let mut given_up = HashSet::new();
+        given_up.insert(98u64);
+
+        let ranges = plan_ranges(&[], &holes, &given_up, 90, 99, 4, 6);
+        // Newest-first from 99 down, skipping 98, six slots total: 99, 97..=93.
+        assert_eq!(
+            ranges,
+            vec![
+                SlotRange { start: 99, end: 99 },
+                SlotRange { start: 94, end: 97 },
+                SlotRange { start: 93, end: 93 },
+            ]
+        );
+
+        // Everything below the floor or above the tip is ignored.
+        let ranges = plan_ranges(&[200, 5], &holes, &HashSet::new(), 90, 99, 4, 64);
+        let total: u64 = ranges.iter().map(|range| range.len_slots()).sum();
+        assert_eq!(total, 10);
+    }
+
+    #[test]
+    fn assemble_blocks_groups_and_validates_counts() {
+        let meta_ok = block_metadata(100, 99, 2);
+        let meta_mismatch = block_metadata(101, 100, 3);
+        let meta_empty = block_metadata(102, 101, 0);
+
+        let txs = vec![
+            transaction(100, 0),
+            transaction(100, 1),
+            transaction(101, 0), // only 1 of 3
+        ];
+
+        let (blocks, mismatched) = assemble_blocks(vec![meta_ok, meta_mismatch, meta_empty], txs);
+        assert_eq!(mismatched, vec![101]);
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(blocks[0].0.slot, 100);
+        assert_eq!(blocks[0].1.len(), 2);
+        assert_eq!(blocks[1].0.slot, 102);
+        assert!(blocks[1].1.is_empty());
+    }
+}

--- a/crates/superbank-rpc/src/disk_cache/filler.rs
+++ b/crates/superbank-rpc/src/disk_cache/filler.rs
@@ -103,6 +103,8 @@ pub(crate) async fn run(
 
         let repair_slots = repair.drain(MAX_SLOTS_PER_ROUND as usize);
         let holes = cache.holes_in(window.floor, window.tip);
+        let hole_slots: u64 = holes.iter().map(|&(start, end)| end - start + 1).sum();
+        crate::metrics::disk_cache_backfill_remaining(hole_slots + repair.len() as u64);
         let ranges = plan_ranges(
             &repair_slots,
             &holes,
@@ -162,6 +164,7 @@ pub(crate) async fn run(
                 }
                 Err(FillError::Shutdown) => return,
                 Err(FillError::ClickHouse(err)) => {
+                    crate::metrics::disk_cache_fill_error();
                     warn!(
                         start = range.start,
                         end = range.end,

--- a/crates/superbank-rpc/src/disk_cache/index.rs
+++ b/crates/superbank-rpc/src/disk_cache/index.rs
@@ -18,7 +18,8 @@ use solana_sdk::pubkey::Pubkey;
 use solana_sdk::signature::Signature;
 
 use crate::clickhouse::{
-    SignatureRecord, SignatureSlot, SlotBoundary, StoredTransactionRecord, extract_memo,
+    NumericFilter, ResolvedSignatureFilter, SignatureRecord, SignatureSlot, SlotBoundary,
+    SortOrder, StoredTransactionRecord, TokenAccountsFilter, TransactionStatusFilter, extract_memo,
     parse_err_json,
 };
 
@@ -293,6 +294,436 @@ impl DiskCacheInner {
             floor,
         }))
     }
+}
+
+/// Disk-side getTransactionsForAddress query. All signature bounds and the
+/// pagination token must already be resolved to positions — the handler skips
+/// the disk tier otherwise.
+#[derive(Debug, Clone)]
+pub(crate) struct DiskTfaQuery {
+    pub(crate) limit: usize,
+    pub(crate) sort_order: SortOrder,
+    /// Exclusive position bound: Desc pages continue strictly below it, Asc
+    /// pages strictly above it.
+    pub(crate) pagination: Option<SignatureSlot>,
+    pub(crate) slot_filter: Option<NumericFilter<u64>>,
+    pub(crate) block_time_filter: Option<NumericFilter<i64>>,
+    pub(crate) signature_filter: Option<ResolvedSignatureFilter>,
+    pub(crate) status: TransactionStatusFilter,
+    pub(crate) token_accounts: TokenAccountsFilter,
+}
+
+impl DiskCacheInner {
+    /// getTransactionsForAddress over the disk indexes: the gsfa index, unioned
+    /// with the token-owner index when the token filter is active, deduplicated
+    /// by position (one transaction occupies one `(slot, idx)`), with all
+    /// resolved bounds folded into the key-space scan window.
+    ///
+    /// Asc queries must be fully answerable from coverage (the handler gates on
+    /// the lower bound being at or above the floor), so `reached_floor` can only
+    /// be set for Desc scans.
+    pub(crate) fn transactions_for_address_sync(
+        &self,
+        address: &Pubkey,
+        query: &DiskTfaQuery,
+    ) -> Result<Option<DiskGsfaPage>, DiskCacheError> {
+        let Some((tip_floor, _)) = self
+            .coverage
+            .read()
+            .expect("coverage lock")
+            .contiguous_tip_span()
+        else {
+            return Ok(None);
+        };
+        let floor = tip_floor.max(self.min_retained());
+        let address_bytes = address.to_bytes();
+
+        let (key_low, key_high, floor_is_effective) = tfa_key_window(&address_bytes, query, floor);
+        if key_low >= key_high {
+            // Bounds are contradictory; nothing in the window. For Desc this can
+            // mean the whole window sits below the floor.
+            return Ok(Some(DiskGsfaPage {
+                records: Vec::new(),
+                reached_floor: query.sort_order == SortOrder::Desc && floor_is_effective,
+                floor,
+            }));
+        }
+
+        let gsfa_iter = self.window_iterator(
+            schema::CF_ADDR_SIG,
+            key_low.clone(),
+            key_high.clone(),
+            query.sort_order,
+        );
+        let token_iter = (query.token_accounts != TokenAccountsFilter::None).then(|| {
+            self.window_iterator(
+                schema::CF_TOKEN_OWNER,
+                key_low.clone(),
+                key_high.clone(),
+                query.sort_order,
+            )
+        });
+
+        let balance_changed_only = query.token_accounts == TokenAccountsFilter::BalanceChanged;
+        let mut gsfa = IndexCursor::new(gsfa_iter, &key_high, query.sort_order, false)?;
+        let mut token = match token_iter {
+            Some(iter) => Some(IndexCursor::new(
+                iter,
+                &key_high,
+                query.sort_order,
+                balance_changed_only,
+            )?),
+            None => None,
+        };
+
+        let mut records: Vec<SignatureRecord> = Vec::new();
+        let mut last_position: Option<(u64, u32)> = None;
+        while records.len() < query.limit {
+            // Pick the next entry across both cursors in scan order.
+            let take_gsfa = match (
+                &gsfa.current,
+                token.as_ref().and_then(|t| t.current.as_ref()),
+            ) {
+                (None, None) => break,
+                (Some(_), None) => true,
+                (None, Some(_)) => false,
+                (Some((g_pos, _)), Some((t_pos, _))) => match query.sort_order {
+                    SortOrder::Desc => g_pos >= t_pos,
+                    SortOrder::Asc => g_pos <= t_pos,
+                },
+            };
+            let (position, value) = if take_gsfa {
+                gsfa.take()?.expect("cursor checked")
+            } else {
+                token
+                    .as_mut()
+                    .expect("token cursor present")
+                    .take()?
+                    .expect("cursor checked")
+            };
+
+            // LIMIT 1 BY signature: one transaction occupies one position, and
+            // the scan visits positions monotonically.
+            if last_position == Some(position) {
+                continue;
+            }
+            last_position = Some(position);
+
+            if !tfa_entry_matches(&value, position.0, query) {
+                continue;
+            }
+
+            let signature = bs58::encode(value.signature).into_string();
+            let err = value
+                .err
+                .and_then(|raw_err| parse_err_json(&signature, raw_err));
+            records.push(SignatureRecord {
+                signature,
+                slot: position.0,
+                slot_idx: position.1,
+                err,
+                memo: value.memo,
+                block_time: value.block_time,
+            });
+        }
+
+        let reached_floor = query.sort_order == SortOrder::Desc
+            && records.len() < query.limit
+            && floor_is_effective;
+        Ok(Some(DiskGsfaPage {
+            records,
+            reached_floor,
+            floor,
+        }))
+    }
+
+    fn window_iterator(
+        &self,
+        cf_name: &str,
+        key_low: Vec<u8>,
+        key_high: Vec<u8>,
+        sort_order: SortOrder,
+    ) -> rocksdb::DBIteratorWithThreadMode<'_, rocksdb::DBWithThreadMode<rocksdb::MultiThreaded>>
+    {
+        let cf = self.cf(cf_name);
+        let mut read_opts = ReadOptions::default();
+        match sort_order {
+            SortOrder::Desc => {
+                read_opts.set_iterate_upper_bound(key_high.clone());
+                self.db.iterator_cf_opt(
+                    &cf,
+                    read_opts,
+                    IteratorMode::From(&key_low, Direction::Forward),
+                )
+            }
+            SortOrder::Asc => {
+                read_opts.set_iterate_lower_bound(key_low.clone());
+                // The reverse start is inclusive; IndexCursor drops any entry at
+                // or beyond the exclusive high bound.
+                self.db.iterator_cf_opt(
+                    &cf,
+                    read_opts,
+                    IteratorMode::From(&key_high, Direction::Reverse),
+                )
+            }
+        }
+    }
+
+    /// Batch full-record fetch by position; `None` per entry on miss (e.g. the
+    /// eviction floor passed the slot between the index scan and this fetch).
+    pub(crate) fn get_txs_by_position_sync(
+        &self,
+        positions: &[(u64, u32)],
+    ) -> Vec<Option<StoredTransactionRecord>> {
+        let tx_cf = self.cf(schema::CF_TX);
+        positions
+            .iter()
+            .map(|&(slot, idx)| {
+                self.db
+                    .get_pinned_cf(&tx_cf, schema::tx_key(slot, idx))
+                    .ok()
+                    .flatten()
+                    .and_then(|raw| codec::decode_record::<StoredTransactionRecord>(&raw))
+            })
+            .collect()
+    }
+}
+
+/// One decoded index entry: position plus value.
+type IndexEntry = ((u64, u32), codec::AddrSigValue);
+
+/// Streaming decode over one index CF; `current` always holds the next
+/// in-window entry (already past the exclusive high bound and flag filters).
+struct IndexCursor<'a> {
+    iter: rocksdb::DBIteratorWithThreadMode<'a, rocksdb::DBWithThreadMode<rocksdb::MultiThreaded>>,
+    key_high: &'a [u8],
+    sort_order: SortOrder,
+    balance_changed_only: bool,
+    current: Option<IndexEntry>,
+}
+
+impl<'a> IndexCursor<'a> {
+    fn new(
+        iter: rocksdb::DBIteratorWithThreadMode<
+            'a,
+            rocksdb::DBWithThreadMode<rocksdb::MultiThreaded>,
+        >,
+        key_high: &'a [u8],
+        sort_order: SortOrder,
+        balance_changed_only: bool,
+    ) -> Result<Self, DiskCacheError> {
+        let mut cursor = Self {
+            iter,
+            key_high,
+            sort_order,
+            balance_changed_only,
+            current: None,
+        };
+        cursor.advance()?;
+        Ok(cursor)
+    }
+
+    fn take(&mut self) -> Result<Option<IndexEntry>, DiskCacheError> {
+        let current = self.current.take();
+        self.advance()?;
+        Ok(current)
+    }
+
+    fn advance(&mut self) -> Result<(), DiskCacheError> {
+        self.current = None;
+        for entry in self.iter.by_ref() {
+            let (key, raw) = entry?;
+            // Reverse iteration starts at the exclusive high bound itself.
+            if self.sort_order == SortOrder::Asc && key.as_ref() >= self.key_high {
+                continue;
+            }
+            let Some(slot) = schema::addr_key_slot(&key) else {
+                return Err(DiskCacheError::CorruptIndexEntry { slot: None });
+            };
+            let Some(idx) = addr_key_idx(&key) else {
+                return Err(DiskCacheError::CorruptIndexEntry { slot: Some(slot) });
+            };
+            let Some(value) = codec::decode_addr_sig_value(&raw) else {
+                return Err(DiskCacheError::CorruptIndexEntry { slot: Some(slot) });
+            };
+            if self.balance_changed_only && !value.balance_changed {
+                continue;
+            }
+            self.current = Some(((slot, idx), value));
+            break;
+        }
+        Ok(())
+    }
+}
+
+/// Translate the resolved bounds into one key-space window
+/// `[key_low, key_high)` shared by both indexes (their first 44 key bytes have
+/// identical layout). Returns whether the floor is the binding old-side bound,
+/// which is what decides `reached_floor` for Desc scans.
+fn tfa_key_window(
+    address: &[u8; 32],
+    query: &DiskTfaQuery,
+    floor: u64,
+) -> (Vec<u8>, Vec<u8>, bool) {
+    // Key space is order-reversed: newer positions have smaller keys. The "new"
+    // side of the window is key_low, the "old" side is key_high.
+    let mut key_low = {
+        let mut key = Vec::with_capacity(44);
+        key.extend_from_slice(address);
+        key.extend_from_slice(&[0u8; 12]);
+        key
+    };
+    let mut key_high = floor_upper_bound(address, floor);
+    let mut floor_is_effective = true;
+
+    let tighten_new_side = |candidate: Vec<u8>, key_low: &mut Vec<u8>| {
+        if candidate > *key_low {
+            *key_low = candidate;
+        }
+    };
+    let tighten_old_side = |candidate: Vec<u8>, key_high: &mut Vec<u8>, floor_eff: &mut bool| {
+        // Equality counts: a filter bound that coincides with the floor means
+        // the query never extends below coverage, so the floor is not the
+        // binding constraint and no ClickHouse remainder exists.
+        if candidate <= *key_high {
+            *key_high = candidate;
+            *floor_eff = false;
+        }
+    };
+
+    let filter = query.signature_filter.clone().unwrap_or_default();
+    let slot_filter = query.slot_filter.clone().unwrap_or_default();
+
+    // New-side (upper position) bounds: pagination for Desc, slot lt/lte,
+    // signature lt/lte.
+    if query.sort_order == SortOrder::Desc
+        && let Some(position) = query.pagination
+    {
+        let mut key = schema::addr_sig_key(address, position.slot, position.slot_idx).to_vec();
+        key.push(0); // strictly older than the position
+        tighten_new_side(key, &mut key_low);
+    }
+    if let Some(slot) = slot_filter.lt
+        && slot > 0
+    {
+        tighten_new_side(
+            seek_key(address, Some(SlotBoundary::Slot(slot))),
+            &mut key_low,
+        );
+    }
+    if let Some(slot) = slot_filter.lte
+        && slot < u64::MAX
+    {
+        tighten_new_side(
+            seek_key(address, Some(SlotBoundary::Slot(slot + 1))),
+            &mut key_low,
+        );
+    }
+    if let Some(position) = filter.lte {
+        tighten_new_side(
+            schema::addr_sig_key(address, position.slot, position.slot_idx).to_vec(),
+            &mut key_low,
+        );
+    }
+    if let Some(position) = filter.lt {
+        let mut key = schema::addr_sig_key(address, position.slot, position.slot_idx).to_vec();
+        key.push(0);
+        tighten_new_side(key, &mut key_low);
+    }
+
+    // Old-side (lower position) bounds: pagination for Asc, slot gt/gte,
+    // signature gt/gte. The floor seeds key_high above.
+    if query.sort_order == SortOrder::Asc
+        && let Some(position) = query.pagination
+    {
+        tighten_old_side(
+            schema::addr_sig_key(address, position.slot, position.slot_idx).to_vec(),
+            &mut key_high,
+            &mut floor_is_effective,
+        );
+    }
+    if let Some(slot) = slot_filter.gt {
+        tighten_old_side(
+            until_upper_bound(address, SlotBoundary::Slot(slot)),
+            &mut key_high,
+            &mut floor_is_effective,
+        );
+    }
+    if let Some(slot) = slot_filter.gte
+        && slot > 0
+    {
+        tighten_old_side(
+            until_upper_bound(address, SlotBoundary::Slot(slot - 1)),
+            &mut key_high,
+            &mut floor_is_effective,
+        );
+    }
+    if let Some(position) = filter.gte {
+        let mut key = schema::addr_sig_key(address, position.slot, position.slot_idx).to_vec();
+        key.push(0); // include the position itself
+        tighten_old_side(key, &mut key_high, &mut floor_is_effective);
+    }
+    if let Some(position) = filter.gt {
+        tighten_old_side(
+            schema::addr_sig_key(address, position.slot, position.slot_idx).to_vec(),
+            &mut key_high,
+            &mut floor_is_effective,
+        );
+    }
+
+    (key_low, key_high, floor_is_effective)
+}
+
+/// Predicates that cannot be folded into the key window.
+fn tfa_entry_matches(value: &codec::AddrSigValue, _slot: u64, query: &DiskTfaQuery) -> bool {
+    match query.status {
+        TransactionStatusFilter::Any => {}
+        TransactionStatusFilter::Succeeded => {
+            if value.err.is_some() {
+                return false;
+            }
+        }
+        TransactionStatusFilter::Failed => {
+            if value.err.is_none() {
+                return false;
+            }
+        }
+    }
+
+    if let Some(filter) = query.block_time_filter.as_ref() {
+        // Mirrors ClickHouse comparison semantics: a NULL block_time fails
+        // every bound.
+        let Some(block_time) = value.block_time else {
+            return false;
+        };
+        if let Some(bound) = filter.eq
+            && block_time != bound
+        {
+            return false;
+        }
+        if let Some(bound) = filter.gte
+            && block_time < bound
+        {
+            return false;
+        }
+        if let Some(bound) = filter.gt
+            && block_time <= bound
+        {
+            return false;
+        }
+        if let Some(bound) = filter.lte
+            && block_time > bound
+        {
+            return false;
+        }
+        if let Some(bound) = filter.lt
+            && block_time >= bound
+        {
+            return false;
+        }
+    }
+
+    true
 }
 
 /// Slot index embedded in an `addr_sig` key.

--- a/crates/superbank-rpc/src/disk_cache/index.rs
+++ b/crates/superbank-rpc/src/disk_cache/index.rs
@@ -1,0 +1,576 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+/*
+ * Copyright 2025-2026 Triton One Limited. All rights reserved.
+ */
+
+//! Signature/address index derivation and reads.
+//!
+//! [`derive_index_entries`] ports the SQL of the ClickHouse materialized views —
+//! `ddl/local/gsfa.sql`, `ddl/local/signatures.sql`, and
+//! `ddl/local/token_owner_activity.sql` — to Rust. The disk cache answers in
+//! place of ClickHouse, so any divergence from the MV semantics yields different
+//! result SETS than ClickHouse, not just staleness. One shared derivation is used
+//! by live, backfill, and repair writes so all sources agree.
+
+use once_cell::sync::Lazy;
+use rocksdb::{Direction, IteratorMode, ReadOptions};
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::Signature;
+
+use crate::clickhouse::{
+    SignatureRecord, SignatureSlot, SlotBoundary, StoredTransactionRecord, extract_memo,
+    parse_err_json,
+};
+
+use super::{DiskCacheError, DiskCacheInner, DiskGsfaPage, codec, schema};
+
+/// Addresses the gsfa MV never indexes (`gsfa_ignored_addresses` in
+/// `ddl/local/gsfa.sql`). The head cache intentionally indexes everything; the
+/// disk cache MUST filter, both to mirror ClickHouse result sets and because ten
+/// epochs of vote-transaction entries would dwarf the rest of the index.
+static GSFA_IGNORED_ADDRESSES: Lazy<[[u8; 32]; 4]> = Lazy::new(|| {
+    use std::str::FromStr;
+    [
+        Pubkey::from_str("11111111111111111111111111111111").expect("system program"),
+        Pubkey::from_str("Vote111111111111111111111111111111111111111").expect("vote program"),
+        Pubkey::from_str("SysvarC1ock11111111111111111111111111111111").expect("sysvar clock"),
+        Pubkey::from_str("SysvarS1otHashes111111111111111111111111111")
+            .expect("sysvar slot hashes"),
+    ]
+    .map(|pubkey| pubkey.to_bytes())
+});
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TokenOwnerEntry {
+    pub(crate) owner: [u8; 32],
+    pub(crate) token_account: [u8; 32],
+    pub(crate) balance_changed: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TxIndexEntries {
+    /// `meta_err` when the transaction failed, `None` on success — the
+    /// `if(meta_status_ok = 1, NULL, meta_err)` of the MVs.
+    pub(crate) err: Option<String>,
+    pub(crate) memo: Option<String>,
+    /// Distinct addresses touched by the transaction, minus the ignored set.
+    pub(crate) addresses: Vec<[u8; 32]>,
+    pub(crate) token_entries: Vec<TokenOwnerEntry>,
+}
+
+pub(crate) fn derive_index_entries(record: &StoredTransactionRecord) -> TxIndexEntries {
+    let err = if record.meta_status_ok {
+        None
+    } else {
+        record.meta_err.clone()
+    };
+    let memo = extract_memo(record);
+
+    // Concatenation order matters: instruction and token-balance account indexes
+    // resolve against static keys, then loaded writable, then loaded readonly.
+    let mut account_keys_all = Vec::with_capacity(
+        record.tx_account_keys.len()
+            + record.meta_loaded_addresses_writable.len()
+            + record.meta_loaded_addresses_readonly.len(),
+    );
+    account_keys_all.extend_from_slice(&record.tx_account_keys);
+    account_keys_all.extend_from_slice(&record.meta_loaded_addresses_writable);
+    account_keys_all.extend_from_slice(&record.meta_loaded_addresses_readonly);
+
+    let mut addresses = account_keys_all.clone();
+    addresses.sort_unstable();
+    addresses.dedup();
+    addresses.retain(|address| !GSFA_IGNORED_ADDRESSES.contains(address));
+
+    let token_entries = derive_token_entries(record, &account_keys_all);
+
+    TxIndexEntries {
+        err,
+        memo,
+        addresses,
+        token_entries,
+    }
+}
+
+/// Ports the `token_entries` expression of `ddl/local/token_owner_activity.sql`
+/// (ClickHouse arrays are 1-based and out-of-range `arrayElement` yields
+/// NULL/default; `Option` chains reproduce that).
+fn derive_token_entries(
+    record: &StoredTransactionRecord,
+    account_keys_all: &[[u8; 32]],
+) -> Vec<TokenOwnerEntry> {
+    let mut token_indices: Vec<u8> = Vec::with_capacity(
+        record.meta_pre_token_account_index.len() + record.meta_post_token_account_index.len(),
+    );
+    token_indices.extend_from_slice(&record.meta_pre_token_account_index);
+    token_indices.extend_from_slice(&record.meta_post_token_account_index);
+    token_indices.sort_unstable();
+    token_indices.dedup();
+
+    let mut entries = Vec::with_capacity(token_indices.len());
+    for idx in token_indices {
+        let pre_pos = record
+            .meta_pre_token_account_index
+            .iter()
+            .position(|&index| index == idx);
+        let post_pos = record
+            .meta_post_token_account_index
+            .iter()
+            .position(|&index| index == idx);
+
+        // coalesce(post_owner[post], pre_owner[pre])
+        let owner = post_pos
+            .and_then(|pos| record.meta_post_token_owner.get(pos).copied().flatten())
+            .or_else(|| {
+                pre_pos.and_then(|pos| record.meta_pre_token_owner.get(pos).copied().flatten())
+            });
+        let Some(owner) = owner else {
+            continue;
+        };
+        // `idx < length(account_keys_all)` bounds guard.
+        let Some(token_account) = account_keys_all.get(usize::from(idx)).copied() else {
+            continue;
+        };
+
+        let balance_changed = match (pre_pos, post_pos) {
+            (Some(pre), Some(post)) => {
+                record
+                    .meta_pre_token_amount
+                    .get(pre)
+                    .map(String::as_str)
+                    .unwrap_or("")
+                    != record
+                        .meta_post_token_amount
+                        .get(post)
+                        .map(String::as_str)
+                        .unwrap_or("")
+            }
+            _ => true,
+        };
+
+        entries.push(TokenOwnerEntry {
+            owner,
+            token_account,
+            balance_changed,
+        });
+    }
+    entries
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DiskSigStatus {
+    pub(crate) slot: u64,
+    pub(crate) slot_idx: u32,
+    pub(crate) err: Option<String>,
+}
+
+impl DiskCacheInner {
+    /// Resolve a signature to its stored status. Bounded by the eviction floor:
+    /// index entries of evicted slots may linger until compaction.
+    pub(crate) fn get_sig_status_sync(&self, signature: &Signature) -> Option<DiskSigStatus> {
+        let raw = self
+            .db
+            .get_pinned_cf(&self.cf(schema::CF_SIG), signature.as_ref())
+            .ok()??;
+        let value = codec::decode_sig_value(&raw)?;
+        if value.slot < self.min_retained() {
+            return None;
+        }
+        Some(DiskSigStatus {
+            slot: value.slot,
+            slot_idx: value.idx,
+            err: value.err,
+        })
+    }
+
+    pub(crate) fn signature_position_sync(&self, signature: &Signature) -> Option<SignatureSlot> {
+        self.get_sig_status_sync(signature)
+            .map(|status| SignatureSlot {
+                slot: status.slot,
+                slot_idx: status.slot_idx,
+            })
+    }
+
+    /// Full transaction lookup: signature index, then the slot-keyed record. The
+    /// record must list the signature (defense against index/record mismatch).
+    pub(crate) fn get_tx_sync(&self, signature: &Signature) -> Option<StoredTransactionRecord> {
+        let position = self.signature_position_sync(signature)?;
+        let raw = self
+            .db
+            .get_pinned_cf(
+                &self.cf(schema::CF_TX),
+                schema::tx_key(position.slot, position.slot_idx),
+            )
+            .ok()??;
+        let record = codec::decode_record::<StoredTransactionRecord>(&raw)?;
+        let sig_bytes: [u8; 64] = *signature.as_array();
+        if !record.tx_signatures.contains(&sig_bytes) {
+            tracing::warn!(
+                signature = %signature,
+                slot = position.slot,
+                "disk cache: signature index points at a record without that signature"
+            );
+            return None;
+        }
+        Some(record)
+    }
+
+    /// Newest-first address-index scan within the contiguous tip span.
+    ///
+    /// `before`/`until` are exclusive, matching gSFA semantics. Returns `None`
+    /// when there is no coverage to evaluate. Any decode failure is an error —
+    /// a gSFA page must be complete, so the caller degrades to ClickHouse rather
+    /// than silently dropping an entry.
+    pub(crate) fn signatures_for_address_sync(
+        &self,
+        address: &Pubkey,
+        before: Option<SlotBoundary>,
+        until: Option<SlotBoundary>,
+        limit: usize,
+    ) -> Result<Option<DiskGsfaPage>, DiskCacheError> {
+        let Some((tip_floor, _)) = self
+            .coverage
+            .read()
+            .expect("coverage lock")
+            .contiguous_tip_span()
+        else {
+            return Ok(None);
+        };
+        let floor = tip_floor.max(self.min_retained());
+        let address_bytes = address.to_bytes();
+
+        let floor_bound = floor_upper_bound(&address_bytes, floor);
+        let until_bound = until.map(|boundary| until_upper_bound(&address_bytes, boundary));
+        let (upper_bound, floor_is_effective) = match until_bound {
+            Some(until_key) if until_key <= floor_bound => (until_key, false),
+            Some(_) | None => (floor_bound, true),
+        };
+        let seek = seek_key(&address_bytes, before);
+
+        let mut read_opts = ReadOptions::default();
+        read_opts.set_iterate_upper_bound(upper_bound);
+        let iter = self.db.iterator_cf_opt(
+            &self.cf(schema::CF_ADDR_SIG),
+            read_opts,
+            IteratorMode::From(&seek, Direction::Forward),
+        );
+
+        let mut records = Vec::new();
+        for entry in iter {
+            let (key, raw) = entry?;
+            let Some(slot) = schema::addr_key_slot(&key) else {
+                return Err(DiskCacheError::CorruptIndexEntry { slot: None });
+            };
+            let idx =
+                addr_key_idx(&key).ok_or(DiskCacheError::CorruptIndexEntry { slot: Some(slot) })?;
+            let Some(value) = codec::decode_addr_sig_value(&raw) else {
+                return Err(DiskCacheError::CorruptIndexEntry { slot: Some(slot) });
+            };
+
+            let signature = bs58::encode(value.signature).into_string();
+            let err = value
+                .err
+                .and_then(|raw_err| parse_err_json(&signature, raw_err));
+            records.push(SignatureRecord {
+                signature,
+                slot,
+                slot_idx: idx,
+                err,
+                // Stored pre-formatted ("[len] text"), identical to what
+                // format_gsfa_memo yields for ClickHouse rows.
+                memo: value.memo,
+                block_time: value.block_time,
+            });
+            if records.len() >= limit {
+                break;
+            }
+        }
+
+        let reached_floor = records.len() < limit && floor_is_effective;
+        Ok(Some(DiskGsfaPage {
+            records,
+            reached_floor,
+            floor,
+        }))
+    }
+}
+
+/// Slot index embedded in an `addr_sig` key.
+fn addr_key_idx(key: &[u8]) -> Option<u32> {
+    let raw = key.get(40..44)?;
+    Some(!u32::from_be_bytes(raw.try_into().ok()?))
+}
+
+/// First key of the scan: everything strictly *older* than `before` (exclusive),
+/// or the newest entry of the address when unbounded.
+fn seek_key(address: &[u8; 32], before: Option<SlotBoundary>) -> Vec<u8> {
+    match before {
+        None => {
+            let mut key = Vec::with_capacity(44);
+            key.extend_from_slice(address);
+            key.extend_from_slice(&[0u8; 12]);
+            key
+        }
+        Some(SlotBoundary::Position(position)) => {
+            // One byte past the exact key: strictly older entries only.
+            let mut key = schema::addr_sig_key(address, position.slot, position.slot_idx).to_vec();
+            key.push(0);
+            key
+        }
+        Some(SlotBoundary::Slot(slot)) => {
+            let Some(prev_slot) = slot.checked_sub(1) else {
+                // slot < 0 is unsatisfiable; seek past the whole prefix.
+                return floor_upper_bound(address, 0);
+            };
+            let mut key = Vec::with_capacity(44);
+            key.extend_from_slice(address);
+            key.extend_from_slice(&schema::rev_slot(prev_slot).to_be_bytes());
+            key.extend_from_slice(&[0u8; 4]);
+            key
+        }
+    }
+}
+
+/// Exclusive upper bound that keeps `slot >= floor` (and stays within the
+/// address prefix when `floor == 0`).
+fn floor_upper_bound(address: &[u8; 32], floor: u64) -> Vec<u8> {
+    let mut key = Vec::with_capacity(45);
+    key.extend_from_slice(address);
+    match floor.checked_sub(1) {
+        Some(prev_slot) => {
+            key.extend_from_slice(&schema::rev_slot(prev_slot).to_be_bytes());
+            key.extend_from_slice(&[0u8; 4]);
+        }
+        None => {
+            // floor == 0: bound just past the last possible key of the prefix.
+            // A longer key sorts after every 44-byte key sharing the prefix.
+            key.extend_from_slice(&[0xFFu8; 12]);
+            key.push(0);
+        }
+    }
+    key
+}
+
+/// Exclusive upper bound for `until`: keeps entries strictly newer than it.
+fn until_upper_bound(address: &[u8; 32], until: SlotBoundary) -> Vec<u8> {
+    match until {
+        // Excludes the until position itself and everything older.
+        SlotBoundary::Position(position) => {
+            schema::addr_sig_key(address, position.slot, position.slot_idx).to_vec()
+        }
+        // Excludes slot <= until.
+        SlotBoundary::Slot(slot) => {
+            let mut key = Vec::with_capacity(44);
+            key.extend_from_slice(address);
+            key.extend_from_slice(&schema::rev_slot(slot).to_be_bytes());
+            key.extend_from_slice(&[0u8; 4]);
+            key
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_record() -> StoredTransactionRecord {
+        StoredTransactionRecord {
+            signature: [9u8; 64],
+            slot: 100,
+            slot_idx: 0,
+            block_time: Some(1_700_000_000),
+            tx_version: None,
+            tx_signatures: vec![[9u8; 64]],
+            tx_num_required_signatures: 1,
+            tx_num_readonly_signed_accounts: 0,
+            tx_num_readonly_unsigned_accounts: 0,
+            tx_account_keys: Vec::new(),
+            tx_recent_blockhash: [0u8; 32],
+            tx_instructions_program_id_index: Vec::new(),
+            tx_instructions_accounts: Vec::new(),
+            tx_instructions_data: Vec::new(),
+            tx_address_table_lookups_present: false,
+            tx_address_table_lookup_account_key: Vec::new(),
+            tx_address_table_lookup_writable_indexes: Vec::new(),
+            tx_address_table_lookup_readonly_indexes: Vec::new(),
+            meta_status_ok: true,
+            meta_err: None,
+            meta_fee: 0,
+            meta_pre_balances: Vec::new(),
+            meta_post_balances: Vec::new(),
+            meta_inner_instructions_present: false,
+            meta_inner_instructions_index: Vec::new(),
+            meta_inner_instructions_program_id_index: Vec::new(),
+            meta_inner_instructions_accounts: Vec::new(),
+            meta_inner_instructions_data: Vec::new(),
+            meta_inner_instructions_stack_height: Vec::new(),
+            meta_log_messages_present: false,
+            meta_log_messages: Vec::new(),
+            meta_pre_token_balances_present: false,
+            meta_pre_token_account_index: Vec::new(),
+            meta_pre_token_mint: Vec::new(),
+            meta_pre_token_owner: Vec::new(),
+            meta_pre_token_program_id: Vec::new(),
+            meta_pre_token_amount: Vec::new(),
+            meta_pre_token_decimals: Vec::new(),
+            meta_pre_token_ui_amount: Vec::new(),
+            meta_pre_token_ui_amount_string: Vec::new(),
+            meta_post_token_balances_present: false,
+            meta_post_token_account_index: Vec::new(),
+            meta_post_token_mint: Vec::new(),
+            meta_post_token_owner: Vec::new(),
+            meta_post_token_program_id: Vec::new(),
+            meta_post_token_amount: Vec::new(),
+            meta_post_token_decimals: Vec::new(),
+            meta_post_token_ui_amount: Vec::new(),
+            meta_post_token_ui_amount_string: Vec::new(),
+            meta_rewards_present: false,
+            meta_reward_pubkey: Vec::new(),
+            meta_reward_lamports: Vec::new(),
+            meta_reward_post_balance: Vec::new(),
+            meta_reward_type: Vec::new(),
+            meta_reward_commission: Vec::new(),
+            meta_loaded_addresses_writable: Vec::new(),
+            meta_loaded_addresses_readonly: Vec::new(),
+            meta_return_data_present: false,
+            meta_return_data_program_id: None,
+            meta_return_data_data: None,
+            meta_compute_units_consumed: None,
+            meta_cost_units: None,
+        }
+    }
+
+    fn pubkey_bytes(seed: u8) -> [u8; 32] {
+        [seed; 32]
+    }
+
+    #[test]
+    fn addresses_are_deduped_and_ignored_set_is_filtered() {
+        use std::str::FromStr;
+        let vote_program = Pubkey::from_str("Vote111111111111111111111111111111111111111")
+            .unwrap()
+            .to_bytes();
+        let system_program = Pubkey::from_str("11111111111111111111111111111111")
+            .unwrap()
+            .to_bytes();
+
+        let mut record = base_record();
+        record.tx_account_keys = vec![
+            pubkey_bytes(1),
+            vote_program,
+            pubkey_bytes(2),
+            pubkey_bytes(1),
+        ];
+        record.meta_loaded_addresses_writable = vec![pubkey_bytes(2), pubkey_bytes(3)];
+        record.meta_loaded_addresses_readonly = vec![system_program, pubkey_bytes(4)];
+
+        let entries = derive_index_entries(&record);
+        let mut expected = vec![
+            pubkey_bytes(1),
+            pubkey_bytes(2),
+            pubkey_bytes(3),
+            pubkey_bytes(4),
+        ];
+        expected.sort_unstable();
+        assert_eq!(entries.addresses, expected);
+    }
+
+    #[test]
+    fn err_follows_meta_status() {
+        let mut record = base_record();
+        record.meta_status_ok = true;
+        record.meta_err = Some("ignored".to_string());
+        assert_eq!(derive_index_entries(&record).err, None);
+
+        record.meta_status_ok = false;
+        assert_eq!(
+            derive_index_entries(&record).err.as_deref(),
+            Some("ignored")
+        );
+    }
+
+    #[test]
+    fn memo_extraction_uses_combined_account_keys() {
+        use std::str::FromStr;
+        let memo_program = Pubkey::from_str("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr")
+            .unwrap()
+            .to_bytes();
+
+        let mut record = base_record();
+        // Memo program resolved through a loaded address (index 1 = loaded writable).
+        record.tx_account_keys = vec![pubkey_bytes(1)];
+        record.meta_loaded_addresses_writable = vec![memo_program];
+        record.tx_instructions_program_id_index = vec![1];
+        record.tx_instructions_data = vec![b"hello".to_vec()];
+
+        let entries = derive_index_entries(&record);
+        assert_eq!(entries.memo.as_deref(), Some("[5] hello"));
+    }
+
+    #[test]
+    fn token_entries_follow_mv_semantics() {
+        let mut record = base_record();
+        record.tx_account_keys = vec![
+            pubkey_bytes(1), // idx 0
+            pubkey_bytes(2), // idx 1: token account A
+            pubkey_bytes(3), // idx 2: token account B
+            pubkey_bytes(4), // idx 3: token account C (pre only)
+        ];
+
+        // idx 1: pre+post, amounts equal -> balance_changed = false
+        // idx 2: pre+post, amounts differ -> balance_changed = true
+        // idx 3: pre only -> balance_changed = true, owner from pre
+        // idx 9: out of bounds -> dropped
+        record.meta_pre_token_account_index = vec![1, 2, 3, 9];
+        record.meta_pre_token_owner = vec![
+            Some(pubkey_bytes(11)),
+            Some(pubkey_bytes(12)),
+            Some(pubkey_bytes(13)),
+            Some(pubkey_bytes(14)),
+        ];
+        record.meta_pre_token_amount = vec![
+            "100".to_string(),
+            "200".to_string(),
+            "300".to_string(),
+            "400".to_string(),
+        ];
+        record.meta_post_token_account_index = vec![1, 2];
+        record.meta_post_token_owner = vec![Some(pubkey_bytes(21)), None];
+        record.meta_post_token_amount = vec!["100".to_string(), "999".to_string()];
+
+        let entries = derive_index_entries(&record).token_entries;
+        assert_eq!(
+            entries,
+            vec![
+                TokenOwnerEntry {
+                    // post owner wins (coalesce).
+                    owner: pubkey_bytes(21),
+                    token_account: pubkey_bytes(2),
+                    balance_changed: false,
+                },
+                TokenOwnerEntry {
+                    // post owner NULL -> falls back to pre owner.
+                    owner: pubkey_bytes(12),
+                    token_account: pubkey_bytes(3),
+                    balance_changed: true,
+                },
+                TokenOwnerEntry {
+                    owner: pubkey_bytes(13),
+                    token_account: pubkey_bytes(4),
+                    balance_changed: true,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn token_entry_with_no_owner_is_dropped() {
+        let mut record = base_record();
+        record.tx_account_keys = vec![pubkey_bytes(1), pubkey_bytes(2)];
+        record.meta_pre_token_account_index = vec![1];
+        record.meta_pre_token_owner = vec![None];
+        record.meta_pre_token_amount = vec!["1".to_string()];
+
+        assert!(derive_index_entries(&record).token_entries.is_empty());
+    }
+}

--- a/crates/superbank-rpc/src/disk_cache/index.rs
+++ b/crates/superbank-rpc/src/disk_cache/index.rs
@@ -54,6 +54,8 @@ pub(crate) struct TxIndexEntries {
     /// `if(meta_status_ok = 1, NULL, meta_err)` of the MVs.
     pub(crate) err: Option<String>,
     pub(crate) memo: Option<String>,
+    /// Every transaction signature, mirroring `signatures.sql`'s ARRAY JOIN.
+    pub(crate) signatures: Vec<[u8; 64]>,
     /// Distinct addresses touched by the transaction, minus the ignored set.
     pub(crate) addresses: Vec<[u8; 32]>,
     pub(crate) token_entries: Vec<TokenOwnerEntry>,
@@ -88,6 +90,7 @@ pub(crate) fn derive_index_entries(record: &StoredTransactionRecord) -> TxIndexE
     TxIndexEntries {
         err,
         memo,
+        signatures: record.tx_signatures.clone(),
         addresses,
         token_entries,
     }
@@ -875,8 +878,10 @@ mod tests {
         [seed; 32]
     }
 
+    // MV parity tests for ddl/local/gsfa.sql, ddl/local/signatures.sql, and
+    // ddl/local/token_owner_activity.sql. Update these when those views change.
     #[test]
-    fn addresses_are_deduped_and_ignored_set_is_filtered() {
+    fn mv_parity_gsfa_addresses_are_distinct_loaded_and_filtered() {
         use std::str::FromStr;
         let vote_program = Pubkey::from_str("Vote111111111111111111111111111111111111111")
             .unwrap()
@@ -907,7 +912,7 @@ mod tests {
     }
 
     #[test]
-    fn err_follows_meta_status() {
+    fn mv_parity_err_follows_meta_status() {
         let mut record = base_record();
         record.meta_status_ok = true;
         record.meta_err = Some("ignored".to_string());
@@ -921,7 +926,20 @@ mod tests {
     }
 
     #[test]
-    fn memo_extraction_uses_combined_account_keys() {
+    fn mv_parity_signatures_indexes_every_transaction_signature() {
+        let mut record = base_record();
+        let second_sig = [8u8; 64];
+        let third_sig = [7u8; 64];
+        record.tx_signatures = vec![record.signature, second_sig, third_sig];
+
+        assert_eq!(
+            derive_index_entries(&record).signatures,
+            record.tx_signatures
+        );
+    }
+
+    #[test]
+    fn mv_parity_memo_extraction_uses_combined_account_keys() {
         use std::str::FromStr;
         let memo_program = Pubkey::from_str("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr")
             .unwrap()
@@ -939,7 +957,7 @@ mod tests {
     }
 
     #[test]
-    fn token_entries_follow_mv_semantics() {
+    fn mv_parity_token_entries_follow_owner_and_balance_semantics() {
         let mut record = base_record();
         record.tx_account_keys = vec![
             pubkey_bytes(1), // idx 0
@@ -995,7 +1013,7 @@ mod tests {
     }
 
     #[test]
-    fn token_entry_with_no_owner_is_dropped() {
+    fn mv_parity_token_entry_with_no_owner_is_dropped() {
         let mut record = base_record();
         record.tx_account_keys = vec![pubkey_bytes(1), pubkey_bytes(2)];
         record.meta_pre_token_account_index = vec![1];

--- a/crates/superbank-rpc/src/disk_cache/ingest.rs
+++ b/crates/superbank-rpc/src/disk_cache/ingest.rs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+/*
+ * Copyright 2025-2026 Triton One Limited. All rights reserved.
+ */
+
+//! Live ingestion hook: copies finalized slots out of the head cache into the
+//! disk-cache write queue.
+//!
+//! The disk cache deliberately has no gRPC stream of its own — a second
+//! finalized block subscription would double the firehose. Instead, when the
+//! head cache observes a slot reaching finalized commitment, the sink snapshots
+//! the complete block (Arc refs, no deep clone) and hands it to the writer.
+//! Anything that cannot be snapshotted — incomplete head data, an evicted slot,
+//! a full write queue — lands in the [`RepairQueue`] to be refilled from
+//! ClickHouse.
+
+use std::collections::BTreeSet;
+use std::sync::{Arc, Mutex};
+
+use tracing::warn;
+
+use crate::head_cache::HeadCache;
+
+use super::DiskCache;
+use super::writer::DiskWriteSender;
+
+/// Slots that must be (re)fetched from ClickHouse. Bounded: on overflow the
+/// newest slots win, because dropped holes are re-discovered by the periodic
+/// coverage scan anyway.
+pub(crate) struct RepairQueue {
+    slots: Mutex<BTreeSet<u64>>,
+    notify: tokio::sync::Notify,
+    capacity: usize,
+}
+
+impl RepairQueue {
+    pub(crate) fn new(capacity: usize) -> Self {
+        Self {
+            slots: Mutex::new(BTreeSet::new()),
+            notify: tokio::sync::Notify::new(),
+            capacity: capacity.max(1),
+        }
+    }
+
+    pub(crate) fn push(&self, slot: u64) {
+        let mut slots = self.slots.lock().expect("repair queue lock");
+        if slots.len() >= self.capacity {
+            // Keep the newest slots: they serve the most traffic, and the
+            // periodic hole scan re-finds anything dropped here.
+            if slots.first().is_some_and(|&oldest| oldest < slot) {
+                slots.pop_first();
+            } else {
+                return;
+            }
+        }
+        slots.insert(slot);
+        drop(slots);
+        self.notify.notify_one();
+    }
+
+    /// Take up to `max` slots, newest first.
+    pub(crate) fn drain(&self, max: usize) -> Vec<u64> {
+        let mut slots = self.slots.lock().expect("repair queue lock");
+        let mut drained = Vec::with_capacity(max.min(slots.len()));
+        while drained.len() < max {
+            match slots.pop_last() {
+                Some(slot) => drained.push(slot),
+                None => break,
+            }
+        }
+        drained
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.slots.lock().expect("repair queue lock").len()
+    }
+
+    /// Wait until at least one slot is queued.
+    pub(crate) async fn notified(&self) {
+        self.notify.notified().await;
+    }
+}
+
+pub(crate) struct DiskIngestSink {
+    cache: Arc<DiskCache>,
+    sender: DiskWriteSender,
+    repair: Arc<RepairQueue>,
+}
+
+impl std::fmt::Debug for DiskIngestSink {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("DiskIngestSink")
+    }
+}
+
+impl DiskIngestSink {
+    pub(crate) fn new(
+        cache: Arc<DiskCache>,
+        sender: DiskWriteSender,
+        repair: Arc<RepairQueue>,
+    ) -> Self {
+        Self {
+            cache,
+            sender,
+            repair,
+        }
+    }
+
+    /// Called from the DragonsMouth stream task on every finalized commitment
+    /// update. Must never block.
+    pub(crate) fn on_slot_finalized(&self, slot: u64, head: &HeadCache) {
+        if slot < self.cache.min_retained_slot() || self.cache.covers_slot(slot) {
+            return;
+        }
+
+        match head.finalized_block_snapshot(slot) {
+            Some((meta, txs)) => self.sender.send_live(meta, txs),
+            None => {
+                warn!(
+                    slot,
+                    "disk cache: head cache view of finalized slot is incomplete; deferring to repair"
+                );
+                self.repair.push(slot);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repair_queue_caps_and_keeps_newest() {
+        let queue = RepairQueue::new(3);
+        queue.push(10);
+        queue.push(30);
+        queue.push(20);
+        assert_eq!(queue.len(), 3);
+
+        // Over capacity: newer slot displaces the oldest.
+        queue.push(40);
+        assert_eq!(queue.len(), 3);
+        assert_eq!(queue.drain(10), vec![40, 30, 20]);
+        assert_eq!(queue.len(), 0);
+
+        // Over capacity with an older slot: dropped.
+        queue.push(10);
+        queue.push(20);
+        queue.push(30);
+        queue.push(5);
+        assert_eq!(queue.drain(2), vec![30, 20]);
+        assert_eq!(queue.drain(10), vec![10]);
+    }
+}

--- a/crates/superbank-rpc/src/disk_cache/ingest.rs
+++ b/crates/superbank-rpc/src/disk_cache/ingest.rs
@@ -120,6 +120,7 @@ impl DiskIngestSink {
                     slot,
                     "disk cache: head cache view of finalized slot is incomplete; deferring to repair"
                 );
+                crate::metrics::disk_cache_dropped_to_repair("incomplete_head");
                 self.repair.push(slot);
             }
         }

--- a/crates/superbank-rpc/src/disk_cache/mod.rs
+++ b/crates/superbank-rpc/src/disk_cache/mod.rs
@@ -1,0 +1,1171 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+/*
+ * Copyright 2025-2026 Triton One Limited. All rights reserved.
+ */
+
+//! RocksDB-backed cache of recent finalized slots, served in place of ClickHouse.
+//!
+//! Stores only finalized data (no fork handling). It is strictly a cache: every
+//! miss, decode failure, or inconsistency degrades to a ClickHouse read. A slot is
+//! "covered" only when its data and coverage marker landed in one atomic
+//! `WriteBatch`, so the cache never claims a slot it holds partially.
+//!
+//! The ClickHouse-to-disk fill is called "backfill" everywhere — "hydration" in
+//! this crate means converting stored records to RPC JSON.
+
+// Wired into handlers/server in follow-up phases; remove once the read tiers land.
+#![allow(dead_code)]
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
+
+use rocksdb::{
+    BoundColumnFamily, DBWithThreadMode, IteratorMode, MultiThreaded, Options, ReadOptions,
+    WriteBatch,
+};
+use solana_transaction_status::TransactionDetails;
+use tokio::sync::Semaphore;
+use tracing::{info, warn};
+
+use crate::clickhouse::{
+    BlockMetadataRecord, StoredAccountsTransactionRecord, StoredBlockPayload, StoredBlockRecord,
+    StoredTransactionRecord,
+};
+
+pub(crate) mod codec;
+pub(crate) mod coverage;
+pub(crate) mod schema;
+
+use codec::CoverageValue;
+use coverage::CoverageMap;
+
+type Db = DBWithThreadMode<MultiThreaded>;
+
+/// Longest run of slots we will mark Skipped from one block's parent link. Runs
+/// beyond this indicate corrupt metadata rather than a real chain gap.
+const MAX_SKIPPED_RUN: u64 = 100_000;
+
+/// When the byte budget trips, evict down to this fraction of it (hysteresis).
+const BYTE_BUDGET_LOW_WATER: f64 = 0.93;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum DiskCacheError {
+    #[error("rocksdb: {0}")]
+    Rocks(#[from] rocksdb::Error),
+    #[error("encode: {0}")]
+    Encode(#[from] bincode::Error),
+    #[error("slot {slot} incomplete: expected {expected} transactions, got {actual}")]
+    IncompleteSlot {
+        slot: u64,
+        expected: u64,
+        actual: usize,
+    },
+    #[error("slot {slot} is below the retention floor {floor}")]
+    BelowFloor { slot: u64, floor: u64 },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DiskCacheConfig {
+    pub(crate) path: PathBuf,
+    pub(crate) retain_slots: u64,
+    /// Disk byte budget; 0 = unlimited. The tighter of byte budget / slot window wins.
+    pub(crate) max_bytes: u64,
+    pub(crate) block_cache_bytes: usize,
+    pub(crate) read_concurrency: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SlotStatus {
+    Covered { tx_count: u32 },
+    Skipped,
+    NotCovered,
+}
+
+#[derive(Debug)]
+pub(crate) enum DiskBlockResult {
+    Found(Box<StoredBlockPayload>),
+    Skipped,
+    NotCovered,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DiskBlockTime {
+    Found(Option<i64>),
+    Skipped,
+    NotCovered,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct EvictionStats {
+    pub(crate) old_floor: u64,
+    pub(crate) new_floor: u64,
+    pub(crate) byte_budget_bound: bool,
+}
+
+pub(crate) struct DiskCache {
+    inner: Arc<DiskCacheInner>,
+}
+
+pub(crate) struct DiskCacheInner {
+    db: Db,
+    cfg: DiskCacheConfig,
+    coverage: RwLock<CoverageMap>,
+    /// Eviction floor: nothing below this slot may be claimed or served. Shared
+    /// with the compaction filters of the `sig`/`addr_sig`/`token_owner` CFs.
+    min_retained: Arc<AtomicU64>,
+    ready: AtomicBool,
+    read_sem: Arc<Semaphore>,
+}
+
+impl DiskCache {
+    /// Open (or wipe-and-recreate) the cache at `cfg.path`.
+    ///
+    /// Corruption and schema-version mismatches destroy and rebuild the database —
+    /// it is only a cache. Path or permission errors propagate so a misconfigured
+    /// deployment fails loudly at startup.
+    pub(crate) fn open(cfg: DiskCacheConfig) -> Result<Self, DiskCacheError> {
+        let min_retained = Arc::new(AtomicU64::new(0));
+        let opts = schema::DiskCacheOptions {
+            block_cache_bytes: cfg.block_cache_bytes,
+            ..Default::default()
+        };
+
+        let db = match open_db(&cfg.path, &opts, min_retained.clone()) {
+            Ok(db) => db,
+            Err(err) => {
+                warn!(
+                    path = %cfg.path.display(),
+                    "disk cache: open failed ({err}); destroying and rebuilding"
+                );
+                destroy_db(&cfg.path)?;
+                open_db(&cfg.path, &opts, min_retained.clone())?
+            }
+        };
+
+        let db = match check_schema_version(db)? {
+            SchemaCheck::Ok(db) => db,
+            SchemaCheck::Mismatch { db, found } => {
+                warn!(
+                    found,
+                    expected = schema::SCHEMA_VERSION,
+                    path = %cfg.path.display(),
+                    "disk cache: schema version mismatch; wiping"
+                );
+                drop(db);
+                destroy_db(&cfg.path)?;
+                let db = open_db(&cfg.path, &opts, min_retained.clone())?;
+                match check_schema_version(db)? {
+                    SchemaCheck::Ok(db) => db,
+                    SchemaCheck::Mismatch { .. } => {
+                        unreachable!("fresh disk cache database has a schema version")
+                    }
+                }
+            }
+        };
+
+        let inner = Arc::new(DiskCacheInner {
+            db,
+            read_sem: Arc::new(Semaphore::new(cfg.read_concurrency.max(1))),
+            cfg,
+            coverage: RwLock::new(CoverageMap::new()),
+            min_retained,
+            ready: AtomicBool::new(false),
+        });
+
+        inner.load_persisted_state()?;
+        inner.ready.store(true, Ordering::Release);
+
+        let (span, slots) = {
+            let map = inner.coverage.read().expect("coverage lock");
+            (map.contiguous_tip_span(), map.covered_slot_count())
+        };
+        info!(
+            path = %inner.cfg.path.display(),
+            covered_slots = slots,
+            tip_span = ?span,
+            "disk cache: open"
+        );
+
+        Ok(Self { inner })
+    }
+
+    pub(crate) fn ready(&self) -> bool {
+        self.inner.ready.load(Ordering::Acquire)
+    }
+
+    /// The contiguous covered range ending at the newest covered slot — the only
+    /// span address-index scans may be answered from.
+    pub(crate) fn tip_span(&self) -> Option<(u64, u64)> {
+        self.inner
+            .coverage
+            .read()
+            .expect("coverage lock")
+            .contiguous_tip_span()
+    }
+
+    pub(crate) fn covers_slot(&self, slot: u64) -> bool {
+        self.inner
+            .coverage
+            .read()
+            .expect("coverage lock")
+            .contains(slot)
+    }
+
+    pub(crate) fn min_retained_slot(&self) -> u64 {
+        self.inner.min_retained.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn holes_in(&self, start: u64, end: u64) -> Vec<(u64, u64)> {
+        self.inner
+            .coverage
+            .read()
+            .expect("coverage lock")
+            .holes_in(start, end)
+    }
+
+    /// Write one finalized slot (block metadata + every transaction) atomically,
+    /// together with its coverage marker and Skipped markers for the parent gap.
+    pub(crate) fn write_finalized_slot(
+        &self,
+        meta: &BlockMetadataRecord,
+        txs: &[StoredTransactionRecord],
+        source: u8,
+    ) -> Result<(), DiskCacheError> {
+        self.inner.write_finalized_slot(meta, txs, source)
+    }
+
+    /// Apply window and byte-budget eviction; returns stats when the floor moved.
+    pub(crate) fn maybe_evict(&self) -> Result<Option<EvictionStats>, DiskCacheError> {
+        self.inner.maybe_evict()
+    }
+
+    /// Total live SST bytes across all column families.
+    pub(crate) fn live_sst_bytes(&self) -> u64 {
+        self.inner.live_sst_bytes()
+    }
+
+    /// Fsync the WAL; called on graceful shutdown.
+    pub(crate) fn flush_wal(&self) -> Result<(), DiskCacheError> {
+        self.inner.db.flush_wal(true)?;
+        Ok(())
+    }
+
+    pub(crate) async fn slot_status(&self, slot: u64) -> SlotStatus {
+        self.run_read("slot_status", move |inner| Ok(inner.slot_status_sync(slot)))
+            .await
+            .unwrap_or(SlotStatus::NotCovered)
+    }
+
+    pub(crate) async fn get_block(
+        &self,
+        slot: u64,
+        transaction_details: TransactionDetails,
+    ) -> DiskBlockResult {
+        self.run_read("get_block", move |inner| {
+            Ok(inner.get_block_sync(slot, transaction_details))
+        })
+        .await
+        .unwrap_or(DiskBlockResult::NotCovered)
+    }
+
+    pub(crate) async fn block_time_for_slot(&self, slot: u64) -> DiskBlockTime {
+        self.run_read("block_time", move |inner| Ok(inner.block_time_sync(slot)))
+            .await
+            .unwrap_or(DiskBlockTime::NotCovered)
+    }
+
+    /// Covered (non-skipped) slots within `[start, end]`, ascending.
+    pub(crate) async fn covered_slots_in_range(&self, start: u64, end: u64) -> Option<Vec<u64>> {
+        self.run_read("slots_in_range", move |inner| {
+            inner.covered_slots_in_range_sync(start, end)
+        })
+        .await
+    }
+
+    /// Run a blocking read against RocksDB off the async runtime, bounded by the
+    /// read semaphore. Any error is logged and becomes a miss (`None`).
+    async fn run_read<T, F>(&self, op: &'static str, f: F) -> Option<T>
+    where
+        T: Send + 'static,
+        F: FnOnce(&DiskCacheInner) -> Result<T, DiskCacheError> + Send + 'static,
+    {
+        if !self.ready() {
+            return None;
+        }
+        let permit = self.inner.read_sem.clone().acquire_owned().await.ok()?;
+        let inner = self.inner.clone();
+        let result = tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            f(&inner)
+        })
+        .await;
+
+        match result {
+            Ok(Ok(value)) => Some(value),
+            Ok(Err(err)) => {
+                warn!(op, "disk cache: read failed: {err}");
+                None
+            }
+            Err(err) => {
+                warn!(op, "disk cache: read task panicked: {err}");
+                None
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn inner_for_tests(&self) -> &DiskCacheInner {
+        &self.inner
+    }
+}
+
+impl DiskCacheInner {
+    fn cf(&self, name: &str) -> Arc<BoundColumnFamily<'_>> {
+        self.db
+            .cf_handle(name)
+            .unwrap_or_else(|| panic!("column family {name} exists"))
+    }
+
+    fn load_persisted_state(&self) -> Result<(), DiskCacheError> {
+        let meta_cf = self.cf(schema::CF_META);
+        let floor = self
+            .db
+            .get_cf(&meta_cf, schema::META_MIN_RETAINED)?
+            .and_then(|raw| raw.try_into().ok().map(u64::from_be_bytes))
+            .unwrap_or(0);
+        self.min_retained.store(floor, Ordering::Relaxed);
+
+        let coverage_cf = self.cf(schema::CF_SLOT_COVERAGE);
+        let mut read_opts = ReadOptions::default();
+        read_opts.set_iterate_lower_bound(schema::slot_key(floor).to_vec());
+        let iter = self
+            .db
+            .iterator_cf_opt(&coverage_cf, read_opts, IteratorMode::Start);
+
+        let mut map = CoverageMap::new();
+        for entry in iter {
+            let (key, value) = entry?;
+            let Some(slot) = key
+                .as_ref()
+                .try_into()
+                .ok()
+                .map(|bytes: [u8; 8]| u64::from_be_bytes(bytes))
+            else {
+                continue;
+            };
+            if codec::decode_coverage_value(&value).is_some() {
+                map.insert(slot);
+            }
+        }
+
+        *self.coverage.write().expect("coverage lock") = map;
+        Ok(())
+    }
+
+    fn write_finalized_slot(
+        &self,
+        meta: &BlockMetadataRecord,
+        txs: &[StoredTransactionRecord],
+        source: u8,
+    ) -> Result<(), DiskCacheError> {
+        let slot = meta.slot;
+        let floor = self.min_retained.load(Ordering::Relaxed);
+        if slot < floor {
+            return Err(DiskCacheError::BelowFloor { slot, floor });
+        }
+        if txs.len() as u64 != meta.executed_transaction_count {
+            return Err(DiskCacheError::IncompleteSlot {
+                slot,
+                expected: meta.executed_transaction_count,
+                actual: txs.len(),
+            });
+        }
+
+        let mut batch = WriteBatch::default();
+        let block_meta_cf = self.cf(schema::CF_BLOCK_META);
+        let tx_cf = self.cf(schema::CF_TX);
+        let coverage_cf = self.cf(schema::CF_SLOT_COVERAGE);
+
+        batch.put_cf(
+            &block_meta_cf,
+            schema::slot_key(slot),
+            codec::encode_record(meta)?,
+        );
+        for record in txs {
+            batch.put_cf(
+                &tx_cf,
+                schema::tx_key(slot, record.slot_idx),
+                codec::encode_record(record)?,
+            );
+        }
+        batch.put_cf(
+            &coverage_cf,
+            schema::slot_key(slot),
+            codec::encode_coverage_value(CoverageValue::Covered {
+                tx_count: txs.len() as u32,
+                source,
+            }),
+        );
+
+        // The parent link of a finalized block proves every slot in between was
+        // skipped on the finalized chain.
+        let claim_start = if meta.parent_slot < slot {
+            let gap = slot - meta.parent_slot - 1;
+            if gap > 0 && gap <= MAX_SKIPPED_RUN {
+                let skipped_value = codec::encode_coverage_value(CoverageValue::Skipped);
+                let first = (meta.parent_slot + 1).max(floor);
+                for skipped_slot in first..slot {
+                    batch.put_cf(&coverage_cf, schema::slot_key(skipped_slot), &skipped_value);
+                }
+                first
+            } else {
+                if gap > MAX_SKIPPED_RUN {
+                    warn!(
+                        slot,
+                        parent_slot = meta.parent_slot,
+                        "disk cache: implausible parent gap; not marking skipped slots"
+                    );
+                }
+                slot
+            }
+        } else {
+            slot
+        };
+
+        self.db.write(batch)?;
+
+        {
+            let mut map = self.coverage.write().expect("coverage lock");
+            map.insert_range(claim_start, slot);
+        }
+        Ok(())
+    }
+
+    fn maybe_evict(&self) -> Result<Option<EvictionStats>, DiskCacheError> {
+        let head = match self.coverage.read().expect("coverage lock").covered_span() {
+            Some((_, head)) => head,
+            None => return Ok(None),
+        };
+
+        let window_floor = head.saturating_sub(self.cfg.retain_slots.saturating_sub(1));
+
+        let mut byte_budget_bound = false;
+        let bytes_floor = if self.cfg.max_bytes > 0 {
+            let live = self.live_sst_bytes();
+            if live >= self.cfg.max_bytes {
+                let covered = self
+                    .coverage
+                    .read()
+                    .expect("coverage lock")
+                    .covered_slot_count()
+                    .max(1);
+                let bytes_per_slot = (live / covered).max(1);
+                let target_bytes = (self.cfg.max_bytes as f64 * BYTE_BUDGET_LOW_WATER) as u64;
+                let keep_slots = (target_bytes / bytes_per_slot).max(1);
+                byte_budget_bound = true;
+                head.saturating_sub(keep_slots - 1)
+            } else {
+                0
+            }
+        } else {
+            0
+        };
+
+        let old_floor = self.min_retained.load(Ordering::Relaxed);
+        let new_floor = window_floor.max(bytes_floor);
+        if new_floor <= old_floor {
+            return Ok(None);
+        }
+
+        // Raise the floor BEFORE deleting: readers bound by the floor can never
+        // observe a partially deleted slot.
+        self.min_retained.store(new_floor, Ordering::Relaxed);
+
+        let mut batch = WriteBatch::default();
+        batch.put_cf(
+            &self.cf(schema::CF_META),
+            schema::META_MIN_RETAINED,
+            new_floor.to_be_bytes(),
+        );
+        let from = schema::slot_key(old_floor);
+        let to = schema::slot_key(new_floor);
+        batch.delete_range_cf(&self.cf(schema::CF_SLOT_COVERAGE), from, to);
+        batch.delete_range_cf(&self.cf(schema::CF_BLOCK_META), from, to);
+        batch.delete_range_cf(
+            &self.cf(schema::CF_TX),
+            schema::tx_key(old_floor, 0),
+            schema::tx_key(new_floor, 0),
+        );
+        self.db.write(batch)?;
+
+        self.coverage
+            .write()
+            .expect("coverage lock")
+            .remove_below(new_floor);
+
+        Ok(Some(EvictionStats {
+            old_floor,
+            new_floor,
+            byte_budget_bound,
+        }))
+    }
+
+    fn live_sst_bytes(&self) -> u64 {
+        schema::ALL_CFS
+            .iter()
+            .filter_map(|name| {
+                self.db
+                    .property_int_value_cf(&self.cf(name), "rocksdb.live-sst-files-size")
+                    .ok()
+                    .flatten()
+            })
+            .sum()
+    }
+
+    /// Drop a slot from coverage after a decode or consistency failure. The slot
+    /// degrades to ClickHouse until repair re-ingests it.
+    fn poison_slot(&self, slot: u64) {
+        warn!(slot, "disk cache: poisoning slot after inconsistency");
+        if let Err(err) = self
+            .db
+            .delete_cf(&self.cf(schema::CF_SLOT_COVERAGE), schema::slot_key(slot))
+        {
+            warn!(slot, "disk cache: failed to delete coverage marker: {err}");
+        }
+        self.coverage.write().expect("coverage lock").remove(slot);
+    }
+
+    pub(crate) fn slot_status_sync(&self, slot: u64) -> SlotStatus {
+        if slot < self.min_retained.load(Ordering::Relaxed) {
+            return SlotStatus::NotCovered;
+        }
+        let Ok(Some(raw)) = self
+            .db
+            .get_cf(&self.cf(schema::CF_SLOT_COVERAGE), schema::slot_key(slot))
+        else {
+            return SlotStatus::NotCovered;
+        };
+        match codec::decode_coverage_value(&raw) {
+            Some(CoverageValue::Covered { tx_count, .. }) => SlotStatus::Covered { tx_count },
+            Some(CoverageValue::Skipped) => SlotStatus::Skipped,
+            None => SlotStatus::NotCovered,
+        }
+    }
+
+    pub(crate) fn get_block_sync(
+        &self,
+        slot: u64,
+        transaction_details: TransactionDetails,
+    ) -> DiskBlockResult {
+        let tx_count = match self.slot_status_sync(slot) {
+            SlotStatus::NotCovered => return DiskBlockResult::NotCovered,
+            SlotStatus::Skipped => return DiskBlockResult::Skipped,
+            SlotStatus::Covered { tx_count } => tx_count,
+        };
+
+        let Ok(Some(raw_meta)) = self
+            .db
+            .get_cf(&self.cf(schema::CF_BLOCK_META), schema::slot_key(slot))
+        else {
+            self.poison_slot(slot);
+            return DiskBlockResult::NotCovered;
+        };
+        let Some(metadata) = codec::decode_record::<BlockMetadataRecord>(&raw_meta) else {
+            self.poison_slot(slot);
+            return DiskBlockResult::NotCovered;
+        };
+
+        if transaction_details == TransactionDetails::None {
+            return DiskBlockResult::Found(Box::new(StoredBlockPayload::Metadata(metadata)));
+        }
+
+        let transactions = match self.read_slot_transactions(slot, tx_count) {
+            Some(transactions) => transactions,
+            None => {
+                self.poison_slot(slot);
+                return DiskBlockResult::NotCovered;
+            }
+        };
+
+        let payload = match transaction_details {
+            TransactionDetails::None => unreachable!("handled above"),
+            TransactionDetails::Signatures => StoredBlockPayload::Signatures {
+                metadata,
+                signatures: transactions
+                    .iter()
+                    .map(|record| bs58::encode(record.signature).into_string())
+                    .collect(),
+            },
+            TransactionDetails::Accounts => StoredBlockPayload::Accounts {
+                metadata,
+                transactions: transactions
+                    .into_iter()
+                    .map(StoredAccountsTransactionRecord::from)
+                    .collect(),
+            },
+            TransactionDetails::Full => StoredBlockPayload::Full(StoredBlockRecord {
+                metadata,
+                transactions,
+            }),
+        };
+        DiskBlockResult::Found(Box::new(payload))
+    }
+
+    /// All transactions of `slot` in execution order, or `None` when the stored
+    /// set does not exactly match the claimed count.
+    fn read_slot_transactions(
+        &self,
+        slot: u64,
+        expected: u32,
+    ) -> Option<Vec<StoredTransactionRecord>> {
+        let mut transactions = Vec::with_capacity(expected as usize);
+        if expected == 0 {
+            return Some(transactions);
+        }
+
+        let tx_cf = self.cf(schema::CF_TX);
+        let mut read_opts = ReadOptions::default();
+        if let Some(next_slot) = slot.checked_add(1) {
+            read_opts.set_iterate_upper_bound(schema::tx_key(next_slot, 0).to_vec());
+        }
+        read_opts.set_prefix_same_as_start(true);
+        let start = schema::tx_key(slot, 0);
+        let iter = self.db.iterator_cf_opt(
+            &tx_cf,
+            read_opts,
+            IteratorMode::From(&start, rocksdb::Direction::Forward),
+        );
+
+        for entry in iter {
+            let (_, value) = entry.ok()?;
+            let record = codec::decode_record::<StoredTransactionRecord>(&value)?;
+            transactions.push(record);
+            if transactions.len() > expected as usize {
+                return None;
+            }
+        }
+
+        (transactions.len() == expected as usize).then_some(transactions)
+    }
+
+    pub(crate) fn block_time_sync(&self, slot: u64) -> DiskBlockTime {
+        match self.slot_status_sync(slot) {
+            SlotStatus::NotCovered => return DiskBlockTime::NotCovered,
+            SlotStatus::Skipped => return DiskBlockTime::Skipped,
+            SlotStatus::Covered { .. } => {}
+        }
+        let Ok(Some(raw)) = self
+            .db
+            .get_cf(&self.cf(schema::CF_BLOCK_META), schema::slot_key(slot))
+        else {
+            self.poison_slot(slot);
+            return DiskBlockTime::NotCovered;
+        };
+        match codec::decode_record::<BlockMetadataRecord>(&raw) {
+            Some(metadata) => DiskBlockTime::Found(metadata.block_time),
+            None => {
+                self.poison_slot(slot);
+                DiskBlockTime::NotCovered
+            }
+        }
+    }
+
+    pub(crate) fn covered_slots_in_range_sync(
+        &self,
+        start: u64,
+        end: u64,
+    ) -> Result<Vec<u64>, DiskCacheError> {
+        let floor = self.min_retained.load(Ordering::Relaxed);
+        let start = start.max(floor);
+        if end < start {
+            return Ok(Vec::new());
+        }
+
+        let coverage_cf = self.cf(schema::CF_SLOT_COVERAGE);
+        let mut read_opts = ReadOptions::default();
+        if let Some(after_end) = end.checked_add(1) {
+            read_opts.set_iterate_upper_bound(schema::slot_key(after_end).to_vec());
+        }
+        let start_key = schema::slot_key(start);
+        let iter = self.db.iterator_cf_opt(
+            &coverage_cf,
+            read_opts,
+            IteratorMode::From(&start_key, rocksdb::Direction::Forward),
+        );
+
+        let mut slots = Vec::new();
+        for entry in iter {
+            let (key, value) = entry?;
+            let Some(slot) = key
+                .as_ref()
+                .try_into()
+                .ok()
+                .map(|bytes: [u8; 8]| u64::from_be_bytes(bytes))
+            else {
+                continue;
+            };
+            if matches!(
+                codec::decode_coverage_value(&value),
+                Some(CoverageValue::Covered { .. })
+            ) {
+                slots.push(slot);
+            }
+        }
+        Ok(slots)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn delete_tx_for_tests(&self, slot: u64, idx: u32) {
+        self.db
+            .delete_cf(&self.cf(schema::CF_TX), schema::tx_key(slot, idx))
+            .expect("delete tx");
+    }
+
+    #[cfg(test)]
+    pub(crate) fn corrupt_block_meta_for_tests(&self, slot: u64) {
+        self.db
+            .put_cf(
+                &self.cf(schema::CF_BLOCK_META),
+                schema::slot_key(slot),
+                [codec::VALUE_VERSION_V1, 0xFF, 0xFF],
+            )
+            .expect("corrupt block meta");
+    }
+}
+
+fn open_db(
+    path: &Path,
+    opts: &schema::DiskCacheOptions,
+    min_retained: Arc<AtomicU64>,
+) -> Result<Db, rocksdb::Error> {
+    let db_opts = schema::db_options(opts);
+    let descriptors = schema::cf_descriptors(opts, min_retained);
+    Db::open_cf_descriptors(&db_opts, path, descriptors)
+}
+
+fn destroy_db(path: &Path) -> Result<(), DiskCacheError> {
+    Db::destroy(&Options::default(), path)?;
+    Ok(())
+}
+
+enum SchemaCheck {
+    Ok(Db),
+    Mismatch { db: Db, found: u32 },
+}
+
+fn check_schema_version(db: Db) -> Result<SchemaCheck, DiskCacheError> {
+    let meta_cf = db
+        .cf_handle(schema::CF_META)
+        .expect("meta column family exists");
+    let stored = db
+        .get_cf(&meta_cf, schema::META_SCHEMA_VERSION)?
+        .and_then(|raw| raw.try_into().ok().map(u32::from_be_bytes));
+
+    match stored {
+        Some(version) if version == schema::SCHEMA_VERSION => {
+            drop(meta_cf);
+            Ok(SchemaCheck::Ok(db))
+        }
+        Some(version) => {
+            drop(meta_cf);
+            Ok(SchemaCheck::Mismatch { db, found: version })
+        }
+        None => {
+            db.put_cf(
+                &meta_cf,
+                schema::META_SCHEMA_VERSION,
+                schema::SCHEMA_VERSION.to_be_bytes(),
+            )?;
+            drop(meta_cf);
+            Ok(SchemaCheck::Ok(db))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_sdk::hash::Hash;
+
+    fn test_config(dir: &tempfile::TempDir) -> DiskCacheConfig {
+        DiskCacheConfig {
+            path: dir.path().join("db"),
+            retain_slots: 1_000,
+            max_bytes: 0,
+            block_cache_bytes: 8 << 20,
+            read_concurrency: 4,
+        }
+    }
+
+    fn open_cache(dir: &tempfile::TempDir) -> DiskCache {
+        DiskCache::open(test_config(dir)).expect("open disk cache")
+    }
+
+    fn block_metadata(slot: u64, parent_slot: u64, tx_count: u64) -> BlockMetadataRecord {
+        BlockMetadataRecord {
+            slot,
+            parent_slot,
+            blockhash: Hash::new_unique().to_bytes(),
+            parent_blockhash: Hash::new_unique().to_bytes(),
+            block_time: Some(1_700_000_000 + slot as i64),
+            block_height: Some(slot.saturating_sub(5)),
+            executed_transaction_count: tx_count,
+            entry_count: tx_count,
+            rewards_present: false,
+            rewards_pubkey: Vec::new(),
+            rewards_lamports: Vec::new(),
+            rewards_post_balance: Vec::new(),
+            rewards_type: Vec::new(),
+            rewards_commission: Vec::new(),
+            rewards_num_partitions: None,
+        }
+    }
+
+    fn transaction(slot: u64, idx: u32) -> StoredTransactionRecord {
+        let mut signature = [0u8; 64];
+        signature[..8].copy_from_slice(&slot.to_be_bytes());
+        signature[8..12].copy_from_slice(&idx.to_be_bytes());
+        StoredTransactionRecord {
+            signature,
+            slot,
+            slot_idx: idx,
+            block_time: Some(1_700_000_000 + slot as i64),
+            tx_version: None,
+            tx_signatures: vec![signature],
+            tx_num_required_signatures: 1,
+            tx_num_readonly_signed_accounts: 0,
+            tx_num_readonly_unsigned_accounts: 0,
+            tx_account_keys: vec![[1u8; 32]],
+            tx_recent_blockhash: [2u8; 32],
+            tx_instructions_program_id_index: Vec::new(),
+            tx_instructions_accounts: Vec::new(),
+            tx_instructions_data: Vec::new(),
+            tx_address_table_lookups_present: false,
+            tx_address_table_lookup_account_key: Vec::new(),
+            tx_address_table_lookup_writable_indexes: Vec::new(),
+            tx_address_table_lookup_readonly_indexes: Vec::new(),
+            meta_status_ok: true,
+            meta_err: None,
+            meta_fee: 5_000,
+            meta_pre_balances: Vec::new(),
+            meta_post_balances: Vec::new(),
+            meta_inner_instructions_present: false,
+            meta_inner_instructions_index: Vec::new(),
+            meta_inner_instructions_program_id_index: Vec::new(),
+            meta_inner_instructions_accounts: Vec::new(),
+            meta_inner_instructions_data: Vec::new(),
+            meta_inner_instructions_stack_height: Vec::new(),
+            meta_log_messages_present: false,
+            meta_log_messages: Vec::new(),
+            meta_pre_token_balances_present: false,
+            meta_pre_token_account_index: Vec::new(),
+            meta_pre_token_mint: Vec::new(),
+            meta_pre_token_owner: Vec::new(),
+            meta_pre_token_program_id: Vec::new(),
+            meta_pre_token_amount: Vec::new(),
+            meta_pre_token_decimals: Vec::new(),
+            meta_pre_token_ui_amount: Vec::new(),
+            meta_pre_token_ui_amount_string: Vec::new(),
+            meta_post_token_balances_present: false,
+            meta_post_token_account_index: Vec::new(),
+            meta_post_token_mint: Vec::new(),
+            meta_post_token_owner: Vec::new(),
+            meta_post_token_program_id: Vec::new(),
+            meta_post_token_amount: Vec::new(),
+            meta_post_token_decimals: Vec::new(),
+            meta_post_token_ui_amount: Vec::new(),
+            meta_post_token_ui_amount_string: Vec::new(),
+            meta_rewards_present: false,
+            meta_reward_pubkey: Vec::new(),
+            meta_reward_lamports: Vec::new(),
+            meta_reward_post_balance: Vec::new(),
+            meta_reward_type: Vec::new(),
+            meta_reward_commission: Vec::new(),
+            meta_loaded_addresses_writable: Vec::new(),
+            meta_loaded_addresses_readonly: Vec::new(),
+            meta_return_data_present: false,
+            meta_return_data_program_id: None,
+            meta_return_data_data: None,
+            meta_compute_units_consumed: None,
+            meta_cost_units: None,
+        }
+    }
+
+    fn write_slot(cache: &DiskCache, slot: u64, parent_slot: u64, tx_count: u32) {
+        let meta = block_metadata(slot, parent_slot, u64::from(tx_count));
+        let txs: Vec<_> = (0..tx_count).map(|idx| transaction(slot, idx)).collect();
+        cache
+            .write_finalized_slot(&meta, &txs, schema::COVERAGE_SOURCE_LIVE)
+            .expect("write slot");
+    }
+
+    fn unwrap_found(result: DiskBlockResult) -> StoredBlockPayload {
+        match result {
+            DiskBlockResult::Found(payload) => *payload,
+            other => panic!("expected found block, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn write_then_read_block_all_detail_levels() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = open_cache(&dir);
+        write_slot(&cache, 100, 99, 3);
+
+        match unwrap_found(cache.get_block(100, TransactionDetails::None).await) {
+            StoredBlockPayload::Metadata(meta) => {
+                assert_eq!(meta.slot, 100);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+
+        match unwrap_found(cache.get_block(100, TransactionDetails::Signatures).await) {
+            StoredBlockPayload::Signatures { signatures, .. } => {
+                assert_eq!(signatures.len(), 3);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+
+        match unwrap_found(cache.get_block(100, TransactionDetails::Accounts).await) {
+            StoredBlockPayload::Accounts { transactions, .. } => {
+                assert_eq!(transactions.len(), 3);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+
+        match unwrap_found(cache.get_block(100, TransactionDetails::Full).await) {
+            StoredBlockPayload::Full(block) => {
+                assert_eq!(block.transactions.len(), 3);
+                // Execution order by slot_idx.
+                let indexes: Vec<u32> = block
+                    .transactions
+                    .iter()
+                    .map(|record| record.slot_idx)
+                    .collect();
+                assert_eq!(indexes, vec![0, 1, 2]);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+
+        assert_eq!(
+            cache.block_time_for_slot(100).await,
+            DiskBlockTime::Found(Some(1_700_000_100))
+        );
+        assert!(matches!(
+            cache.get_block(101, TransactionDetails::Full).await,
+            DiskBlockResult::NotCovered
+        ));
+    }
+
+    #[tokio::test]
+    async fn zero_transaction_block_round_trips() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = open_cache(&dir);
+        write_slot(&cache, 50, 49, 0);
+
+        match unwrap_found(cache.get_block(50, TransactionDetails::Full).await) {
+            StoredBlockPayload::Full(block) => {
+                assert!(block.transactions.is_empty());
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn parent_gap_marks_skipped_slots() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = open_cache(&dir);
+        write_slot(&cache, 100, 99, 1);
+        // 101..=104 skipped on the finalized chain.
+        write_slot(&cache, 105, 100, 1);
+
+        assert_eq!(cache.slot_status(103).await, SlotStatus::Skipped);
+        assert!(matches!(
+            cache.get_block(103, TransactionDetails::Full).await,
+            DiskBlockResult::Skipped
+        ));
+        assert_eq!(cache.block_time_for_slot(103).await, DiskBlockTime::Skipped);
+        assert_eq!(cache.tip_span(), Some((100, 105)));
+
+        assert_eq!(
+            cache.covered_slots_in_range(99, 106).await,
+            Some(vec![100, 105])
+        );
+    }
+
+    #[tokio::test]
+    async fn incomplete_slot_is_rejected() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = open_cache(&dir);
+        let meta = block_metadata(10, 9, 2);
+        let txs = vec![transaction(10, 0)];
+        let err = cache
+            .write_finalized_slot(&meta, &txs, schema::COVERAGE_SOURCE_LIVE)
+            .expect_err("must reject");
+        assert!(matches!(err, DiskCacheError::IncompleteSlot { .. }));
+        assert!(!cache.covers_slot(10));
+    }
+
+    #[tokio::test]
+    async fn missing_transaction_poisons_slot() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = open_cache(&dir);
+        write_slot(&cache, 100, 99, 2);
+        cache.inner_for_tests().delete_tx_for_tests(100, 1);
+
+        assert!(matches!(
+            cache.get_block(100, TransactionDetails::Full).await,
+            DiskBlockResult::NotCovered
+        ));
+        // Poisoned: no longer claimed at all.
+        assert!(!cache.covers_slot(100));
+        assert_eq!(cache.slot_status(100).await, SlotStatus::NotCovered);
+    }
+
+    #[tokio::test]
+    async fn corrupt_block_meta_poisons_slot() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = open_cache(&dir);
+        write_slot(&cache, 100, 99, 1);
+        cache.inner_for_tests().corrupt_block_meta_for_tests(100);
+
+        assert!(matches!(
+            cache.get_block(100, TransactionDetails::None).await,
+            DiskBlockResult::NotCovered
+        ));
+        assert!(!cache.covers_slot(100));
+    }
+
+    #[tokio::test]
+    async fn coverage_survives_reopen() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        {
+            let cache = open_cache(&dir);
+            write_slot(&cache, 100, 99, 2);
+            write_slot(&cache, 101, 100, 1);
+        }
+        let cache = open_cache(&dir);
+        assert_eq!(cache.tip_span(), Some((100, 101)));
+        match unwrap_found(cache.get_block(101, TransactionDetails::Full).await) {
+            StoredBlockPayload::Full(block) => {
+                assert_eq!(block.transactions.len(), 1);
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn schema_version_mismatch_wipes_database() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        {
+            let cache = open_cache(&dir);
+            write_slot(&cache, 100, 99, 1);
+            // Force a version mismatch for the next open.
+            cache
+                .inner_for_tests()
+                .db
+                .put_cf(
+                    &cache.inner_for_tests().cf(schema::CF_META),
+                    schema::META_SCHEMA_VERSION,
+                    9999u32.to_be_bytes(),
+                )
+                .expect("overwrite version");
+        }
+        let cache = open_cache(&dir);
+        assert_eq!(cache.tip_span(), None);
+        assert!(!cache.covers_slot(100));
+    }
+
+    #[tokio::test]
+    async fn window_eviction_raises_floor_and_deletes() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut cfg = test_config(&dir);
+        cfg.retain_slots = 5;
+        let cache = DiskCache::open(cfg).expect("open");
+
+        for slot in 100..=110 {
+            write_slot(&cache, slot, slot - 1, 1);
+        }
+        let stats = cache
+            .maybe_evict()
+            .expect("evict")
+            .expect("floor should move");
+        assert_eq!(stats.new_floor, 106);
+        assert!(!stats.byte_budget_bound);
+
+        assert_eq!(cache.min_retained_slot(), 106);
+        assert!(!cache.covers_slot(105));
+        assert!(cache.covers_slot(106));
+        assert!(matches!(
+            cache.get_block(105, TransactionDetails::Full).await,
+            DiskBlockResult::NotCovered
+        ));
+        assert!(matches!(
+            cache.get_block(110, TransactionDetails::Full).await,
+            DiskBlockResult::Found(_)
+        ));
+
+        // Below-floor writes are refused.
+        let err = cache
+            .write_finalized_slot(
+                &block_metadata(50, 49, 0),
+                &[],
+                schema::COVERAGE_SOURCE_LIVE,
+            )
+            .expect_err("below floor");
+        assert!(matches!(err, DiskCacheError::BelowFloor { .. }));
+
+        // Floor persists across reopen.
+        drop(cache);
+        let cache = open_cache(&dir);
+        assert_eq!(cache.min_retained_slot(), 106);
+        assert_eq!(cache.tip_span(), Some((106, 110)));
+    }
+
+    #[tokio::test]
+    async fn byte_budget_eviction_binds_tighter_than_window() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut cfg = test_config(&dir);
+        cfg.retain_slots = 1_000_000;
+        cfg.max_bytes = 1; // Anything on disk trips the budget.
+        let cache = DiskCache::open(cfg).expect("open");
+
+        for slot in 100..=120 {
+            write_slot(&cache, slot, slot - 1, 2);
+        }
+        // SST sizes only materialize after a flush.
+        cache
+            .inner_for_tests()
+            .db
+            .flush_cfs_opt(
+                &schema::ALL_CFS
+                    .iter()
+                    .map(|name| cache.inner_for_tests().cf(name))
+                    .collect::<Vec<_>>()
+                    .iter()
+                    .collect::<Vec<_>>(),
+                &rocksdb::FlushOptions::default(),
+            )
+            .expect("flush");
+
+        let stats = cache
+            .maybe_evict()
+            .expect("evict")
+            .expect("budget should bind");
+        assert!(stats.byte_budget_bound);
+        assert!(stats.new_floor > 100);
+    }
+
+    #[test]
+    fn holes_in_reflects_coverage() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = open_cache(&dir);
+        write_slot(&cache, 100, 99, 1);
+        write_slot(&cache, 105, 100, 1); // covers 101..=105 via skip markers
+        write_slot(&cache, 110, 108, 1); // covers 109..=110; 106..=108 hole
+
+        assert_eq!(cache.holes_in(100, 110), vec![(106, 108)]);
+        assert_eq!(cache.tip_span(), Some((109, 110)));
+    }
+}

--- a/crates/superbank-rpc/src/disk_cache/mod.rs
+++ b/crates/superbank-rpc/src/disk_cache/mod.rs
@@ -36,7 +36,9 @@ use crate::clickhouse::{
 pub(crate) mod codec;
 pub(crate) mod coverage;
 pub(crate) mod index;
+pub(crate) mod ingest;
 pub(crate) mod schema;
+pub(crate) mod writer;
 
 use codec::CoverageValue;
 use coverage::CoverageMap;
@@ -244,7 +246,7 @@ impl DiskCache {
     pub(crate) fn write_finalized_slot(
         &self,
         meta: &BlockMetadataRecord,
-        txs: &[StoredTransactionRecord],
+        txs: &[Arc<StoredTransactionRecord>],
         source: u8,
     ) -> Result<(), DiskCacheError> {
         self.inner.write_finalized_slot(meta, txs, source)
@@ -262,8 +264,11 @@ impl DiskCache {
 
     /// Fsync the WAL; called on graceful shutdown.
     pub(crate) fn flush_wal(&self) -> Result<(), DiskCacheError> {
-        self.inner.db.flush_wal(true)?;
-        Ok(())
+        self.inner.flush_wal()
+    }
+
+    pub(crate) fn inner_arc(&self) -> Arc<DiskCacheInner> {
+        self.inner.clone()
     }
 
     pub(crate) async fn slot_status(&self, slot: u64) -> SlotStatus {
@@ -411,6 +416,15 @@ impl DiskCacheInner {
         self.min_retained.load(Ordering::Relaxed)
     }
 
+    pub(crate) fn covers_slot(&self, slot: u64) -> bool {
+        self.coverage.read().expect("coverage lock").contains(slot)
+    }
+
+    pub(crate) fn flush_wal(&self) -> Result<(), DiskCacheError> {
+        self.db.flush_wal(true)?;
+        Ok(())
+    }
+
     fn load_persisted_state(&self) -> Result<(), DiskCacheError> {
         let meta_cf = self.cf(schema::CF_META);
         let floor = self
@@ -450,7 +464,7 @@ impl DiskCacheInner {
     fn write_finalized_slot(
         &self,
         meta: &BlockMetadataRecord,
-        txs: &[StoredTransactionRecord],
+        txs: &[Arc<StoredTransactionRecord>],
         source: u8,
     ) -> Result<(), DiskCacheError> {
         let slot = meta.slot;
@@ -483,7 +497,7 @@ impl DiskCacheInner {
             batch.put_cf(
                 &tx_cf,
                 schema::tx_key(slot, record.slot_idx),
-                codec::encode_record(record)?,
+                codec::encode_record(record.as_ref())?,
             );
 
             let entries = index::derive_index_entries(record);
@@ -917,7 +931,7 @@ mod tests {
     use super::*;
     use solana_sdk::hash::Hash;
 
-    fn test_config(dir: &tempfile::TempDir) -> DiskCacheConfig {
+    pub(crate) fn test_config(dir: &tempfile::TempDir) -> DiskCacheConfig {
         DiskCacheConfig {
             path: dir.path().join("db"),
             retain_slots: 1_000,
@@ -927,11 +941,15 @@ mod tests {
         }
     }
 
-    fn open_cache(dir: &tempfile::TempDir) -> DiskCache {
+    pub(crate) fn open_cache(dir: &tempfile::TempDir) -> DiskCache {
         DiskCache::open(test_config(dir)).expect("open disk cache")
     }
 
-    fn block_metadata(slot: u64, parent_slot: u64, tx_count: u64) -> BlockMetadataRecord {
+    pub(crate) fn block_metadata(
+        slot: u64,
+        parent_slot: u64,
+        tx_count: u64,
+    ) -> BlockMetadataRecord {
         BlockMetadataRecord {
             slot,
             parent_slot,
@@ -951,7 +969,7 @@ mod tests {
         }
     }
 
-    fn transaction(slot: u64, idx: u32) -> StoredTransactionRecord {
+    pub(crate) fn transaction(slot: u64, idx: u32) -> StoredTransactionRecord {
         let mut signature = [0u8; 64];
         signature[..8].copy_from_slice(&slot.to_be_bytes());
         signature[8..12].copy_from_slice(&idx.to_be_bytes());
@@ -1021,9 +1039,11 @@ mod tests {
         }
     }
 
-    fn write_slot(cache: &DiskCache, slot: u64, parent_slot: u64, tx_count: u32) {
+    pub(crate) fn write_slot(cache: &DiskCache, slot: u64, parent_slot: u64, tx_count: u32) {
         let meta = block_metadata(slot, parent_slot, u64::from(tx_count));
-        let txs: Vec<_> = (0..tx_count).map(|idx| transaction(slot, idx)).collect();
+        let txs: Vec<_> = (0..tx_count)
+            .map(|idx| Arc::new(transaction(slot, idx)))
+            .collect();
         cache
             .write_finalized_slot(&meta, &txs, schema::COVERAGE_SOURCE_LIVE)
             .expect("write slot");
@@ -1128,7 +1148,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let cache = open_cache(&dir);
         let meta = block_metadata(10, 9, 2);
-        let txs = vec![transaction(10, 0)];
+        let txs = vec![Arc::new(transaction(10, 0))];
         let err = cache
             .write_finalized_slot(&meta, &txs, schema::COVERAGE_SOURCE_LIVE)
             .expect_err("must reject");
@@ -1301,8 +1321,14 @@ mod tests {
         record
     }
 
-    fn write_block(cache: &DiskCache, slot: u64, parent: u64, txs: Vec<StoredTransactionRecord>) {
+    pub(crate) fn write_block(
+        cache: &DiskCache,
+        slot: u64,
+        parent: u64,
+        txs: Vec<StoredTransactionRecord>,
+    ) {
         let meta = block_metadata(slot, parent, txs.len() as u64);
+        let txs: Vec<_> = txs.into_iter().map(Arc::new).collect();
         cache
             .write_finalized_slot(&meta, &txs, schema::COVERAGE_SOURCE_LIVE)
             .expect("write block");

--- a/crates/superbank-rpc/src/disk_cache/mod.rs
+++ b/crates/superbank-rpc/src/disk_cache/mod.rs
@@ -13,9 +13,6 @@
 //! The ClickHouse-to-disk fill is called "backfill" everywhere — "hydration" in
 //! this crate means converting stored records to RPC JSON.
 
-// Wired into handlers/server in follow-up phases; remove once the read tiers land.
-#![allow(dead_code)]
-
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
@@ -246,6 +243,9 @@ impl DiskCache {
 
     /// Write one finalized slot (block metadata + every transaction) atomically,
     /// together with its coverage marker and Skipped markers for the parent gap.
+    /// Production writes flow through the writer thread; this is the direct
+    /// surface used by tests.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn write_finalized_slot(
         &self,
         meta: &BlockMetadataRecord,
@@ -256,18 +256,10 @@ impl DiskCache {
     }
 
     /// Apply window and byte-budget eviction; returns stats when the floor moved.
+    /// Production eviction runs on the writer thread's tick; tests call this.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn maybe_evict(&self) -> Result<Option<EvictionStats>, DiskCacheError> {
         self.inner.maybe_evict()
-    }
-
-    /// Total live SST bytes across all column families.
-    pub(crate) fn live_sst_bytes(&self) -> u64 {
-        self.inner.live_sst_bytes()
-    }
-
-    /// Fsync the WAL; called on graceful shutdown.
-    pub(crate) fn flush_wal(&self) -> Result<(), DiskCacheError> {
-        self.inner.flush_wal()
     }
 
     pub(crate) fn inner_arc(&self) -> Arc<DiskCacheInner> {
@@ -343,6 +335,7 @@ impl DiskCache {
         result
     }
 
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) async fn get_sig_status(
         &self,
         signature: solana_sdk::signature::Signature,
@@ -399,6 +392,40 @@ impl DiskCache {
             if result.is_some() { "hit" } else { "miss" },
         );
         result
+    }
+
+    /// getTransactionsForAddress page from the contiguous tip span; same
+    /// `None` semantics as [`Self::signatures_for_address`].
+    pub(crate) async fn transactions_for_address(
+        &self,
+        address: solana_sdk::pubkey::Pubkey,
+        query: index::DiskTfaQuery,
+    ) -> Option<DiskGsfaPage> {
+        let result = self
+            .run_read("transactions_for_address", move |inner| {
+                inner.transactions_for_address_sync(&address, &query)
+            })
+            .await
+            .flatten();
+        crate::metrics::disk_cache_read(
+            "transactions_for_address",
+            if result.is_some() { "hit" } else { "miss" },
+        );
+        result
+    }
+
+    /// Batch full-record fetch by `(slot, idx)` position; per-entry `None` on a
+    /// miss (e.g. the eviction floor passed the slot after the index scan).
+    pub(crate) async fn get_txs_by_position(
+        &self,
+        positions: Vec<(u64, u32)>,
+    ) -> Vec<Option<StoredTransactionRecord>> {
+        let count = positions.len();
+        self.run_read("get_txs_by_position", move |inner| {
+            Ok(inner.get_txs_by_position_sync(&positions))
+        })
+        .await
+        .unwrap_or_else(|| vec![None; count])
     }
 
     /// Newest-first gSFA page from the contiguous tip span. `None` means the

--- a/crates/superbank-rpc/src/disk_cache/mod.rs
+++ b/crates/superbank-rpc/src/disk_cache/mod.rs
@@ -35,10 +35,12 @@ use crate::clickhouse::{
 
 pub(crate) mod codec;
 pub(crate) mod coverage;
+pub(crate) mod index;
 pub(crate) mod schema;
 
 use codec::CoverageValue;
 use coverage::CoverageMap;
+pub(crate) use index::DiskSigStatus;
 
 type Db = DBWithThreadMode<MultiThreaded>;
 
@@ -63,6 +65,8 @@ pub(crate) enum DiskCacheError {
     },
     #[error("slot {slot} is below the retention floor {floor}")]
     BelowFloor { slot: u64, floor: u64 },
+    #[error("corrupt address-index entry (slot {slot:?})")]
+    CorruptIndexEntry { slot: Option<u64> },
 }
 
 #[derive(Debug, Clone)]
@@ -94,6 +98,17 @@ pub(crate) enum DiskBlockTime {
     Found(Option<i64>),
     Skipped,
     NotCovered,
+}
+
+/// One page of a newest-first address-index scan over the contiguous tip span.
+#[derive(Debug)]
+pub(crate) struct DiskGsfaPage {
+    pub(crate) records: Vec<crate::clickhouse::SignatureRecord>,
+    /// The scan hit the coverage floor before filling the limit: ClickHouse must
+    /// be consulted for slots strictly below `floor`.
+    pub(crate) reached_floor: bool,
+    /// Coverage floor the scan was evaluated against.
+    pub(crate) floor: u64,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -283,6 +298,71 @@ impl DiskCache {
         .await
     }
 
+    /// Full transaction lookup by any of its signatures.
+    pub(crate) async fn get_tx(
+        &self,
+        signature: solana_sdk::signature::Signature,
+    ) -> Option<StoredTransactionRecord> {
+        self.run_read("get_tx", move |inner| Ok(inner.get_tx_sync(&signature)))
+            .await
+            .flatten()
+    }
+
+    pub(crate) async fn get_sig_status(
+        &self,
+        signature: solana_sdk::signature::Signature,
+    ) -> Option<DiskSigStatus> {
+        self.run_read("get_sig_status", move |inner| {
+            Ok(inner.get_sig_status_sync(&signature))
+        })
+        .await
+        .flatten()
+    }
+
+    /// Batch signature-status lookup; one blocking hop for the whole batch.
+    pub(crate) async fn get_sig_statuses(
+        &self,
+        signatures: Vec<solana_sdk::signature::Signature>,
+    ) -> Vec<Option<DiskSigStatus>> {
+        let count = signatures.len();
+        self.run_read("get_sig_statuses", move |inner| {
+            Ok(signatures
+                .iter()
+                .map(|signature| inner.get_sig_status_sync(signature))
+                .collect())
+        })
+        .await
+        .unwrap_or_else(|| vec![None; count])
+    }
+
+    pub(crate) async fn signature_position(
+        &self,
+        signature: solana_sdk::signature::Signature,
+    ) -> Option<crate::clickhouse::SignatureSlot> {
+        self.run_read("signature_position", move |inner| {
+            Ok(inner.signature_position_sync(&signature))
+        })
+        .await
+        .flatten()
+    }
+
+    /// Newest-first gSFA page from the contiguous tip span. `None` means the
+    /// disk tier contributed nothing (no coverage, or a read error) and the
+    /// caller must use ClickHouse with its original bounds.
+    pub(crate) async fn signatures_for_address(
+        &self,
+        address: solana_sdk::pubkey::Pubkey,
+        before: Option<crate::clickhouse::SlotBoundary>,
+        until: Option<crate::clickhouse::SlotBoundary>,
+        limit: usize,
+    ) -> Option<DiskGsfaPage> {
+        self.run_read("signatures_for_address", move |inner| {
+            inner.signatures_for_address_sync(&address, before, until, limit)
+        })
+        .await
+        .flatten()
+    }
+
     /// Run a blocking read against RocksDB off the async runtime, bounded by the
     /// read semaphore. Any error is logged and becomes a miss (`None`).
     async fn run_read<T, F>(&self, op: &'static str, f: F) -> Option<T>
@@ -325,6 +405,10 @@ impl DiskCacheInner {
         self.db
             .cf_handle(name)
             .unwrap_or_else(|| panic!("column family {name} exists"))
+    }
+
+    pub(crate) fn min_retained(&self) -> u64 {
+        self.min_retained.load(Ordering::Relaxed)
     }
 
     fn load_persisted_state(&self) -> Result<(), DiskCacheError> {
@@ -386,6 +470,9 @@ impl DiskCacheInner {
         let block_meta_cf = self.cf(schema::CF_BLOCK_META);
         let tx_cf = self.cf(schema::CF_TX);
         let coverage_cf = self.cf(schema::CF_SLOT_COVERAGE);
+        let sig_cf = self.cf(schema::CF_SIG);
+        let addr_cf = self.cf(schema::CF_ADDR_SIG);
+        let token_cf = self.cf(schema::CF_TOKEN_OWNER);
 
         batch.put_cf(
             &block_meta_cf,
@@ -398,6 +485,48 @@ impl DiskCacheInner {
                 schema::tx_key(slot, record.slot_idx),
                 codec::encode_record(record)?,
             );
+
+            let entries = index::derive_index_entries(record);
+            // signatures.sql ARRAY JOINs tx_signatures: any signature resolves.
+            let sig_value = codec::encode_sig_value(slot, record.slot_idx, entries.err.as_deref());
+            for tx_signature in &record.tx_signatures {
+                batch.put_cf(&sig_cf, tx_signature, &sig_value);
+            }
+
+            let addr_value = codec::encode_addr_sig_value(&codec::AddrSigValue {
+                signature: record.signature,
+                err: entries.err.clone(),
+                memo: entries.memo.clone(),
+                block_time: record.block_time,
+                balance_changed: false,
+            });
+            for address in &entries.addresses {
+                batch.put_cf(
+                    &addr_cf,
+                    schema::addr_sig_key(address, slot, record.slot_idx),
+                    &addr_value,
+                );
+            }
+
+            for token_entry in &entries.token_entries {
+                let token_value = codec::encode_addr_sig_value(&codec::AddrSigValue {
+                    signature: record.signature,
+                    err: entries.err.clone(),
+                    memo: entries.memo.clone(),
+                    block_time: record.block_time,
+                    balance_changed: token_entry.balance_changed,
+                });
+                batch.put_cf(
+                    &token_cf,
+                    schema::token_owner_key(
+                        &token_entry.owner,
+                        slot,
+                        record.slot_idx,
+                        &token_entry.token_account,
+                    ),
+                    &token_value,
+                );
+            }
         }
         batch.put_cf(
             &coverage_cf,
@@ -1155,6 +1284,227 @@ mod tests {
             .expect("budget should bind");
         assert!(stats.byte_budget_bound);
         assert!(stats.new_floor > 100);
+    }
+
+    fn transaction_with(
+        slot: u64,
+        idx: u32,
+        addresses: &[[u8; 32]],
+        status_err: Option<&str>,
+    ) -> StoredTransactionRecord {
+        let mut record = transaction(slot, idx);
+        record.tx_account_keys = addresses.to_vec();
+        if let Some(err) = status_err {
+            record.meta_status_ok = false;
+            record.meta_err = Some(err.to_string());
+        }
+        record
+    }
+
+    fn write_block(cache: &DiskCache, slot: u64, parent: u64, txs: Vec<StoredTransactionRecord>) {
+        let meta = block_metadata(slot, parent, txs.len() as u64);
+        cache
+            .write_finalized_slot(&meta, &txs, schema::COVERAGE_SOURCE_LIVE)
+            .expect("write block");
+    }
+
+    #[tokio::test]
+    async fn get_tx_resolves_any_listed_signature() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = open_cache(&dir);
+
+        let mut record = transaction(100, 0);
+        let mut second_sig = [7u8; 64];
+        second_sig[0] = 42;
+        record.tx_signatures = vec![record.signature, second_sig];
+        write_block(&cache, 100, 99, vec![record.clone()]);
+
+        let primary = solana_sdk::signature::Signature::from(record.signature);
+        let secondary = solana_sdk::signature::Signature::from(second_sig);
+        let unknown = solana_sdk::signature::Signature::from([255u8; 64]);
+
+        assert_eq!(
+            cache.get_tx(primary).await.map(|r| r.signature),
+            Some(record.signature)
+        );
+        assert_eq!(
+            cache.get_tx(secondary).await.map(|r| r.signature),
+            Some(record.signature)
+        );
+        assert!(cache.get_tx(unknown).await.is_none());
+
+        let position = cache.signature_position(primary).await.expect("position");
+        assert_eq!((position.slot, position.slot_idx), (100, 0));
+    }
+
+    #[tokio::test]
+    async fn sig_status_propagates_error_and_respects_floor() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut cfg = test_config(&dir);
+        cfg.retain_slots = 3;
+        let cache = DiskCache::open(cfg).expect("open");
+
+        let failed = transaction_with(
+            100,
+            0,
+            &[[1u8; 32]],
+            Some("{\"InstructionError\":[0,{\"Custom\":42}]}"),
+        );
+        let ok = transaction_with(100, 1, &[[1u8; 32]], None);
+        let failed_sig = solana_sdk::signature::Signature::from(failed.signature);
+        let ok_sig = solana_sdk::signature::Signature::from(ok.signature);
+        write_block(&cache, 100, 99, vec![failed, ok]);
+
+        let status = cache.get_sig_status(failed_sig).await.expect("status");
+        assert_eq!(status.slot, 100);
+        assert_eq!(status.slot_idx, 0);
+        assert!(status.err.is_some());
+        assert!(
+            cache
+                .get_sig_status(ok_sig)
+                .await
+                .expect("status")
+                .err
+                .is_none()
+        );
+
+        // Push the floor past slot 100: lingering index entries become invisible.
+        for slot in 101..=110 {
+            write_block(&cache, slot, slot - 1, vec![transaction(slot, 0)]);
+        }
+        cache.maybe_evict().expect("evict").expect("floor moved");
+        assert!(cache.min_retained_slot() > 100);
+        assert!(cache.get_sig_status(failed_sig).await.is_none());
+        assert!(cache.get_tx(failed_sig).await.is_none());
+
+        let batch = cache.get_sig_statuses(vec![failed_sig, ok_sig]).await;
+        assert_eq!(batch, vec![None, None]);
+    }
+
+    #[tokio::test]
+    async fn gsfa_scan_orders_filters_and_bounds() {
+        use crate::clickhouse::{SignatureSlot, SlotBoundary};
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = open_cache(&dir);
+
+        let addr_a = [10u8; 32];
+        let addr_b = [11u8; 32];
+        let address = solana_sdk::pubkey::Pubkey::from(addr_a);
+
+        // Slots 100..=104; address A in every slot, B only in 102.
+        for slot in 100..=104u64 {
+            let mut txs = vec![transaction_with(slot, 0, &[addr_a], None)];
+            if slot == 102 {
+                txs.push(transaction_with(slot, 1, &[addr_b], None));
+            }
+            write_block(&cache, slot, slot - 1, txs);
+        }
+
+        // Unbounded scan: newest-first, only address A, hits the floor unfilled.
+        let page = cache
+            .signatures_for_address(address, None, None, 10)
+            .await
+            .expect("page");
+        let slots: Vec<u64> = page.records.iter().map(|r| r.slot).collect();
+        assert_eq!(slots, vec![104, 103, 102, 101, 100]);
+        assert!(page.reached_floor);
+        assert_eq!(page.floor, 100);
+
+        // Limit satisfied: no floor escape.
+        let page = cache
+            .signatures_for_address(address, None, None, 2)
+            .await
+            .expect("page");
+        let slots: Vec<u64> = page.records.iter().map(|r| r.slot).collect();
+        assert_eq!(slots, vec![104, 103]);
+        assert!(!page.reached_floor);
+
+        // before excludes the position itself.
+        let before = SlotBoundary::Position(SignatureSlot {
+            slot: 104,
+            slot_idx: 0,
+        });
+        let page = cache
+            .signatures_for_address(address, Some(before), None, 10)
+            .await
+            .expect("page");
+        let slots: Vec<u64> = page.records.iter().map(|r| r.slot).collect();
+        assert_eq!(slots, vec![103, 102, 101, 100]);
+
+        // before as a slot bound: strictly below it.
+        let page = cache
+            .signatures_for_address(address, Some(SlotBoundary::Slot(103)), None, 10)
+            .await
+            .expect("page");
+        let slots: Vec<u64> = page.records.iter().map(|r| r.slot).collect();
+        assert_eq!(slots, vec![102, 101, 100]);
+
+        // until inside the span: fully answered, no floor escape.
+        let page = cache
+            .signatures_for_address(address, None, Some(SlotBoundary::Slot(101)), 10)
+            .await
+            .expect("page");
+        let slots: Vec<u64> = page.records.iter().map(|r| r.slot).collect();
+        assert_eq!(slots, vec![104, 103, 102]);
+        assert!(!page.reached_floor);
+
+        // until below the floor: the floor still bounds the scan.
+        let page = cache
+            .signatures_for_address(address, None, Some(SlotBoundary::Slot(50)), 10)
+            .await
+            .expect("page");
+        assert_eq!(page.records.len(), 5);
+        assert!(page.reached_floor);
+    }
+
+    #[tokio::test]
+    async fn gsfa_scan_orders_within_slot_and_carries_metadata() {
+        use std::str::FromStr;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = open_cache(&dir);
+
+        let addr = [20u8; 32];
+        let address = solana_sdk::pubkey::Pubkey::from(addr);
+        let memo_program =
+            solana_sdk::pubkey::Pubkey::from_str("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr")
+                .unwrap()
+                .to_bytes();
+
+        let mut with_memo = transaction_with(100, 1, &[addr], None);
+        with_memo.tx_account_keys.push(memo_program);
+        with_memo.tx_instructions_program_id_index = vec![1];
+        with_memo.tx_instructions_data = vec![b"hi".to_vec()];
+
+        let failed = transaction_with(100, 0, &[addr], Some("\"AccountNotFound\""));
+        write_block(&cache, 100, 99, vec![failed, with_memo]);
+
+        let page = cache
+            .signatures_for_address(address, None, None, 10)
+            .await
+            .expect("page");
+        assert_eq!(page.records.len(), 2);
+        // Desc by slot_idx within the slot.
+        assert_eq!(page.records[0].slot_idx, 1);
+        assert_eq!(page.records[0].memo.as_deref(), Some("[2] hi"));
+        assert!(page.records[0].err.is_none());
+        assert_eq!(page.records[1].slot_idx, 0);
+        assert!(page.records[1].err.is_some());
+        assert_eq!(page.records[0].block_time, Some(1_700_000_100));
+    }
+
+    #[tokio::test]
+    async fn gsfa_scan_without_coverage_returns_none() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = open_cache(&dir);
+        let address = solana_sdk::pubkey::Pubkey::from([1u8; 32]);
+        assert!(
+            cache
+                .signatures_for_address(address, None, None, 10)
+                .await
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/superbank-rpc/src/disk_cache/mod.rs
+++ b/crates/superbank-rpc/src/disk_cache/mod.rs
@@ -156,6 +156,7 @@ impl DiskCache {
                     path = %cfg.path.display(),
                     "disk cache: open failed ({err}); destroying and rebuilding"
                 );
+                crate::metrics::disk_cache_wipe();
                 destroy_db(&cfg.path)?;
                 open_db(&cfg.path, &opts, min_retained.clone())?
             }
@@ -171,6 +172,7 @@ impl DiskCache {
                     "disk cache: schema version mismatch; wiping"
                 );
                 drop(db);
+                crate::metrics::disk_cache_wipe();
                 destroy_db(&cfg.path)?;
                 let db = open_db(&cfg.path, &opts, min_retained.clone())?;
                 match check_schema_version(db)? {
@@ -273,9 +275,17 @@ impl DiskCache {
     }
 
     pub(crate) async fn slot_status(&self, slot: u64) -> SlotStatus {
-        self.run_read("slot_status", move |inner| Ok(inner.slot_status_sync(slot)))
+        let status = self
+            .run_read("slot_status", move |inner| Ok(inner.slot_status_sync(slot)))
             .await
-            .unwrap_or(SlotStatus::NotCovered)
+            .unwrap_or(SlotStatus::NotCovered);
+        let outcome = match status {
+            SlotStatus::Covered { .. } => "hit",
+            SlotStatus::Skipped => "skipped",
+            SlotStatus::NotCovered => "not_covered",
+        };
+        crate::metrics::disk_cache_read("slot_status", outcome);
+        status
     }
 
     pub(crate) async fn get_block(
@@ -283,17 +293,33 @@ impl DiskCache {
         slot: u64,
         transaction_details: TransactionDetails,
     ) -> DiskBlockResult {
-        self.run_read("get_block", move |inner| {
-            Ok(inner.get_block_sync(slot, transaction_details))
-        })
-        .await
-        .unwrap_or(DiskBlockResult::NotCovered)
+        let result = self
+            .run_read("get_block", move |inner| {
+                Ok(inner.get_block_sync(slot, transaction_details))
+            })
+            .await
+            .unwrap_or(DiskBlockResult::NotCovered);
+        let outcome = match &result {
+            DiskBlockResult::Found(_) => "hit",
+            DiskBlockResult::Skipped => "skipped",
+            DiskBlockResult::NotCovered => "not_covered",
+        };
+        crate::metrics::disk_cache_read("get_block", outcome);
+        result
     }
 
     pub(crate) async fn block_time_for_slot(&self, slot: u64) -> DiskBlockTime {
-        self.run_read("block_time", move |inner| Ok(inner.block_time_sync(slot)))
+        let result = self
+            .run_read("block_time", move |inner| Ok(inner.block_time_sync(slot)))
             .await
-            .unwrap_or(DiskBlockTime::NotCovered)
+            .unwrap_or(DiskBlockTime::NotCovered);
+        let outcome = match result {
+            DiskBlockTime::Found(_) => "hit",
+            DiskBlockTime::Skipped => "skipped",
+            DiskBlockTime::NotCovered => "not_covered",
+        };
+        crate::metrics::disk_cache_read("block_time", outcome);
+        result
     }
 
     /// Covered (non-skipped) slots within `[start, end]`, ascending.
@@ -309,20 +335,29 @@ impl DiskCache {
         &self,
         signature: solana_sdk::signature::Signature,
     ) -> Option<StoredTransactionRecord> {
-        self.run_read("get_tx", move |inner| Ok(inner.get_tx_sync(&signature)))
+        let result = self
+            .run_read("get_tx", move |inner| Ok(inner.get_tx_sync(&signature)))
             .await
-            .flatten()
+            .flatten();
+        crate::metrics::disk_cache_read("get_tx", if result.is_some() { "hit" } else { "miss" });
+        result
     }
 
     pub(crate) async fn get_sig_status(
         &self,
         signature: solana_sdk::signature::Signature,
     ) -> Option<DiskSigStatus> {
-        self.run_read("get_sig_status", move |inner| {
-            Ok(inner.get_sig_status_sync(&signature))
-        })
-        .await
-        .flatten()
+        let result = self
+            .run_read("get_sig_status", move |inner| {
+                Ok(inner.get_sig_status_sync(&signature))
+            })
+            .await
+            .flatten();
+        crate::metrics::disk_cache_read(
+            "get_sig_status",
+            if result.is_some() { "hit" } else { "miss" },
+        );
+        result
     }
 
     /// Batch signature-status lookup; one blocking hop for the whole batch.
@@ -331,25 +366,39 @@ impl DiskCache {
         signatures: Vec<solana_sdk::signature::Signature>,
     ) -> Vec<Option<DiskSigStatus>> {
         let count = signatures.len();
-        self.run_read("get_sig_statuses", move |inner| {
-            Ok(signatures
-                .iter()
-                .map(|signature| inner.get_sig_status_sync(signature))
-                .collect())
-        })
-        .await
-        .unwrap_or_else(|| vec![None; count])
+        let results: Vec<Option<DiskSigStatus>> = self
+            .run_read("get_sig_statuses", move |inner| {
+                Ok(signatures
+                    .iter()
+                    .map(|signature| inner.get_sig_status_sync(signature))
+                    .collect())
+            })
+            .await
+            .unwrap_or_else(|| vec![None; count]);
+        for result in &results {
+            crate::metrics::disk_cache_read(
+                "get_sig_statuses",
+                if result.is_some() { "hit" } else { "miss" },
+            );
+        }
+        results
     }
 
     pub(crate) async fn signature_position(
         &self,
         signature: solana_sdk::signature::Signature,
     ) -> Option<crate::clickhouse::SignatureSlot> {
-        self.run_read("signature_position", move |inner| {
-            Ok(inner.signature_position_sync(&signature))
-        })
-        .await
-        .flatten()
+        let result = self
+            .run_read("signature_position", move |inner| {
+                Ok(inner.signature_position_sync(&signature))
+            })
+            .await
+            .flatten();
+        crate::metrics::disk_cache_read(
+            "signature_position",
+            if result.is_some() { "hit" } else { "miss" },
+        );
+        result
     }
 
     /// Newest-first gSFA page from the contiguous tip span. `None` means the
@@ -362,11 +411,17 @@ impl DiskCache {
         until: Option<crate::clickhouse::SlotBoundary>,
         limit: usize,
     ) -> Option<DiskGsfaPage> {
-        self.run_read("signatures_for_address", move |inner| {
-            inner.signatures_for_address_sync(&address, before, until, limit)
-        })
-        .await
-        .flatten()
+        let result = self
+            .run_read("signatures_for_address", move |inner| {
+                inner.signatures_for_address_sync(&address, before, until, limit)
+            })
+            .await
+            .flatten();
+        crate::metrics::disk_cache_read(
+            "signatures_for_address",
+            if result.is_some() { "hit" } else { "miss" },
+        );
+        result
     }
 
     /// Run a blocking read against RocksDB off the async runtime, bounded by the
@@ -424,6 +479,13 @@ impl DiskCacheInner {
     pub(crate) fn flush_wal(&self) -> Result<(), DiskCacheError> {
         self.db.flush_wal(true)?;
         Ok(())
+    }
+
+    fn publish_coverage_metrics(&self) {
+        let map = self.coverage.read().expect("coverage lock");
+        let (min_covered, max_covered) = map.covered_span().unwrap_or((0, 0));
+        let contiguous_floor = map.contiguous_tip_span().map_or(0, |(floor, _)| floor);
+        crate::metrics::disk_cache_coverage(min_covered, max_covered, contiguous_floor);
     }
 
     fn load_persisted_state(&self) -> Result<(), DiskCacheError> {
@@ -583,6 +645,7 @@ impl DiskCacheInner {
             let mut map = self.coverage.write().expect("coverage lock");
             map.insert_range(claim_start, slot);
         }
+        self.publish_coverage_metrics();
         Ok(())
     }
 
@@ -648,6 +711,13 @@ impl DiskCacheInner {
             .expect("coverage lock")
             .remove_below(new_floor);
 
+        crate::metrics::disk_cache_evicted(
+            if byte_budget_bound { "bytes" } else { "window" },
+            new_floor - old_floor,
+        );
+        crate::metrics::disk_cache_size_bytes(self.live_sst_bytes());
+        self.publish_coverage_metrics();
+
         Ok(Some(EvictionStats {
             old_floor,
             new_floor,
@@ -671,6 +741,7 @@ impl DiskCacheInner {
     /// degrades to ClickHouse until repair re-ingests it.
     fn poison_slot(&self, slot: u64) {
         warn!(slot, "disk cache: poisoning slot after inconsistency");
+        crate::metrics::disk_cache_poisoned_slot();
         if let Err(err) = self
             .db
             .delete_cf(&self.cf(schema::CF_SLOT_COVERAGE), schema::slot_key(slot))
@@ -678,6 +749,7 @@ impl DiskCacheInner {
             warn!(slot, "disk cache: failed to delete coverage marker: {err}");
         }
         self.coverage.write().expect("coverage lock").remove(slot);
+        self.publish_coverage_metrics();
     }
 
     pub(crate) fn slot_status_sync(&self, slot: u64) -> SlotStatus {

--- a/crates/superbank-rpc/src/disk_cache/mod.rs
+++ b/crates/superbank-rpc/src/disk_cache/mod.rs
@@ -35,6 +35,7 @@ use crate::clickhouse::{
 
 pub(crate) mod codec;
 pub(crate) mod coverage;
+pub(crate) mod filler;
 pub(crate) mod index;
 pub(crate) mod ingest;
 pub(crate) mod schema;

--- a/crates/superbank-rpc/src/disk_cache/mod.rs
+++ b/crates/superbank-rpc/src/disk_cache/mod.rs
@@ -1000,7 +1000,7 @@ fn check_schema_version(db: Db) -> Result<SchemaCheck, DiskCacheError> {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use solana_sdk::hash::Hash;
 

--- a/crates/superbank-rpc/src/disk_cache/mod.rs
+++ b/crates/superbank-rpc/src/disk_cache/mod.rs
@@ -51,6 +51,30 @@ const MAX_SKIPPED_RUN: u64 = 100_000;
 /// When the byte budget trips, evict down to this fraction of it (hysteresis).
 const BYTE_BUDGET_LOW_WATER: f64 = 0.93;
 
+/// Column families range-deleted immediately by eviction. Index CFs are cleaned
+/// by compaction filters and can lag without changing the slot floor estimate.
+const BYTE_BUDGET_EVICTION_CFS: [&str; 3] = [
+    schema::CF_SLOT_COVERAGE,
+    schema::CF_BLOCK_META,
+    schema::CF_TX,
+];
+
+fn byte_budget_floor(
+    head: u64,
+    max_bytes: u64,
+    data_live_bytes: u64,
+    covered_slots: u64,
+) -> Option<u64> {
+    if max_bytes == 0 || data_live_bytes < max_bytes {
+        return None;
+    }
+
+    let bytes_per_slot = (data_live_bytes / covered_slots.max(1)).max(1);
+    let target_bytes = (max_bytes as f64 * BYTE_BUDGET_LOW_WATER) as u64;
+    let keep_slots = (target_bytes / bytes_per_slot).max(1);
+    Some(head.saturating_sub(keep_slots - 1))
+}
+
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum DiskCacheError {
     #[error("rocksdb: {0}")]
@@ -593,7 +617,7 @@ impl DiskCacheInner {
             let entries = index::derive_index_entries(record);
             // signatures.sql ARRAY JOINs tx_signatures: any signature resolves.
             let sig_value = codec::encode_sig_value(slot, record.slot_idx, entries.err.as_deref());
-            for tx_signature in &record.tx_signatures {
+            for tx_signature in &entries.signatures {
                 batch.put_cf(&sig_cf, tx_signature, &sig_value);
             }
 
@@ -686,19 +710,16 @@ impl DiskCacheInner {
 
         let mut byte_budget_bound = false;
         let bytes_floor = if self.cfg.max_bytes > 0 {
-            let live = self.live_sst_bytes();
-            if live >= self.cfg.max_bytes {
-                let covered = self
+            let data_live = self.live_sst_bytes_for(&BYTE_BUDGET_EVICTION_CFS);
+            if data_live >= self.cfg.max_bytes {
+                let covered_slots = self
                     .coverage
                     .read()
                     .expect("coverage lock")
-                    .covered_slot_count()
-                    .max(1);
-                let bytes_per_slot = (live / covered).max(1);
-                let target_bytes = (self.cfg.max_bytes as f64 * BYTE_BUDGET_LOW_WATER) as u64;
-                let keep_slots = (target_bytes / bytes_per_slot).max(1);
+                    .covered_slot_count();
                 byte_budget_bound = true;
-                head.saturating_sub(keep_slots - 1)
+                byte_budget_floor(head, self.cfg.max_bytes, data_live, covered_slots)
+                    .unwrap_or_default()
             } else {
                 0
             }
@@ -753,7 +774,11 @@ impl DiskCacheInner {
     }
 
     fn live_sst_bytes(&self) -> u64 {
-        schema::ALL_CFS
+        self.live_sst_bytes_for(&schema::ALL_CFS)
+    }
+
+    fn live_sst_bytes_for(&self, cf_names: &[&str]) -> u64 {
+        cf_names
             .iter()
             .filter_map(|name| {
                 self.db
@@ -1149,6 +1174,22 @@ pub(crate) mod tests {
             .expect("write slot");
     }
 
+    fn flush_all_cfs(cache: &DiskCache) {
+        cache
+            .inner_for_tests()
+            .db
+            .flush_cfs_opt(
+                &schema::ALL_CFS
+                    .iter()
+                    .map(|name| cache.inner_for_tests().cf(name))
+                    .collect::<Vec<_>>()
+                    .iter()
+                    .collect::<Vec<_>>(),
+                &rocksdb::FlushOptions::default(),
+            )
+            .expect("flush");
+    }
+
     fn unwrap_found(result: DiskBlockResult) -> StoredBlockPayload {
         match result {
             DiskBlockResult::Found(payload) => *payload,
@@ -1384,19 +1425,7 @@ pub(crate) mod tests {
             write_slot(&cache, slot, slot - 1, 2);
         }
         // SST sizes only materialize after a flush.
-        cache
-            .inner_for_tests()
-            .db
-            .flush_cfs_opt(
-                &schema::ALL_CFS
-                    .iter()
-                    .map(|name| cache.inner_for_tests().cf(name))
-                    .collect::<Vec<_>>()
-                    .iter()
-                    .collect::<Vec<_>>(),
-                &rocksdb::FlushOptions::default(),
-            )
-            .expect("flush");
+        flush_all_cfs(&cache);
 
         let stats = cache
             .maybe_evict()
@@ -1404,6 +1433,57 @@ pub(crate) mod tests {
             .expect("budget should bind");
         assert!(stats.byte_budget_bound);
         assert!(stats.new_floor > 100);
+    }
+
+    #[test]
+    fn byte_budget_floor_uses_data_cf_pressure() {
+        let head = 120;
+        let max_bytes = 1_000;
+        let covered_slots = 21;
+
+        // The estimator receives evictable data-CF bytes, not total RocksDB
+        // bytes, so lagging index CFs alone cannot move the floor.
+        assert_eq!(
+            byte_budget_floor(head, max_bytes, max_bytes - 1, covered_slots),
+            None
+        );
+        assert!(byte_budget_floor(head, max_bytes, max_bytes, covered_slots).is_some());
+    }
+
+    #[tokio::test]
+    async fn byte_budget_eviction_ignores_lagging_index_cf_pressure() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut cfg = test_config(&dir);
+        cfg.retain_slots = 1_000_000;
+        let cache = DiskCache::open(cfg.clone()).expect("open");
+
+        for slot in 100..=104u64 {
+            let mut record = transaction(slot, 0);
+            record.tx_account_keys = (0..192)
+                .map(|idx| {
+                    let mut key = [0u8; 32];
+                    key[..8].copy_from_slice(&slot.to_be_bytes());
+                    key[8..16].copy_from_slice(&(idx as u64).to_be_bytes());
+                    key
+                })
+                .collect();
+            write_block(&cache, slot, slot - 1, vec![record]);
+        }
+        flush_all_cfs(&cache);
+
+        let data_live = cache
+            .inner_for_tests()
+            .live_sst_bytes_for(&BYTE_BUDGET_EVICTION_CFS);
+        let total_live = cache.inner_for_tests().live_sst_bytes();
+        assert!(data_live > 0);
+        assert!(total_live > data_live + 1);
+
+        drop(cache);
+        cfg.max_bytes = data_live + 1;
+        let cache = DiskCache::open(cfg).expect("reopen");
+
+        assert!(cache.maybe_evict().expect("evict").is_none());
+        assert_eq!(cache.min_retained_slot(), 0);
     }
 
     fn transaction_with(

--- a/crates/superbank-rpc/src/disk_cache/schema.rs
+++ b/crates/superbank-rpc/src/disk_cache/schema.rs
@@ -1,0 +1,415 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+/*
+ * Copyright 2025-2026 Triton One Limited. All rights reserved.
+ */
+
+//! RocksDB schema for the disk cache: column families, key encodings, and options.
+//!
+//! All integers in keys are big-endian so lexicographic order equals numeric order.
+//! `addr_sig` / `token_owner` keys store the bitwise NOT of slot/idx so a forward
+//! iterator yields newest-first, matching the `ORDER BY slot DESC, slot_idx DESC`
+//! of the gsfa / token_owner_activity materialized views.
+//!
+//! Bump [`SCHEMA_VERSION`] whenever any key or value layout changes; a mismatch at
+//! open wipes and rebuilds the database (it is only a cache).
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use rocksdb::{
+    BlockBasedIndexType, BlockBasedOptions, Cache, ColumnFamilyDescriptor, DBCompressionType,
+    Options, SliceTransform, compaction_filter::Decision,
+};
+
+pub(crate) const SCHEMA_VERSION: u32 = 1;
+
+pub(crate) const CF_META: &str = "meta";
+pub(crate) const CF_SLOT_COVERAGE: &str = "slot_coverage";
+pub(crate) const CF_BLOCK_META: &str = "block_meta";
+pub(crate) const CF_TX: &str = "tx";
+pub(crate) const CF_SIG: &str = "sig";
+pub(crate) const CF_ADDR_SIG: &str = "addr_sig";
+pub(crate) const CF_TOKEN_OWNER: &str = "token_owner";
+
+pub(crate) const ALL_CFS: [&str; 7] = [
+    CF_META,
+    CF_SLOT_COVERAGE,
+    CF_BLOCK_META,
+    CF_TX,
+    CF_SIG,
+    CF_ADDR_SIG,
+    CF_TOKEN_OWNER,
+];
+
+// `meta` CF keys.
+pub(crate) const META_SCHEMA_VERSION: &[u8] = b"schema_version";
+pub(crate) const META_MIN_RETAINED: &[u8] = b"min_retained";
+
+// `slot_coverage` value tags.
+pub(crate) const COVERAGE_TAG_COVERED: u8 = 1;
+pub(crate) const COVERAGE_TAG_SKIPPED: u8 = 2;
+
+// `slot_coverage` source bytes (diagnostics only).
+pub(crate) const COVERAGE_SOURCE_LIVE: u8 = 0;
+pub(crate) const COVERAGE_SOURCE_BACKFILL: u8 = 1;
+pub(crate) const COVERAGE_SOURCE_REPAIR: u8 = 2;
+
+#[inline]
+pub(crate) fn rev_slot(slot: u64) -> u64 {
+    !slot
+}
+
+#[inline]
+pub(crate) fn rev_idx(idx: u32) -> u32 {
+    !idx
+}
+
+#[inline]
+pub(crate) fn slot_key(slot: u64) -> [u8; 8] {
+    slot.to_be_bytes()
+}
+
+#[inline]
+pub(crate) fn tx_key(slot: u64, idx: u32) -> [u8; 12] {
+    let mut key = [0u8; 12];
+    key[..8].copy_from_slice(&slot.to_be_bytes());
+    key[8..].copy_from_slice(&idx.to_be_bytes());
+    key
+}
+
+/// `addr_sig` key: `address ++ rev(slot) ++ rev(idx)`. The signature lives in the
+/// value: `(address, slot, idx)` is unique because one transaction occupies one
+/// `(slot, idx)` and addresses are deduplicated per transaction.
+#[inline]
+pub(crate) fn addr_sig_key(address: &[u8; 32], slot: u64, idx: u32) -> [u8; 44] {
+    let mut key = [0u8; 44];
+    key[..32].copy_from_slice(address);
+    key[32..40].copy_from_slice(&rev_slot(slot).to_be_bytes());
+    key[40..44].copy_from_slice(&rev_idx(idx).to_be_bytes());
+    key
+}
+
+/// `token_owner` key: `owner ++ rev(slot) ++ rev(idx) ++ token_account`. The token
+/// account is part of the key because one transaction may touch several token
+/// accounts of the same owner (mirrors the token_owner_activity ordering key).
+#[inline]
+pub(crate) fn token_owner_key(
+    owner: &[u8; 32],
+    slot: u64,
+    idx: u32,
+    token_account: &[u8; 32],
+) -> [u8; 76] {
+    let mut key = [0u8; 76];
+    key[..32].copy_from_slice(owner);
+    key[32..40].copy_from_slice(&rev_slot(slot).to_be_bytes());
+    key[40..44].copy_from_slice(&rev_idx(idx).to_be_bytes());
+    key[44..].copy_from_slice(token_account);
+    key
+}
+
+/// Slot embedded in an `addr_sig` / `token_owner` key (for the compaction filter).
+#[inline]
+pub(crate) fn addr_key_slot(key: &[u8]) -> Option<u64> {
+    let raw = key.get(32..40)?;
+    Some(!u64::from_be_bytes(raw.try_into().ok()?))
+}
+
+pub(crate) struct DiskCacheOptions {
+    pub(crate) block_cache_bytes: usize,
+    pub(crate) total_write_buffer_bytes: usize,
+    pub(crate) compaction_rate_bytes_per_sec: i64,
+}
+
+impl Default for DiskCacheOptions {
+    fn default() -> Self {
+        Self {
+            block_cache_bytes: 4 << 30,
+            total_write_buffer_bytes: 2 << 30,
+            compaction_rate_bytes_per_sec: 256 << 20,
+        }
+    }
+}
+
+/// SSTs of the index CFs are rewritten at least daily so the compaction filters
+/// reclaim evicted entries with bounded lag.
+const INDEX_PERIODIC_COMPACTION_SECS: u64 = 86_400;
+
+pub(crate) fn db_options(opts: &DiskCacheOptions) -> Options {
+    let mut db = Options::default();
+    db.create_if_missing(true);
+    db.create_missing_column_families(true);
+    // Required for crash consistency of WAL-disabled backfill batches: flushes
+    // cover all CFs atomically, so cross-CF batches never land partially.
+    db.set_atomic_flush(true);
+    db.increase_parallelism(num_cpus().min(16) as i32);
+    db.set_max_background_jobs(8);
+    db.set_db_write_buffer_size(opts.total_write_buffer_bytes);
+    db.set_max_total_wal_size(1 << 30);
+    db.set_bytes_per_sync(1 << 20);
+    db.set_wal_bytes_per_sync(1 << 20);
+    if opts.compaction_rate_bytes_per_sec > 0 {
+        db.set_ratelimiter(opts.compaction_rate_bytes_per_sec, 100_000, 10);
+    }
+    db
+}
+
+pub(crate) fn cf_descriptors(
+    opts: &DiskCacheOptions,
+    min_retained: Arc<AtomicU64>,
+) -> Vec<ColumnFamilyDescriptor> {
+    let cache = Cache::new_lru_cache(opts.block_cache_bytes);
+
+    let block_opts = |block_size: usize, ribbon: bool, cache: &Cache| {
+        let mut block = BlockBasedOptions::default();
+        block.set_block_size(block_size);
+        block.set_block_cache(cache);
+        block.set_cache_index_and_filter_blocks(true);
+        block.set_pin_l0_filter_and_index_blocks_in_cache(true);
+        // Partitioned filters bound resident filter memory: full filters over the
+        // tens of billions of keys in a 10-epoch window would need tens of GB.
+        block.set_index_type(BlockBasedIndexType::TwoLevelIndexSearch);
+        block.set_partition_filters(true);
+        if ribbon {
+            block.set_ribbon_filter(10.0);
+        } else {
+            block.set_bloom_filter(10.0, false);
+        }
+        block
+    };
+
+    let data_compression = |cf: &mut Options| {
+        cf.set_compression_per_level(&[
+            DBCompressionType::None,
+            DBCompressionType::None,
+            DBCompressionType::Lz4,
+            DBCompressionType::Lz4,
+            DBCompressionType::Zstd,
+            DBCompressionType::Zstd,
+            DBCompressionType::Zstd,
+        ]);
+        cf.set_bottommost_compression_type(DBCompressionType::Zstd);
+        cf.set_bottommost_zstd_max_train_bytes(16 * 1024 * 100, true);
+    };
+
+    let mut descriptors = Vec::with_capacity(ALL_CFS.len());
+
+    let mut meta = Options::default();
+    meta.set_write_buffer_size(8 << 20);
+    descriptors.push(ColumnFamilyDescriptor::new(CF_META, meta));
+
+    let mut slot_coverage = Options::default();
+    slot_coverage.set_write_buffer_size(32 << 20);
+    slot_coverage.set_compression_type(DBCompressionType::Lz4);
+    descriptors.push(ColumnFamilyDescriptor::new(CF_SLOT_COVERAGE, slot_coverage));
+
+    let mut block_meta = Options::default();
+    block_meta.set_write_buffer_size(32 << 20);
+    block_meta.set_compression_type(DBCompressionType::Lz4);
+    block_meta.set_block_based_table_factory(&block_opts(16 << 10, false, &cache));
+    descriptors.push(ColumnFamilyDescriptor::new(CF_BLOCK_META, block_meta));
+
+    let mut tx = Options::default();
+    tx.set_write_buffer_size(256 << 20);
+    tx.set_target_file_size_base(256 << 20);
+    tx.set_level_compaction_dynamic_level_bytes(true);
+    data_compression(&mut tx);
+    tx.set_prefix_extractor(SliceTransform::create_fixed_prefix(8));
+    tx.set_memtable_prefix_bloom_ratio(0.1);
+    tx.set_block_based_table_factory(&block_opts(32 << 10, false, &cache));
+    descriptors.push(ColumnFamilyDescriptor::new(CF_TX, tx));
+
+    let mut sig = Options::default();
+    sig.set_write_buffer_size(64 << 20);
+    sig.set_level_compaction_dynamic_level_bytes(true);
+    sig.set_compression_type(DBCompressionType::Lz4);
+    sig.set_block_based_table_factory(&block_opts(4 << 10, true, &cache));
+    sig.set_periodic_compaction_seconds(INDEX_PERIODIC_COMPACTION_SECS);
+    let sig_floor = min_retained.clone();
+    sig.set_compaction_filter("disk_cache_window_sig", move |_level, _key, value| {
+        match crate::disk_cache::codec::sig_value_slot(value) {
+            Some(slot) if slot < sig_floor.load(Ordering::Relaxed) => Decision::Remove,
+            _ => Decision::Keep,
+        }
+    });
+    descriptors.push(ColumnFamilyDescriptor::new(CF_SIG, sig));
+
+    let addr_like = |name: &'static str, floor: Arc<AtomicU64>, cache: &Cache| {
+        let mut cf = Options::default();
+        cf.set_write_buffer_size(128 << 20);
+        cf.set_level_compaction_dynamic_level_bytes(true);
+        data_compression(&mut cf);
+        cf.set_prefix_extractor(SliceTransform::create_fixed_prefix(32));
+        cf.set_memtable_prefix_bloom_ratio(0.1);
+        cf.set_block_based_table_factory(&block_opts(16 << 10, true, cache));
+        cf.set_periodic_compaction_seconds(INDEX_PERIODIC_COMPACTION_SECS);
+        cf.set_compaction_filter(
+            "disk_cache_window_addr",
+            move |_level, key: &[u8], _value: &[u8]| match super::schema::addr_key_slot(key) {
+                Some(slot) if slot < floor.load(Ordering::Relaxed) => Decision::Remove,
+                _ => Decision::Keep,
+            },
+        );
+        ColumnFamilyDescriptor::new(name, cf)
+    };
+
+    descriptors.push(addr_like(CF_ADDR_SIG, min_retained.clone(), &cache));
+    descriptors.push(addr_like(CF_TOKEN_OWNER, min_retained, &cache));
+
+    descriptors
+}
+
+fn num_cpus() -> usize {
+    std::thread::available_parallelism()
+        .map(std::num::NonZeroUsize::get)
+        .unwrap_or(4)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn key_orderings_match_slot_order() {
+        // Slot-keyed CFs: ascending slot order.
+        assert!(slot_key(5) < slot_key(6));
+        assert!(tx_key(5, u32::MAX) < tx_key(6, 0));
+        assert!(tx_key(5, 1) < tx_key(5, 2));
+
+        // addr_sig: forward iteration yields newest-first within an address.
+        let addr = [9u8; 32];
+        assert!(addr_sig_key(&addr, 100, 0) < addr_sig_key(&addr, 99, 0));
+        assert!(addr_sig_key(&addr, 100, 5) < addr_sig_key(&addr, 100, 4));
+
+        // Different addresses never interleave.
+        let addr_b = [10u8; 32];
+        assert!(addr_sig_key(&addr, 0, 0) < addr_sig_key(&addr_b, u64::MAX, u32::MAX));
+    }
+
+    #[test]
+    fn addr_key_slot_round_trips() {
+        let addr = [3u8; 32];
+        for slot in [0u64, 1, 432_000, u64::MAX - 1, u64::MAX] {
+            let key = addr_sig_key(&addr, slot, 7);
+            assert_eq!(addr_key_slot(&key), Some(slot));
+            let token_key = token_owner_key(&addr, slot, 7, &[4u8; 32]);
+            assert_eq!(addr_key_slot(&token_key), Some(slot));
+        }
+        assert_eq!(addr_key_slot(&[0u8; 10]), None);
+    }
+
+    /// Guards against silent bincode layout drift: if this test fails, the on-disk
+    /// format changed — bump [`SCHEMA_VERSION`] in the same change.
+    #[test]
+    fn stored_record_bincode_fingerprint() {
+        use crate::clickhouse::{BlockMetadataRecord, StoredTransactionRecord};
+
+        let record = StoredTransactionRecord {
+            signature: [7u8; 64],
+            slot: 123,
+            slot_idx: 4,
+            block_time: Some(1_700_000_000),
+            tx_version: Some(0),
+            tx_signatures: vec![[7u8; 64], [8u8; 64]],
+            tx_num_required_signatures: 1,
+            tx_num_readonly_signed_accounts: 0,
+            tx_num_readonly_unsigned_accounts: 2,
+            tx_account_keys: vec![[1u8; 32], [2u8; 32]],
+            tx_recent_blockhash: [3u8; 32],
+            tx_instructions_program_id_index: vec![1],
+            tx_instructions_accounts: vec![vec![0, 1]],
+            tx_instructions_data: vec![vec![9, 9, 9]],
+            tx_address_table_lookups_present: true,
+            tx_address_table_lookup_account_key: vec![[4u8; 32]],
+            tx_address_table_lookup_writable_indexes: vec![vec![0]],
+            tx_address_table_lookup_readonly_indexes: vec![vec![1]],
+            meta_status_ok: false,
+            meta_err: Some("{\"InstructionError\":[0,{\"Custom\":1}]}".to_string()),
+            meta_fee: 5000,
+            meta_pre_balances: vec![10, 20],
+            meta_post_balances: vec![5, 25],
+            meta_inner_instructions_present: true,
+            meta_inner_instructions_index: vec![0],
+            meta_inner_instructions_program_id_index: vec![vec![1]],
+            meta_inner_instructions_accounts: vec![vec![vec![0]]],
+            meta_inner_instructions_data: vec![vec![vec![1]]],
+            meta_inner_instructions_stack_height: vec![vec![Some(2)]],
+            meta_log_messages_present: true,
+            meta_log_messages: vec!["Program log: hi".to_string()],
+            meta_pre_token_balances_present: true,
+            meta_pre_token_account_index: vec![1],
+            meta_pre_token_mint: vec![[5u8; 32]],
+            meta_pre_token_owner: vec![Some([6u8; 32])],
+            meta_pre_token_program_id: vec![None],
+            meta_pre_token_amount: vec!["100".to_string()],
+            meta_pre_token_decimals: vec![6],
+            meta_pre_token_ui_amount: vec![Some(0.0001)],
+            meta_pre_token_ui_amount_string: vec!["0.0001".to_string()],
+            meta_post_token_balances_present: false,
+            meta_post_token_account_index: Vec::new(),
+            meta_post_token_mint: Vec::new(),
+            meta_post_token_owner: Vec::new(),
+            meta_post_token_program_id: Vec::new(),
+            meta_post_token_amount: Vec::new(),
+            meta_post_token_decimals: Vec::new(),
+            meta_post_token_ui_amount: Vec::new(),
+            meta_post_token_ui_amount_string: Vec::new(),
+            meta_rewards_present: false,
+            meta_reward_pubkey: Vec::new(),
+            meta_reward_lamports: Vec::new(),
+            meta_reward_post_balance: Vec::new(),
+            meta_reward_type: Vec::new(),
+            meta_reward_commission: Vec::new(),
+            meta_loaded_addresses_writable: vec![[11u8; 32]],
+            meta_loaded_addresses_readonly: Vec::new(),
+            meta_return_data_present: true,
+            meta_return_data_program_id: Some([12u8; 32]),
+            meta_return_data_data: Some(vec![1, 2, 3]),
+            meta_compute_units_consumed: Some(200_000),
+            meta_cost_units: Some(300),
+        };
+
+        let tx_bytes = bincode::serialize(&record).expect("serialize tx");
+        let decoded: StoredTransactionRecord = bincode::deserialize(&tx_bytes).expect("round trip");
+        assert_eq!(decoded.signature, record.signature);
+        assert_eq!(decoded.tx_signatures, record.tx_signatures);
+        assert_eq!(
+            fingerprint(&tx_bytes),
+            0x7448_21a9_4fd3_d7bb,
+            "tx layout drift"
+        );
+
+        let meta = BlockMetadataRecord {
+            slot: 123,
+            parent_slot: 122,
+            blockhash: [1u8; 32],
+            parent_blockhash: [2u8; 32],
+            block_time: Some(1_700_000_000),
+            block_height: Some(99),
+            executed_transaction_count: 2,
+            entry_count: 3,
+            rewards_present: true,
+            rewards_pubkey: vec![[3u8; 32]],
+            rewards_lamports: vec![55],
+            rewards_post_balance: vec![99],
+            rewards_type: vec![Some("Fee".to_string())],
+            rewards_commission: vec![Some(7)],
+            rewards_num_partitions: Some(4),
+        };
+        let meta_bytes = bincode::serialize(&meta).expect("serialize meta");
+        assert_eq!(
+            fingerprint(&meta_bytes),
+            0x3200_ea90_2cf4_50dc,
+            "block-meta layout drift"
+        );
+    }
+
+    /// FNV-1a, dependency-free stand-in for a real hash — stability is all that matters.
+    fn fingerprint(bytes: &[u8]) -> u64 {
+        let mut hash = 0xcbf2_9ce4_8422_2325u64;
+        for &byte in bytes {
+            hash ^= u64::from(byte);
+            hash = hash.wrapping_mul(0x100_0000_01b3);
+        }
+        hash
+    }
+}

--- a/crates/superbank-rpc/src/disk_cache/schema.rs
+++ b/crates/superbank-rpc/src/disk_cache/schema.rs
@@ -54,6 +54,15 @@ pub(crate) const COVERAGE_SOURCE_LIVE: u8 = 0;
 pub(crate) const COVERAGE_SOURCE_BACKFILL: u8 = 1;
 pub(crate) const COVERAGE_SOURCE_REPAIR: u8 = 2;
 
+pub(crate) fn coverage_source_label(source: u8) -> &'static str {
+    match source {
+        COVERAGE_SOURCE_LIVE => "live",
+        COVERAGE_SOURCE_BACKFILL => "backfill",
+        COVERAGE_SOURCE_REPAIR => "repair",
+        _ => "unknown",
+    }
+}
+
 #[inline]
 pub(crate) fn rev_slot(slot: u64) -> u64 {
     !slot

--- a/crates/superbank-rpc/src/disk_cache/writer.rs
+++ b/crates/superbank-rpc/src/disk_cache/writer.rs
@@ -65,6 +65,7 @@ impl DiskWriteSender {
                     slot,
                     "disk cache: live write queue full; deferring slot to repair"
                 );
+                crate::metrics::disk_cache_dropped_to_repair("queue_full");
                 self.repair.push(slot);
             }
             Err(TrySendError::Disconnected(_)) => {
@@ -205,12 +206,24 @@ fn write_one(
     if inner.covers_slot(slot) {
         return;
     }
-    if let Err(err) = inner.write_finalized_slot(&meta, &txs, source) {
-        warn!(
-            slot,
-            "disk cache: slot write failed ({err}); deferring to repair"
-        );
-        repair.push(slot);
+    let start = Instant::now();
+    match inner.write_finalized_slot(&meta, &txs, source) {
+        Ok(()) => {
+            crate::metrics::disk_cache_write(
+                schema::coverage_source_label(source),
+                txs.len() as u64,
+                start.elapsed().as_secs_f64(),
+            );
+        }
+        Err(err) => {
+            warn!(
+                slot,
+                "disk cache: slot write failed ({err}); deferring to repair"
+            );
+            crate::metrics::disk_cache_write_error();
+            crate::metrics::disk_cache_dropped_to_repair("write_error");
+            repair.push(slot);
+        }
     }
 }
 

--- a/crates/superbank-rpc/src/disk_cache/writer.rs
+++ b/crates/superbank-rpc/src/disk_cache/writer.rs
@@ -1,0 +1,398 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+/*
+ * Copyright 2025-2026 Triton One Limited. All rights reserved.
+ */
+
+//! Dedicated writer thread for the disk cache.
+//!
+//! All RocksDB writes flow through one OS thread (not `spawn_blocking`, so the
+//! shared blocking pool stays free for hydration work and watermark updates have
+//! a single owner). Two bounded channels feed it: `live` (finalized slots from
+//! the DragonsMouth stream; producers only ever `try_send` so the gRPC task can
+//! never block on disk) and `bulk` (backfill/repair batches). The loop drains
+//! live jobs fully before taking one bulk job, so the tip always wins.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, SyncSender, TrySendError, sync_channel};
+use std::time::{Duration, Instant};
+
+use tracing::{info, warn};
+
+use crate::clickhouse::{BlockMetadataRecord, StoredTransactionRecord};
+
+use super::ingest::RepairQueue;
+use super::{DiskCache, DiskCacheInner, schema};
+
+const EVICTION_TICK: Duration = Duration::from_secs(30);
+const RECV_TIMEOUT: Duration = Duration::from_millis(100);
+
+pub(crate) enum DiskWriteJob {
+    LiveSlot {
+        meta: Box<BlockMetadataRecord>,
+        txs: Vec<Arc<StoredTransactionRecord>>,
+    },
+    /// Backfill/repair batch; written in order, oldest within the batch first.
+    FillBatch {
+        source: u8,
+        blocks: Vec<(BlockMetadataRecord, Vec<Arc<StoredTransactionRecord>>)>,
+    },
+    Shutdown,
+}
+
+#[derive(Clone)]
+pub(crate) struct DiskWriteSender {
+    live: SyncSender<DiskWriteJob>,
+    repair: Arc<RepairQueue>,
+}
+
+impl DiskWriteSender {
+    /// Enqueue a finalized slot without ever blocking. A full queue routes the
+    /// slot to the repair queue (it will be refilled from ClickHouse).
+    pub(crate) fn send_live(
+        &self,
+        meta: BlockMetadataRecord,
+        txs: Vec<Arc<StoredTransactionRecord>>,
+    ) {
+        let slot = meta.slot;
+        match self.live.try_send(DiskWriteJob::LiveSlot {
+            meta: Box::new(meta),
+            txs,
+        }) {
+            Ok(()) => {}
+            Err(TrySendError::Full(_)) => {
+                warn!(
+                    slot,
+                    "disk cache: live write queue full; deferring slot to repair"
+                );
+                self.repair.push(slot);
+            }
+            Err(TrySendError::Disconnected(_)) => {
+                warn!(slot, "disk cache: writer is gone; dropping live slot");
+            }
+        }
+    }
+
+    pub(crate) fn send_shutdown(&self) {
+        let _ = self.live.try_send(DiskWriteJob::Shutdown);
+    }
+}
+
+pub(crate) struct DiskWriterHandle {
+    pub(crate) sender: DiskWriteSender,
+    pub(crate) bulk: SyncSender<DiskWriteJob>,
+    stop: Arc<AtomicBool>,
+    join: Option<std::thread::JoinHandle<()>>,
+}
+
+impl DiskWriterHandle {
+    /// Signal the writer and wait for it to drain and flush the WAL.
+    pub(crate) fn shutdown(mut self) {
+        self.stop.store(true, Ordering::Release);
+        self.sender.send_shutdown();
+        if let Some(join) = self.join.take()
+            && join.join().is_err()
+        {
+            warn!("disk cache: writer thread panicked during shutdown");
+        }
+    }
+}
+
+impl DiskCache {
+    pub(crate) fn spawn_writer(
+        &self,
+        repair: Arc<RepairQueue>,
+        live_queue_slots: usize,
+    ) -> DiskWriterHandle {
+        let (live_tx, live_rx) = sync_channel(live_queue_slots.max(1));
+        let (bulk_tx, bulk_rx) = sync_channel(2);
+        let stop = Arc::new(AtomicBool::new(false));
+
+        let inner = self.inner_arc();
+        let thread_stop = stop.clone();
+        let thread_repair = repair.clone();
+        let join = std::thread::Builder::new()
+            .name("superbank-disk-writer".to_string())
+            .spawn(move || writer_loop(inner, live_rx, bulk_rx, thread_repair, thread_stop))
+            .expect("spawn disk-cache writer thread");
+
+        DiskWriterHandle {
+            sender: DiskWriteSender {
+                live: live_tx,
+                repair,
+            },
+            bulk: bulk_tx,
+            stop,
+            join: Some(join),
+        }
+    }
+}
+
+fn writer_loop(
+    inner: Arc<DiskCacheInner>,
+    live_rx: Receiver<DiskWriteJob>,
+    bulk_rx: Receiver<DiskWriteJob>,
+    repair: Arc<RepairQueue>,
+    stop: Arc<AtomicBool>,
+) {
+    info!("disk cache: writer thread started");
+    let mut last_eviction = Instant::now();
+
+    'outer: loop {
+        if stop.load(Ordering::Acquire) {
+            break;
+        }
+
+        // Drain everything queued on the live channel first.
+        loop {
+            match live_rx.try_recv() {
+                Ok(DiskWriteJob::Shutdown) => break 'outer,
+                Ok(job) => handle_job(&inner, job, &repair),
+                Err(_) => break,
+            }
+        }
+
+        // At most one bulk job per round, so live slots never wait long.
+        match bulk_rx.try_recv() {
+            Ok(DiskWriteJob::Shutdown) => break 'outer,
+            Ok(job) => {
+                handle_job(&inner, job, &repair);
+                maybe_evict_tick(&inner, &mut last_eviction);
+                continue;
+            }
+            Err(_) => {}
+        }
+
+        match live_rx.recv_timeout(RECV_TIMEOUT) {
+            Ok(DiskWriteJob::Shutdown) => break,
+            Ok(job) => handle_job(&inner, job, &repair),
+            Err(RecvTimeoutError::Timeout) => {}
+            Err(RecvTimeoutError::Disconnected) => break,
+        }
+
+        maybe_evict_tick(&inner, &mut last_eviction);
+    }
+
+    if let Err(err) = inner.flush_wal() {
+        warn!("disk cache: WAL flush on shutdown failed: {err}");
+    }
+    info!("disk cache: writer thread stopped");
+}
+
+fn handle_job(inner: &DiskCacheInner, job: DiskWriteJob, repair: &RepairQueue) {
+    match job {
+        DiskWriteJob::LiveSlot { meta, txs } => {
+            write_one(inner, *meta, txs, schema::COVERAGE_SOURCE_LIVE, repair);
+        }
+        DiskWriteJob::FillBatch { source, blocks } => {
+            for (meta, txs) in blocks {
+                write_one(inner, meta, txs, source, repair);
+            }
+        }
+        DiskWriteJob::Shutdown => {}
+    }
+}
+
+fn write_one(
+    inner: &DiskCacheInner,
+    meta: BlockMetadataRecord,
+    txs: Vec<Arc<StoredTransactionRecord>>,
+    source: u8,
+    repair: &RepairQueue,
+) {
+    let slot = meta.slot;
+    // Reconnects replay finalized updates; coverage makes the write idempotent.
+    if inner.covers_slot(slot) {
+        return;
+    }
+    if let Err(err) = inner.write_finalized_slot(&meta, &txs, source) {
+        warn!(
+            slot,
+            "disk cache: slot write failed ({err}); deferring to repair"
+        );
+        repair.push(slot);
+    }
+}
+
+fn maybe_evict_tick(inner: &DiskCacheInner, last_eviction: &mut Instant) {
+    if last_eviction.elapsed() < EVICTION_TICK {
+        return;
+    }
+    *last_eviction = Instant::now();
+    match inner.maybe_evict() {
+        Ok(Some(stats)) => {
+            info!(
+                old_floor = stats.old_floor,
+                new_floor = stats.new_floor,
+                byte_budget_bound = stats.byte_budget_bound,
+                "disk cache: evicted slots below floor"
+            );
+        }
+        Ok(None) => {}
+        Err(err) => warn!("disk cache: eviction failed: {err}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use solana_commitment_config::CommitmentLevel;
+    use solana_sdk::{pubkey::Pubkey, signature::Signature};
+    use solana_transaction_status::TransactionDetails;
+
+    use crate::disk_cache::ingest::{DiskIngestSink, RepairQueue};
+    use crate::disk_cache::tests::{block_metadata, test_config, transaction};
+    use crate::disk_cache::{DiskBlockResult, DiskCache};
+    use crate::head_cache::HeadCache;
+
+    fn finalized_head_with_block(slot: u64, tx_count: u32) -> HeadCache {
+        let head = HeadCache::new(64, 64);
+        head.note_block_metadata(block_metadata(slot, slot - 1, u64::from(tx_count)));
+        for idx in 0..tx_count {
+            let record = transaction(slot, idx);
+            head.insert_for_tests(
+                Signature::from(record.signature),
+                record,
+                idx,
+                &[Pubkey::new_unique()],
+                CommitmentLevel::Finalized,
+            );
+        }
+        head
+    }
+
+    async fn wait_until(deadline: Duration, mut condition: impl FnMut() -> bool) -> bool {
+        let start = std::time::Instant::now();
+        while start.elapsed() < deadline {
+            if condition() {
+                return true;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        condition()
+    }
+
+    #[tokio::test]
+    async fn sink_writes_finalized_slot_through_writer() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = Arc::new(DiskCache::open(test_config(&dir)).expect("open"));
+        let repair = Arc::new(RepairQueue::new(100));
+        let handle = cache.spawn_writer(repair.clone(), 64);
+        let sink = DiskIngestSink::new(cache.clone(), handle.sender.clone(), repair.clone());
+
+        let head = finalized_head_with_block(100, 2);
+        sink.on_slot_finalized(100, &head);
+
+        assert!(
+            wait_until(Duration::from_secs(5), || cache.covers_slot(100)).await,
+            "writer should cover the slot"
+        );
+        match cache.get_block(100, TransactionDetails::Full).await {
+            DiskBlockResult::Found(payload) => {
+                assert_eq!(payload.observed_transaction_count(), Some(2));
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+
+        // Replayed finalized updates are no-ops.
+        sink.on_slot_finalized(100, &head);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(repair.len(), 0);
+
+        handle.shutdown();
+    }
+
+    #[tokio::test]
+    async fn incomplete_head_view_defers_to_repair() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = Arc::new(DiskCache::open(test_config(&dir)).expect("open"));
+        let repair = Arc::new(RepairQueue::new(100));
+        let handle = cache.spawn_writer(repair.clone(), 64);
+        let sink = DiskIngestSink::new(cache.clone(), handle.sender.clone(), repair.clone());
+
+        // Block meta claims 2 transactions but only 1 reached the head cache.
+        let head = HeadCache::new(64, 64);
+        head.note_block_metadata(block_metadata(200, 199, 2));
+        let record = transaction(200, 0);
+        head.insert_for_tests(
+            Signature::from(record.signature),
+            record,
+            0,
+            &[Pubkey::new_unique()],
+            CommitmentLevel::Finalized,
+        );
+
+        sink.on_slot_finalized(200, &head);
+        assert_eq!(repair.drain(10), vec![200]);
+        assert!(!cache.covers_slot(200));
+        handle.shutdown();
+    }
+
+    #[tokio::test]
+    async fn bulk_fill_batch_is_written() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache = Arc::new(DiskCache::open(test_config(&dir)).expect("open"));
+        let repair = Arc::new(RepairQueue::new(100));
+        let handle = cache.spawn_writer(repair.clone(), 64);
+
+        let blocks = (300..303u64)
+            .map(|slot| {
+                let txs = vec![Arc::new(transaction(slot, 0))];
+                (block_metadata(slot, slot - 1, 1), txs)
+            })
+            .collect();
+        handle
+            .bulk
+            .send(super::DiskWriteJob::FillBatch {
+                source: crate::disk_cache::schema::COVERAGE_SOURCE_BACKFILL,
+                blocks,
+            })
+            .expect("send bulk");
+
+        assert!(
+            wait_until(Duration::from_secs(5), || cache.covers_slot(302)).await,
+            "bulk batch should land"
+        );
+        assert!(cache.covers_slot(300) && cache.covers_slot(301));
+        handle.shutdown();
+    }
+
+    #[test]
+    fn finalized_block_snapshot_orders_and_validates() {
+        let head = HeadCache::new(64, 64);
+        head.note_block_metadata(block_metadata(300, 299, 2));
+        let tx_late = transaction(300, 5);
+        let tx_early = transaction(300, 2);
+        head.insert_for_tests(
+            Signature::from(tx_late.signature),
+            tx_late,
+            5,
+            &[Pubkey::new_unique()],
+            CommitmentLevel::Finalized,
+        );
+        head.insert_for_tests(
+            Signature::from(tx_early.signature),
+            tx_early,
+            2,
+            &[Pubkey::new_unique()],
+            CommitmentLevel::Finalized,
+        );
+
+        let (meta, records) = head.finalized_block_snapshot(300).expect("snapshot");
+        assert_eq!(meta.slot, 300);
+        let indexes: Vec<u32> = records.iter().map(|record| record.slot_idx).collect();
+        assert_eq!(indexes, vec![2, 5]);
+
+        // Unknown slot and incomplete blocks are not snapshottable.
+        assert!(head.finalized_block_snapshot(301).is_none());
+        head.note_block_metadata(block_metadata(302, 301, 3));
+        assert!(head.finalized_block_snapshot(302).is_none());
+
+        // Zero-transaction blocks are.
+        head.note_block_metadata(block_metadata(303, 302, 0));
+        let (_, records) = head.finalized_block_snapshot(303).expect("snapshot");
+        assert!(records.is_empty());
+    }
+}

--- a/crates/superbank-rpc/src/handlers/blocks.rs
+++ b/crates/superbank-rpc/src/handlers/blocks.rs
@@ -224,23 +224,64 @@ async fn get_block_slots_response_for_range(
     #[cfg(not(feature = "grpc-head-cache"))]
     let _ = commitment;
 
+    // Disk tier: the contiguous covered span answers its part of the range, so
+    // ClickHouse is only consulted below the coverage floor and above the
+    // covered head (the latter matters when disk writes lag the chain tip).
+    #[cfg(feature = "disk-cache")]
+    let (disk_slots, disk_span): (Vec<u64>, Option<(u64, u64)>) =
+        if let Some(disk) = state.disk_cache.as_ref() {
+            route.disk_cache_read();
+            match disk.tip_span() {
+                Some((floor, head)) if end_slot >= floor && start_slot <= head => {
+                    match disk
+                        .covered_slots_in_range(start_slot.max(floor), end_slot.min(head))
+                        .await
+                    {
+                        Some(slots) => (slots, Some((floor, head))),
+                        None => (Vec::new(), None),
+                    }
+                }
+                _ => (Vec::new(), None),
+            }
+        } else {
+            (Vec::new(), None)
+        };
+    #[cfg(not(feature = "disk-cache"))]
+    let (disk_slots, disk_span): (Vec<u64>, Option<(u64, u64)>) = (Vec::new(), None);
+
+    let disk_contributed = disk_span.is_some();
+    let mut clickhouse_ranges: Vec<(u64, u64)> = Vec::new();
+    match disk_span {
+        Some((floor, head)) => {
+            if start_slot < floor {
+                clickhouse_ranges.push((start_slot, end_slot.min(floor.saturating_sub(1))));
+            }
+            if end_slot > head {
+                clickhouse_ranges.push((start_slot.max(head + 1), end_slot));
+            }
+        }
+        None => clickhouse_ranges.push((start_slot, end_slot)),
+    }
+
     let mut clickhouse_slots = Vec::new();
     let mut clickhouse_read = false;
     let mut clickhouse_error: Option<String> = None;
 
-    match state
-        .clickhouse
-        .get_block_slots_by_range(start_slot, end_slot)
-        .await
-    {
-        Ok((slots, query_timings)) => {
-            clickhouse_slots = slots;
-            clickhouse_read = true;
-            timings.add(query_timings);
-        }
-        Err(e) => {
-            metrics::backend_error("get_block_slots_by_range");
-            clickhouse_error = Some(e.to_string());
+    for (range_start, range_end) in clickhouse_ranges {
+        match state
+            .clickhouse
+            .get_block_slots_by_range(range_start, range_end)
+            .await
+        {
+            Ok((slots, query_timings)) => {
+                clickhouse_slots = merge_sorted_block_slots(clickhouse_slots, slots);
+                clickhouse_read = true;
+                timings.add(query_timings);
+            }
+            Err(e) => {
+                metrics::backend_error("get_block_slots_by_range");
+                clickhouse_error = Some(e.to_string());
+            }
         }
     }
 
@@ -258,7 +299,7 @@ async fn get_block_slots_response_for_range(
     let head_contributed = !head_slots.is_empty();
 
     if let Some(err) = clickhouse_error {
-        if !head_contributed {
+        if !head_contributed && !disk_contributed {
             error!(
                 "Failed to query ClickHouse for block slots {}..={}: {}",
                 start_slot, end_slot, err
@@ -267,13 +308,16 @@ async fn get_block_slots_response_for_range(
         }
 
         warn!(
-            "Falling back to head-cache-only slots for range {}..={} after ClickHouse error: {}",
+            "Serving cache-only slots for range {}..={} after ClickHouse error: {}",
             start_slot, end_slot, err
         );
     }
 
     if clickhouse_read {
         route.source_clickhouse();
+    } else if disk_contributed {
+        #[cfg(feature = "disk-cache")]
+        route.source_disk_cache();
     } else if head_contributed {
         #[cfg(feature = "grpc-head-cache")]
         route.source_head_cache();
@@ -281,7 +325,10 @@ async fn get_block_slots_response_for_range(
         route.source_none();
     }
 
-    let slots = merge_sorted_block_slots(clickhouse_slots, head_slots);
+    let slots = merge_sorted_block_slots(
+        merge_sorted_block_slots(clickhouse_slots, disk_slots),
+        head_slots,
+    );
     metrics::blocks_slots_returned(route.method(), slots.len());
     route.success();
     let mut resp = json_rpc_success_response(id, slots);
@@ -976,6 +1023,113 @@ pub(crate) async fn handle_get_latest_blockhash(
     Ok(resp)
 }
 
+/// Hydrate a block payload and build the JSON-RPC response; shared by the
+/// head-cache, disk-cache, and ClickHouse branches of getBlock.
+async fn respond_with_hydrated_block(
+    state: &AppState,
+    id: Value,
+    route: &mut RouteMetric,
+    slot: u64,
+    payload: StoredBlockPayload,
+    fetch_plan: GetBlockFetchPlan,
+    timings: Option<QueryTimings>,
+) -> Result<Response, StatusCode> {
+    if payload.metadata().slot != slot {
+        warn!(
+            requested = slot,
+            observed = payload.metadata().slot,
+            "Block metadata slot mismatch"
+        );
+    }
+    if let Some(observed) = block_payload_transaction_count(&payload)
+        && payload.metadata().executed_transaction_count != observed as u64
+    {
+        warn!(
+            slot,
+            expected = payload.metadata().executed_transaction_count,
+            observed = observed,
+            entry_count = payload.metadata().entry_count,
+            "Block transaction count mismatch"
+        );
+    }
+
+    let attach_timings = |resp: &mut Response| {
+        if let Some(timings) = timings.as_ref() {
+            add_downstream_header(resp, timings);
+        }
+    };
+
+    let hydrated = if fetch_plan.needs_blocking_hydration() {
+        let permit = match state.hydration_sem.clone().acquire_owned().await {
+            Ok(permit) => permit,
+            Err(_) => {
+                error!(slot, "Hydration semaphore closed");
+                let mut resp = json_rpc_internal_error_response(id);
+                attach_timings(&mut resp);
+                return Ok(resp);
+            }
+        };
+        match tokio::task::spawn_blocking(move || {
+            let _permit = permit;
+            hydrate_block_payload(
+                payload,
+                fetch_plan.encoding,
+                fetch_plan.transaction_details,
+                fetch_plan.show_rewards,
+                fetch_plan.max_supported_transaction_version,
+            )
+        })
+        .await
+        {
+            Ok(result) => result,
+            Err(join_err) => {
+                error!(
+                    "Failed to join hydration task for block {}: {}",
+                    slot, join_err
+                );
+                let mut resp = json_rpc_internal_error_response(id);
+                attach_timings(&mut resp);
+                return Ok(resp);
+            }
+        }
+    } else {
+        hydrate_block_payload(
+            payload,
+            fetch_plan.encoding,
+            fetch_plan.transaction_details,
+            fetch_plan.show_rewards,
+            fetch_plan.max_supported_transaction_version,
+        )
+    };
+
+    match hydrated {
+        Ok(encoded_block) => {
+            route.success();
+            let mut resp = json_rpc_success_response(id, encoded_block);
+            attach_timings(&mut resp);
+            Ok(resp)
+        }
+        Err(BlockHydrationError::Encode(EncodeError::UnsupportedTransactionVersion(version))) => {
+            route.rpc_error();
+            let code = JSON_RPC_SERVER_ERROR_UNSUPPORTED_TRANSACTION_VERSION as i32;
+            let mut resp = json_rpc_error_response(
+                id,
+                code,
+                unsupported_transaction_version_message(version),
+                None,
+            );
+            attach_timings(&mut resp);
+            Ok(resp)
+        }
+        Err(e) => {
+            error!("Failed to hydrate block {}: {}", slot, e);
+            let mut resp = json_rpc_internal_error_response(id);
+            attach_timings(&mut resp);
+            Ok(resp)
+        }
+    }
+}
+
 pub(crate) async fn handle_get_block(
     state: Arc<AppState>,
     id: Value,
@@ -1076,85 +1230,51 @@ pub(crate) async fn handle_get_block(
             }
 
             route.source_head_cache();
-            if fetch_plan.needs_blocking_hydration() {
-                let permit = match state.hydration_sem.clone().acquire_owned().await {
-                    Ok(permit) => permit,
-                    Err(_) => {
-                        error!(slot, "Hydration semaphore closed");
-                        return Ok(json_rpc_internal_error_response(id));
-                    }
-                };
-
-                match tokio::task::spawn_blocking(move || {
-                    let _permit = permit;
-                    hydrate_block_payload(
-                        payload,
-                        fetch_plan.encoding,
-                        fetch_plan.transaction_details,
-                        fetch_plan.show_rewards,
-                        fetch_plan.max_supported_transaction_version,
-                    )
-                })
-                .await
-                {
-                    Ok(Ok(encoded_block)) => {
-                        route.success();
-                        return Ok(json_rpc_success_response(id, encoded_block));
-                    }
-                    Ok(Err(BlockHydrationError::Encode(
-                        EncodeError::UnsupportedTransactionVersion(version),
-                    ))) => {
-                        route.rpc_error();
-                        let code = JSON_RPC_SERVER_ERROR_UNSUPPORTED_TRANSACTION_VERSION as i32;
-                        return Ok(json_rpc_error_response(
-                            id,
-                            code,
-                            unsupported_transaction_version_message(version),
-                            None,
-                        ));
-                    }
-                    Ok(Err(e)) => {
-                        error!("Failed to hydrate head-cache block {}: {}", slot, e);
-                        return Ok(json_rpc_internal_error_response(id));
-                    }
-                    Err(join_err) => {
-                        error!(
-                            "Failed to join hydration task for head-cache block {}: {}",
-                            slot, join_err
-                        );
-                        return Ok(json_rpc_internal_error_response(id));
-                    }
-                }
-            }
-
-            match hydrate_block_payload(
+            return respond_with_hydrated_block(
+                state.as_ref(),
+                id,
+                &mut route,
+                slot,
                 payload,
-                fetch_plan.encoding,
-                fetch_plan.transaction_details,
-                fetch_plan.show_rewards,
-                fetch_plan.max_supported_transaction_version,
-            ) {
-                Ok(encoded_block) => {
-                    route.success();
-                    return Ok(json_rpc_success_response(id, encoded_block));
-                }
-                Err(BlockHydrationError::Encode(EncodeError::UnsupportedTransactionVersion(
-                    version,
-                ))) => {
-                    route.rpc_error();
-                    let code = JSON_RPC_SERVER_ERROR_UNSUPPORTED_TRANSACTION_VERSION as i32;
-                    return Ok(json_rpc_error_response(
-                        id,
-                        code,
-                        unsupported_transaction_version_message(version),
-                        None,
-                    ));
-                }
-                Err(e) => {
-                    error!("Failed to hydrate head-cache block {}: {}", slot, e);
-                    return Ok(json_rpc_internal_error_response(id));
-                }
+                fetch_plan,
+                None,
+            )
+            .await;
+        }
+    }
+
+    // Disk tier: serves any individually covered slot (all stored data is
+    // finalized, satisfying the confirmed/finalized commitments accepted
+    // above). A Skipped marker is proof the slot has no block on the finalized
+    // chain, so the miss is answered without ClickHouse.
+    #[cfg(feature = "disk-cache")]
+    if let Some(disk) = state.disk_cache.as_ref() {
+        route.disk_cache_read();
+        match disk.get_block(slot, fetch_plan.transaction_details).await {
+            crate::disk_cache::DiskBlockResult::Found(payload) => {
+                route.source_disk_cache();
+                return respond_with_hydrated_block(
+                    state.as_ref(),
+                    id,
+                    &mut route,
+                    slot,
+                    *payload,
+                    fetch_plan,
+                    None,
+                )
+                .await;
             }
+            crate::disk_cache::DiskBlockResult::Skipped => {
+                route.source_disk_cache();
+                route.not_found();
+                return Ok(json_rpc_error_response(
+                    id,
+                    JSON_RPC_SERVER_ERROR_LONG_TERM_STORAGE_SLOT_SKIPPED as i32,
+                    format!("Slot {slot} was skipped, or missing in long-term storage"),
+                    None,
+                ));
+            }
+            crate::disk_cache::DiskBlockResult::NotCovered => {}
         }
     }
 
@@ -1273,121 +1393,16 @@ pub(crate) async fn handle_get_block(
         return Ok(resp);
     };
 
-    if block_payload.metadata().slot != slot {
-        warn!(
-            requested = slot,
-            observed = block_payload.metadata().slot,
-            "Block metadata slot mismatch"
-        );
-    }
-
-    if let Some(observed) = block_payload_transaction_count(&block_payload)
-        && block_payload.metadata().executed_transaction_count != observed as u64
-    {
-        warn!(
-            slot,
-            expected = block_payload.metadata().executed_transaction_count,
-            observed = observed,
-            entry_count = block_payload.metadata().entry_count,
-            "Block transaction count mismatch"
-        );
-    }
-
-    if fetch_plan.needs_blocking_hydration() {
-        let permit = match state.hydration_sem.clone().acquire_owned().await {
-            Ok(permit) => permit,
-            Err(_) => {
-                error!(slot, "Hydration semaphore closed");
-                let mut resp = json_rpc_internal_error_response(id);
-                add_downstream_header(&mut resp, &timings);
-                return Ok(resp);
-            }
-        };
-
-        match tokio::task::spawn_blocking(move || {
-            let _permit = permit;
-            hydrate_block_payload(
-                block_payload,
-                fetch_plan.encoding,
-                fetch_plan.transaction_details,
-                fetch_plan.show_rewards,
-                fetch_plan.max_supported_transaction_version,
-            )
-        })
-        .await
-        {
-            Ok(Ok(encoded_block)) => {
-                route.success();
-                let mut resp = json_rpc_success_response(id, encoded_block);
-                add_downstream_header(&mut resp, &timings);
-                Ok(resp)
-            }
-            Ok(Err(BlockHydrationError::Encode(EncodeError::UnsupportedTransactionVersion(
-                version,
-            )))) => {
-                route.rpc_error();
-                let code = JSON_RPC_SERVER_ERROR_UNSUPPORTED_TRANSACTION_VERSION as i32;
-                let mut resp = json_rpc_error_response(
-                    id,
-                    code,
-                    unsupported_transaction_version_message(version),
-                    None,
-                );
-                add_downstream_header(&mut resp, &timings);
-                Ok(resp)
-            }
-            Ok(Err(e)) => {
-                error!("Failed to hydrate block {}: {}", slot, e);
-                let mut resp = json_rpc_internal_error_response(id);
-                add_downstream_header(&mut resp, &timings);
-                Ok(resp)
-            }
-            Err(join_err) => {
-                error!(
-                    "Failed to join hydration task for block {}: {}",
-                    slot, join_err
-                );
-                let mut resp = json_rpc_internal_error_response(id);
-                add_downstream_header(&mut resp, &timings);
-                Ok(resp)
-            }
-        }
-    } else {
-        match hydrate_block_payload(
-            block_payload,
-            fetch_plan.encoding,
-            fetch_plan.transaction_details,
-            fetch_plan.show_rewards,
-            fetch_plan.max_supported_transaction_version,
-        ) {
-            Ok(encoded_block) => {
-                route.success();
-                let mut resp = json_rpc_success_response(id, encoded_block);
-                add_downstream_header(&mut resp, &timings);
-                Ok(resp)
-            }
-            Err(BlockHydrationError::Encode(EncodeError::UnsupportedTransactionVersion(
-                version,
-            ))) => {
-                route.rpc_error();
-                let code = JSON_RPC_SERVER_ERROR_UNSUPPORTED_TRANSACTION_VERSION as i32;
-                let mut resp = json_rpc_error_response(
-                    id,
-                    code,
-                    unsupported_transaction_version_message(version),
-                    None,
-                );
-                add_downstream_header(&mut resp, &timings);
-                Ok(resp)
-            }
-            Err(e) => {
-                error!("Failed to hydrate block {}: {}", slot, e);
-                let mut resp = json_rpc_internal_error_response(id);
-                add_downstream_header(&mut resp, &timings);
-                Ok(resp)
-            }
-        }
-    }
+    respond_with_hydrated_block(
+        state.as_ref(),
+        id,
+        &mut route,
+        slot,
+        block_payload,
+        fetch_plan,
+        Some(timings),
+    )
+    .await
 }
 
 pub(crate) async fn handle_get_block_time(
@@ -1450,6 +1465,34 @@ pub(crate) async fn handle_get_block_time(
             route.source_head_cache();
             route.success();
             return Ok(json_rpc_success_response(id, json!(block_time)));
+        }
+    }
+
+    // Disk tier: a covered slot answers conclusively (including a stored NULL
+    // block time); a Skipped marker proves the slot has no block.
+    #[cfg(feature = "disk-cache")]
+    if let Some(disk) = state.disk_cache.as_ref() {
+        route.disk_cache_read();
+        match disk.block_time_for_slot(slot).await {
+            crate::disk_cache::DiskBlockTime::Found(block_time) => {
+                route.source_disk_cache();
+                route.success();
+                return Ok(match block_time {
+                    Some(value) => json_rpc_success_response(id, json!(value)),
+                    None => json_rpc_null_response(id),
+                });
+            }
+            crate::disk_cache::DiskBlockTime::Skipped => {
+                route.source_disk_cache();
+                route.not_found();
+                return Ok(json_rpc_error_response(
+                    id,
+                    -32009,
+                    format!("Slot {slot} was skipped, or missing in long-term storage"),
+                    None,
+                ));
+            }
+            crate::disk_cache::DiskBlockTime::NotCovered => {}
         }
     }
 

--- a/crates/superbank-rpc/src/handlers/mod.rs
+++ b/crates/superbank-rpc/src/handlers/mod.rs
@@ -41,6 +41,8 @@ pub(crate) const ROUTE_SOURCE_NONE: &str = "none";
 pub(crate) const ROUTE_SOURCE_CLICKHOUSE: &str = "clickhouse";
 #[cfg(feature = "grpc-head-cache")]
 pub(crate) const ROUTE_SOURCE_HEAD_CACHE: &str = "head_cache";
+#[cfg(feature = "disk-cache")]
+pub(crate) const ROUTE_SOURCE_DISK_CACHE: &str = "disk_cache";
 pub(crate) const ROUTE_OUTCOME_SUCCESS: &str = "success";
 pub(crate) const ROUTE_OUTCOME_NOT_FOUND: &str = "not_found";
 pub(crate) const ROUTE_OUTCOME_INVALID_PARAMS: &str = "invalid_params";
@@ -54,6 +56,8 @@ const HEADER_X_SUBSCRIPTION_ID: &str = "X-Subscription-ID";
 const HEADER_X_ACCOUNT_ID: &str = "X-Account-ID";
 const SOURCE_TOUCHED_CLICKHOUSE_BIT: u8 = 0b0000_0001;
 const SOURCE_TOUCHED_HEAD_CACHE_BIT: u8 = 0b0000_0010;
+#[cfg(feature = "disk-cache")]
+const SOURCE_TOUCHED_DISK_CACHE_BIT: u8 = 0b0000_0100;
 
 #[derive(Debug, Default)]
 struct ResponseHeaderMetricsContext {
@@ -83,6 +87,12 @@ impl ResponseHeaderMetricsContext {
     fn mark_head_cache_source_touched(&self) {
         self.source_touched_bits
             .fetch_or(SOURCE_TOUCHED_HEAD_CACHE_BIT, Ordering::Relaxed);
+    }
+
+    #[cfg(feature = "disk-cache")]
+    fn mark_disk_cache_source_touched(&self) {
+        self.source_touched_bits
+            .fetch_or(SOURCE_TOUCHED_DISK_CACHE_BIT, Ordering::Relaxed);
     }
 
     fn observe_clickhouse_timings(&self, timings: &QueryTimings) {
@@ -165,6 +175,13 @@ fn mark_head_cache_source_touched() {
     }
 }
 
+#[cfg(feature = "disk-cache")]
+fn mark_disk_cache_source_touched() {
+    if let Some(context) = current_response_header_metrics_context() {
+        context.mark_disk_cache_source_touched();
+    }
+}
+
 fn observe_clickhouse_timings(timings: &QueryTimings) {
     if let Some(context) = current_response_header_metrics_context() {
         let has_clickhouse_signal = timings.elapsed_ms > 0
@@ -184,11 +201,20 @@ fn observe_clickhouse_timings(timings: &QueryTimings) {
 fn sources_touched_header_value(source_touched_bits: u8) -> &'static str {
     let clickhouse = (source_touched_bits & SOURCE_TOUCHED_CLICKHOUSE_BIT) != 0;
     let head_cache = (source_touched_bits & SOURCE_TOUCHED_HEAD_CACHE_BIT) != 0;
-    match (head_cache, clickhouse) {
-        (false, false) => "none",
-        (true, false) => "head-cache",
-        (false, true) => "clickhouse",
-        (true, true) => "both",
+    #[cfg(feature = "disk-cache")]
+    let disk_cache = (source_touched_bits & SOURCE_TOUCHED_DISK_CACHE_BIT) != 0;
+    #[cfg(not(feature = "disk-cache"))]
+    let disk_cache = false;
+    match (head_cache, disk_cache, clickhouse) {
+        (false, false, false) => "none",
+        (true, false, false) => "head-cache",
+        (false, false, true) => "clickhouse",
+        // Legacy value, kept for header consumers that predate the disk cache.
+        (true, false, true) => "both",
+        (false, true, false) => "disk-cache",
+        (false, true, true) => "disk-cache,clickhouse",
+        (true, true, false) => "head-cache,disk-cache",
+        (true, true, true) => "all",
     }
 }
 
@@ -272,6 +298,7 @@ pub(crate) struct RouteMetric {
     scope: &'static str,
     source: &'static str,
     head_cache_read: bool,
+    disk_cache_read: bool,
     outcome: &'static str,
     started: Instant,
     timeout: std::time::Duration,
@@ -291,6 +318,7 @@ impl RouteMetric {
             scope,
             source: ROUTE_SOURCE_NONE,
             head_cache_read: false,
+            disk_cache_read: false,
             outcome: ROUTE_OUTCOME_BACKEND_ERROR,
             started: Instant::now(),
             timeout: state.rpc_request_timeout,
@@ -335,6 +363,19 @@ impl RouteMetric {
         self.head_cache_read = true;
     }
 
+    #[cfg(feature = "disk-cache")]
+    pub(crate) fn source_disk_cache(&mut self) {
+        mark_disk_cache_source_touched();
+        self.source = ROUTE_SOURCE_DISK_CACHE;
+        self.disk_cache_read = true;
+    }
+
+    #[cfg(feature = "disk-cache")]
+    pub(crate) fn disk_cache_read(&mut self) {
+        mark_disk_cache_source_touched();
+        self.disk_cache_read = true;
+    }
+
     pub(crate) fn success(&mut self) {
         self.outcome = ROUTE_OUTCOME_SUCCESS;
     }
@@ -371,6 +412,7 @@ impl Drop for RouteMetric {
             scope: self.scope,
             source: self.source,
             head_cache_read: self.head_cache_read,
+            disk_cache_read: self.disk_cache_read,
             outcome,
             x_endpoint: self.x_endpoint.as_deref(),
             x_rpc_node: self.x_rpc_node.as_deref(),

--- a/crates/superbank-rpc/src/handlers/mod.rs
+++ b/crates/superbank-rpc/src/handlers/mod.rs
@@ -777,7 +777,7 @@ async fn dispatch_json_rpc_request(
     let id_for_dispatch = id.clone();
     let params = req.params;
     let method_str = method.as_str();
-    let dispatch = async {
+    let dispatch = Box::pin(async {
         match method_str {
             "getSignaturesForAddress" => {
                 signatures::handle_get_signatures_for_address(state, id_for_dispatch, params).await
@@ -825,7 +825,7 @@ async fn dispatch_json_rpc_request(
                 None,
             )),
         }
-    };
+    });
     let result = if let Some(timeout) = timeout {
         match tokio::time::timeout(timeout, dispatch).await {
             Ok(result) => result,
@@ -988,7 +988,11 @@ async fn handle_single_request(
     let dispatch_request = request.into_dispatch_request();
     let response = metrics::with_request_metric_labels(
         request_metric_labels,
-        dispatch_json_rpc_request(state, dispatch_request, Some(timeout)),
+        Box::pin(dispatch_json_rpc_request(
+            state,
+            dispatch_request,
+            Some(timeout),
+        )),
     )
     .await?;
     Ok(response)
@@ -1028,7 +1032,7 @@ async fn execute_batch_requests(
                         response_header_metrics_context,
                         metrics::with_request_metric_labels(
                             request_metric_labels,
-                            dispatch_json_rpc_request(state, dispatch_request, None),
+                            Box::pin(dispatch_json_rpc_request(state, dispatch_request, None)),
                         ),
                     )
                     .await

--- a/crates/superbank-rpc/src/handlers/signatures.rs
+++ b/crates/superbank-rpc/src/handlers/signatures.rs
@@ -369,6 +369,21 @@ pub(crate) async fn handle_get_signature_statuses(
     Ok(resp)
 }
 
+/// Tighter of the caller's `before` bound and the disk coverage floor: the
+/// ClickHouse remainder must stay strictly below the floor (the disk page has
+/// already evaluated everything at or above it).
+#[cfg(feature = "disk-cache")]
+fn clamp_before_to_floor(before: Option<SlotBoundary>, floor: u64) -> SlotBoundary {
+    match before {
+        None => SlotBoundary::Slot(floor),
+        Some(SlotBoundary::Slot(slot)) => SlotBoundary::Slot(slot.min(floor)),
+        Some(SlotBoundary::Position(position)) if position.slot < floor => {
+            SlotBoundary::Position(position)
+        }
+        Some(SlotBoundary::Position(_)) => SlotBoundary::Slot(floor),
+    }
+}
+
 pub(crate) async fn handle_get_signatures_for_address(
     state: Arc<AppState>,
     id: Value,
@@ -618,6 +633,15 @@ pub(crate) async fn handle_get_signatures_for_address(
                 });
             }
 
+            #[cfg(feature = "disk-cache")]
+            if pos.is_none()
+                && let Some(disk) = state.disk_cache.as_ref()
+                && let Ok(sig) = Signature::from_str(sig_str)
+            {
+                route.disk_cache_read();
+                pos = disk.signature_position(sig).await;
+            }
+
             if pos.is_none() {
                 route.source_clickhouse();
                 match state.clickhouse.get_signature_slot(sig_str).await {
@@ -653,6 +677,15 @@ pub(crate) async fn handle_get_signatures_for_address(
                         slot: head_pos.slot,
                         slot_idx: head_pos.idx,
                     });
+                }
+
+                #[cfg(feature = "disk-cache")]
+                if pos.is_none()
+                    && let Some(disk) = state.disk_cache.as_ref()
+                    && let Ok(sig) = Signature::from_str(sig_str)
+                {
+                    route.disk_cache_read();
+                    pos = disk.signature_position(sig).await;
                 }
 
                 if pos.is_none() {
@@ -717,33 +750,68 @@ pub(crate) async fn handle_get_signatures_for_address(
             confirmation_status: String,
         }
 
-        route.source_clickhouse();
-        let (signatures, mut timings) = match state
-            .clickhouse
-            .get_signatures_for_address_with_positions(
-                address,
-                limit,
-                before_boundary,
-                until_boundary,
-            )
-            .await
-        {
-            Ok(result) => result,
-            Err(e) => {
-                metrics::backend_error("get_signatures_for_address_with_positions");
-                error!("Failed to query ClickHouse: {}", e);
-                route.rpc_error();
-                return Ok(json_rpc_long_term_storage_unreachable_response(id));
+        // Disk tier: newest-first page over the contiguous covered span. The
+        // page tells us whether ClickHouse still owes the remainder below the
+        // coverage floor — and when it does, the ClickHouse bound is clamped
+        // strictly below the floor so the tiers can never overlap.
+        #[cfg(feature = "disk-cache")]
+        let disk_page = match state.disk_cache.as_ref() {
+            Some(disk) => {
+                route.disk_cache_read();
+                disk.signatures_for_address(
+                    address_pubkey,
+                    before_boundary,
+                    until_boundary,
+                    limit as usize,
+                )
+                .await
+            }
+            None => None,
+        };
+
+        #[cfg(feature = "disk-cache")]
+        let (skip_clickhouse, clickhouse_before, clickhouse_limit) = match disk_page.as_ref() {
+            Some(page) if !page.reached_floor => (true, before_boundary, 0),
+            Some(page) => (
+                false,
+                Some(clamp_before_to_floor(before_boundary, page.floor)),
+                limit - page.records.len() as u64,
+            ),
+            None => (false, before_boundary, limit),
+        };
+        #[cfg(not(feature = "disk-cache"))]
+        let (skip_clickhouse, clickhouse_before, clickhouse_limit) =
+            (false, before_boundary, limit);
+
+        let (signatures, mut timings) = if skip_clickhouse {
+            (Vec::new(), crate::clickhouse::QueryTimings::zero())
+        } else {
+            route.source_clickhouse();
+            match state
+                .clickhouse
+                .get_signatures_for_address_with_positions(
+                    address,
+                    clickhouse_limit,
+                    clickhouse_before,
+                    until_boundary,
+                )
+                .await
+            {
+                Ok(result) => result,
+                Err(e) => {
+                    metrics::backend_error("get_signatures_for_address_with_positions");
+                    error!("Failed to query ClickHouse: {}", e);
+                    route.rpc_error();
+                    return Ok(json_rpc_long_term_storage_unreachable_response(id));
+                }
             }
         };
 
         timings.add(precheck_timings);
-        if signatures.is_empty() && !head_metas.is_empty() {
-            route.source_head_cache();
-        }
 
         let mut seen = HashSet::new();
         let mut merged = Vec::with_capacity(signatures.len() + head_metas.len());
+        let clickhouse_contributed = !signatures.is_empty();
         for sig in signatures {
             seen.insert(sig.signature.clone());
             merged.push(MergedSignature {
@@ -755,6 +823,39 @@ pub(crate) async fn handle_get_signatures_for_address(
                 block_time: sig.block_time,
                 confirmation_status: "finalized".to_string(),
             });
+        }
+
+        #[cfg(feature = "disk-cache")]
+        let disk_contributed = {
+            let mut contributed = false;
+            if let Some(page) = disk_page {
+                for record in page.records {
+                    if seen.insert(record.signature.clone()) {
+                        contributed = true;
+                        merged.push(MergedSignature {
+                            signature: record.signature,
+                            slot: record.slot,
+                            slot_idx: record.slot_idx,
+                            err: record.err,
+                            memo: record.memo,
+                            block_time: record.block_time,
+                            confirmation_status: "finalized".to_string(),
+                        });
+                    }
+                }
+            }
+            contributed
+        };
+        #[cfg(not(feature = "disk-cache"))]
+        let disk_contributed = false;
+
+        if !clickhouse_contributed {
+            if disk_contributed {
+                #[cfg(feature = "disk-cache")]
+                route.source_disk_cache();
+            } else if !head_metas.is_empty() {
+                route.source_head_cache();
+            }
         }
 
         for meta in head_metas {

--- a/crates/superbank-rpc/src/handlers/signatures.rs
+++ b/crates/superbank-rpc/src/handlers/signatures.rs
@@ -190,6 +190,49 @@ pub(crate) async fn handle_get_signature_statuses(
         }
     };
 
+    // Disk tier: finalized statuses for signatures the head cache does not hold.
+    // A disk miss proves nothing (the signature may predate the window), so the
+    // remainder still goes to ClickHouse.
+    #[cfg(feature = "disk-cache")]
+    let disk_statuses: HashMap<String, (u64, Option<Value>)> =
+        if let Some(disk) = state.disk_cache.as_ref() {
+            let pending: Vec<(String, Signature)> = unique_valid
+                .iter()
+                .filter(|sig_str| !head_statuses.contains_key(*sig_str))
+                .filter_map(|sig_str| {
+                    Signature::from_str(sig_str)
+                        .ok()
+                        .map(|sig| (sig_str.clone(), sig))
+                })
+                .collect();
+            if pending.is_empty() {
+                HashMap::new()
+            } else {
+                route.disk_cache_read();
+                let signatures: Vec<Signature> = pending.iter().map(|(_, sig)| *sig).collect();
+                let statuses = disk.get_sig_statuses(signatures).await;
+                pending
+                    .into_iter()
+                    .zip(statuses)
+                    .filter_map(|((sig_str, _), status)| {
+                        status.map(|status| {
+                            let err = status
+                                .err
+                                .and_then(|raw| crate::clickhouse::parse_err_json(&sig_str, raw));
+                            (sig_str, (status.slot, err))
+                        })
+                    })
+                    .collect()
+            }
+        } else {
+            HashMap::new()
+        };
+
+    #[cfg(feature = "disk-cache")]
+    let in_disk = |sig: &String| disk_statuses.contains_key(sig);
+    #[cfg(not(feature = "disk-cache"))]
+    let in_disk = |_sig: &String| false;
+
     let mut timings: Option<crate::clickhouse::QueryTimings> = None;
     let status_map: HashMap<String, SignatureStatusRecord> = if unique_valid.is_empty() {
         HashMap::new()
@@ -197,11 +240,15 @@ pub(crate) async fn handle_get_signature_statuses(
         #[cfg(feature = "grpc-head-cache")]
         let to_query = unique_valid
             .iter()
-            .filter(|sig| !head_statuses.contains_key(*sig))
+            .filter(|sig| !head_statuses.contains_key(*sig) && !in_disk(sig))
             .cloned()
             .collect::<Vec<_>>();
         #[cfg(not(feature = "grpc-head-cache"))]
-        let to_query = unique_valid.clone();
+        let to_query: Vec<String> = unique_valid
+            .iter()
+            .filter(|sig| !in_disk(sig))
+            .cloned()
+            .collect();
 
         if to_query.is_empty() {
             HashMap::new()
@@ -226,6 +273,8 @@ pub(crate) async fn handle_get_signature_statuses(
 
     let mut value = Vec::with_capacity(inputs.len());
     let mut has_clickhouse_match = false;
+    #[cfg(feature = "disk-cache")]
+    let mut has_disk_match = false;
     #[cfg(feature = "grpc-head-cache")]
     let mut has_head_match = false;
     for maybe_sig in inputs {
@@ -246,6 +295,24 @@ pub(crate) async fn handle_get_signature_statuses(
                 slot: record.slot,
                 confirmations: None,
                 err: err_value,
+                status: status_value,
+                confirmation_status: "finalized".to_string(),
+            }));
+            continue;
+        }
+
+        #[cfg(feature = "disk-cache")]
+        if let Some((slot, err)) = disk_statuses.get(&sig) {
+            has_disk_match = true;
+            let status_value = match err {
+                Some(err) => json!({ "Err": err }),
+                None => json!({ "Ok": Value::Null }),
+            };
+
+            value.push(Some(SignatureStatusInfo {
+                slot: *slot,
+                confirmations: None,
+                err: err.clone(),
                 status: status_value,
                 confirmation_status: "finalized".to_string(),
             }));
@@ -276,8 +343,16 @@ pub(crate) async fn handle_get_signature_statuses(
     if has_clickhouse_match {
         route.source_clickhouse();
     }
+    #[cfg(all(feature = "grpc-head-cache", feature = "disk-cache"))]
+    let disk_matched = has_disk_match;
+    #[cfg(all(feature = "grpc-head-cache", not(feature = "disk-cache")))]
+    let disk_matched = false;
+    #[cfg(feature = "disk-cache")]
+    if !has_clickhouse_match && has_disk_match {
+        route.source_disk_cache();
+    }
     #[cfg(feature = "grpc-head-cache")]
-    if !has_clickhouse_match && has_head_match {
+    if !has_clickhouse_match && !disk_matched && has_head_match {
         route.source_head_cache();
     }
 

--- a/crates/superbank-rpc/src/handlers/transactions.rs
+++ b/crates/superbank-rpc/src/handlers/transactions.rs
@@ -22,8 +22,8 @@ use tracing::error;
 
 use crate::clickhouse::{
     NumericFilter, PaginationToken, QueryTimings, ResolvedSignatureFilter, SignatureFilter,
-    SignatureSlot, SortOrder, TokenAccountsFilter, TransactionStatusFilter,
-    TransactionsForAddressQuery,
+    SignatureSlot, SortOrder, StoredTransactionRecord, TokenAccountsFilter,
+    TransactionStatusFilter, TransactionsForAddressQuery,
 };
 use crate::handlers::{
     RouteMetric,
@@ -157,6 +157,83 @@ fn unsupported_transaction_version_message(version: u8) -> String {
     )
 }
 
+/// Hydrate a stored record and build the JSON-RPC response; shared by the
+/// head-cache, disk-cache, and ClickHouse branches of getTransaction.
+#[allow(clippy::too_many_arguments)]
+async fn respond_with_hydrated_transaction(
+    state: &AppState,
+    id: Value,
+    route: &mut RouteMetric,
+    signature_str: &str,
+    record: Arc<StoredTransactionRecord>,
+    encoding: UiTransactionEncoding,
+    max_version: Option<u8>,
+    timings: Option<QueryTimings>,
+) -> Result<Response, StatusCode> {
+    let attach_timings = |resp: &mut Response| {
+        if let Some(timings) = timings.as_ref() {
+            add_downstream_header(resp, timings);
+        }
+    };
+
+    let permit = match state.hydration_sem.clone().acquire_owned().await {
+        Ok(permit) => permit,
+        Err(_) => {
+            error!(signature = signature_str, "Hydration semaphore closed");
+            let mut resp = json_rpc_internal_error_response(id);
+            attach_timings(&mut resp);
+            return Ok(resp);
+        }
+    };
+
+    let record_slot = record.slot;
+    match tokio::task::spawn_blocking(move || {
+        let _permit = permit;
+        hydrate_transaction_record(record.as_ref(), encoding, max_version)
+    })
+    .await
+    {
+        Ok(Ok(encoded_tx)) => {
+            route.success();
+            let mut resp = json_rpc_success_response(id, encoded_tx);
+            attach_timings(&mut resp);
+            Ok(resp)
+        }
+        Ok(Err(TransactionHydrationError::Encode(EncodeError::UnsupportedTransactionVersion(
+            version,
+        )))) => {
+            route.rpc_error();
+            let code = JSON_RPC_SERVER_ERROR_UNSUPPORTED_TRANSACTION_VERSION as i32;
+            let mut resp = json_rpc_error_response(
+                id,
+                code,
+                unsupported_transaction_version_message(version),
+                None,
+            );
+            attach_timings(&mut resp);
+            Ok(resp)
+        }
+        Ok(Err(e)) => {
+            error!(
+                "Failed to hydrate transaction {} in slot {}: {}",
+                signature_str, record_slot, e
+            );
+            let mut resp = json_rpc_internal_error_response(id);
+            attach_timings(&mut resp);
+            Ok(resp)
+        }
+        Err(join_err) => {
+            error!(
+                "Failed to join hydration task for transaction {} in slot {}: {}",
+                signature_str, record_slot, join_err
+            );
+            let mut resp = json_rpc_internal_error_response(id);
+            attach_timings(&mut resp);
+            Ok(resp)
+        }
+    }
+}
+
 pub(crate) async fn handle_get_transaction(
     state: Arc<AppState>,
     id: Value,
@@ -278,57 +355,61 @@ pub(crate) async fn handle_get_transaction(
         }
 
         route.source_head_cache();
-        let max_version = config.max_supported_transaction_version;
-        let permit = match state.hydration_sem.clone().acquire_owned().await {
-            Ok(permit) => permit,
-            Err(_) => {
-                error!(signature = signature_str, "Hydration semaphore closed");
-                return Ok(json_rpc_internal_error_response(id));
-            }
-        };
-        let record = record.clone();
-
-        match tokio::task::spawn_blocking(move || {
-            let _permit = permit;
-            hydrate_transaction_record(record.as_ref(), encoding, max_version)
-        })
-        .await
-        {
-            Ok(Ok(encoded_tx)) => {
-                route.success();
-                return Ok(json_rpc_success_response(id, encoded_tx));
-            }
-            Ok(Err(TransactionHydrationError::Encode(
-                EncodeError::UnsupportedTransactionVersion(version),
-            ))) => {
-                route.rpc_error();
-                let code = JSON_RPC_SERVER_ERROR_UNSUPPORTED_TRANSACTION_VERSION as i32;
-                return Ok(json_rpc_error_response(
-                    id,
-                    code,
-                    unsupported_transaction_version_message(version),
-                    None,
-                ));
-            }
-            Ok(Err(e)) => {
-                error!(
-                    "Failed to hydrate head-cache transaction {}: {}",
-                    signature_str, e
-                );
-                return Ok(json_rpc_internal_error_response(id));
-            }
-            Err(join_err) => {
-                error!(
-                    "Failed to join hydration task for head-cache transaction {}: {}",
-                    signature_str, join_err
-                );
-                return Ok(json_rpc_internal_error_response(id));
-            }
-        }
+        return respond_with_hydrated_transaction(
+            state.as_ref(),
+            id,
+            &mut route,
+            signature_str,
+            record,
+            encoding,
+            config.max_supported_transaction_version,
+            None,
+        )
+        .await;
     }
     #[cfg(feature = "grpc-head-cache")]
     if state.head_cache.is_some() {
         route.head_cache_read();
+    }
+
+    // Disk tier: everything stored is finalized, which satisfies any commitment
+    // accepted above. A hit answers without ClickHouse. A miss proves nothing by
+    // itself (the signature may be older than the window or in a coverage hole) —
+    // EXCEPT when the request pinned a slot that the disk fully covers: then the
+    // transaction conclusively does not exist there.
+    #[cfg(feature = "disk-cache")]
+    if let Some(disk) = state.disk_cache.as_ref() {
+        route.disk_cache_read();
+        if let Some(record) = disk.get_tx(signature).await {
+            if requested_slot.is_some_and(|slot| record.slot != slot) {
+                route.source_disk_cache();
+                route.not_found();
+                return Ok(json_rpc_null_response(id));
+            }
+            route.source_disk_cache();
+            return respond_with_hydrated_transaction(
+                state.as_ref(),
+                id,
+                &mut route,
+                signature_str,
+                Arc::new(record),
+                encoding,
+                config.max_supported_transaction_version,
+                None,
+            )
+            .await;
+        }
+        if let Some(slot) = requested_slot
+            && matches!(
+                disk.slot_status(slot).await,
+                crate::disk_cache::SlotStatus::Covered { .. }
+                    | crate::disk_cache::SlotStatus::Skipped
+            )
+        {
+            route.source_disk_cache();
+            route.not_found();
+            return Ok(json_rpc_null_response(id));
+        }
     }
 
     route.source_clickhouse();
@@ -367,63 +448,17 @@ pub(crate) async fn handle_get_transaction(
         return Ok(resp);
     };
 
-    let max_version = config.max_supported_transaction_version;
-    let permit = match state.hydration_sem.clone().acquire_owned().await {
-        Ok(permit) => permit,
-        Err(_) => {
-            error!(signature = signature_str, "Hydration semaphore closed");
-            let mut resp = json_rpc_internal_error_response(id);
-            add_downstream_header(&mut resp, &timings);
-            return Ok(resp);
-        }
-    };
-
-    let record_slot = record.slot;
-    match tokio::task::spawn_blocking(move || {
-        let _permit = permit;
-        hydrate_transaction_record(&record, encoding, max_version)
-    })
+    respond_with_hydrated_transaction(
+        state.as_ref(),
+        id,
+        &mut route,
+        signature_str,
+        Arc::new(record),
+        encoding,
+        config.max_supported_transaction_version,
+        Some(timings),
+    )
     .await
-    {
-        Ok(Ok(encoded_tx)) => {
-            route.success();
-            let mut resp = json_rpc_success_response(id, encoded_tx);
-            add_downstream_header(&mut resp, &timings);
-            Ok(resp)
-        }
-        Ok(Err(TransactionHydrationError::Encode(EncodeError::UnsupportedTransactionVersion(
-            version,
-        )))) => {
-            route.rpc_error();
-            let code = JSON_RPC_SERVER_ERROR_UNSUPPORTED_TRANSACTION_VERSION as i32;
-            let mut resp = json_rpc_error_response(
-                id,
-                code,
-                unsupported_transaction_version_message(version),
-                None,
-            );
-            add_downstream_header(&mut resp, &timings);
-            Ok(resp)
-        }
-        Ok(Err(e)) => {
-            error!(
-                "Failed to hydrate transaction {} in slot {}: {}",
-                signature_str, record_slot, e
-            );
-            let mut resp = json_rpc_internal_error_response(id);
-            add_downstream_header(&mut resp, &timings);
-            Ok(resp)
-        }
-        Err(join_err) => {
-            error!(
-                "Failed to join hydration task for transaction {} in slot {}: {}",
-                signature_str, record_slot, join_err
-            );
-            let mut resp = json_rpc_internal_error_response(id);
-            add_downstream_header(&mut resp, &timings);
-            Ok(resp)
-        }
-    }
 }
 
 pub(crate) async fn handle_get_transactions_for_address(

--- a/crates/superbank-rpc/src/handlers/transactions.rs
+++ b/crates/superbank-rpc/src/handlers/transactions.rs
@@ -130,7 +130,7 @@ fn apply_get_transactions_for_address_slot_aliases(
     Ok(())
 }
 
-async fn resolve_signature_slot_for_hot_bounds(
+async fn resolve_signature_slot_for_bounds(
     state: &AppState,
     signature: &str,
 ) -> crate::processing::ProcessingResult<(Option<SignatureSlot>, QueryTimings)> {
@@ -146,6 +146,14 @@ async fn resolve_signature_slot_for_hot_bounds(
             }),
             QueryTimings::zero(),
         ));
+    }
+
+    #[cfg(feature = "disk-cache")]
+    if let Some(disk) = state.disk_cache.as_ref()
+        && let Ok(parsed) = Signature::from_str(signature)
+        && let Some(position) = disk.signature_position(parsed).await
+    {
+        return Ok((Some(position), QueryTimings::zero()));
     }
 
     state.clickhouse.get_signature_slot(signature).await
@@ -747,6 +755,30 @@ pub(crate) async fn handle_get_transactions_for_address(
         }
     };
 
+    #[cfg(feature = "disk-cache")]
+    let pagination = {
+        if let Some(disk) = state.disk_cache.as_ref() {
+            match pagination {
+                Some(PaginationToken::Signature(sig_str)) => {
+                    route.disk_cache_read();
+                    if let Ok(sig) = Signature::from_str(&sig_str)
+                        && let Some(position) = disk.signature_position(sig).await
+                    {
+                        Some(PaginationToken::SlotIndex {
+                            slot: position.slot,
+                            idx: position.slot_idx,
+                        })
+                    } else {
+                        Some(PaginationToken::Signature(sig_str))
+                    }
+                }
+                other => other,
+            }
+        } else {
+            pagination
+        }
+    };
+
     let mut filters = options.filters.unwrap_or_default();
 
     if let Err(message) = apply_get_transactions_for_address_slot_aliases(
@@ -897,8 +929,13 @@ pub(crate) async fn handle_get_transactions_for_address(
         token_accounts,
     };
 
+    #[cfg(feature = "disk-cache")]
+    let disk_candidate = state.disk_cache.is_some();
+    #[cfg(not(feature = "disk-cache"))]
+    let disk_candidate = false;
+
     let mut prequery_timings = QueryTimings::zero();
-    if hot_fanout_eligible {
+    if hot_fanout_eligible || disk_candidate {
         match query.pagination.as_ref() {
             Some(PaginationToken::SlotIndex { slot, idx }) => {
                 query.resolved_pagination = Some(SignatureSlot {
@@ -908,7 +945,7 @@ pub(crate) async fn handle_get_transactions_for_address(
             }
             Some(PaginationToken::Signature(signature)) => {
                 let (position, timings) =
-                    match resolve_signature_slot_for_hot_bounds(state.as_ref(), signature).await {
+                    match resolve_signature_slot_for_bounds(state.as_ref(), signature).await {
                         Ok(result) => result,
                         Err(e) => {
                             metrics::backend_error("get_signature_slot");
@@ -937,7 +974,7 @@ pub(crate) async fn handle_get_transactions_for_address(
                     continue;
                 };
                 let (position, timings) =
-                    match resolve_signature_slot_for_hot_bounds(state.as_ref(), signature).await {
+                    match resolve_signature_slot_for_bounds(state.as_ref(), signature).await {
                         Ok(result) => result,
                         Err(e) => {
                             metrics::backend_error("get_signature_slot");
@@ -960,6 +997,8 @@ pub(crate) async fn handle_get_transactions_for_address(
         ClickHouse,
         #[cfg(feature = "grpc-head-cache")]
         Head,
+        #[cfg(feature = "disk-cache")]
+        Disk,
     }
 
     #[derive(Debug)]
@@ -1192,17 +1231,122 @@ pub(crate) async fn handle_get_transactions_for_address(
         }
     }
 
-    route.source_clickhouse();
-    let (signature_records, mut timings) = match state
-        .clickhouse
-        .get_transactions_for_address_signatures(&query)
+    // Disk tier: eligible only when every signature-shaped bound resolved to a
+    // position (otherwise ClickHouse's NULL-tolerant SQL semantics must apply),
+    // and — for ascending pages, which start from the oldest row — when the
+    // whole eligible range lies inside the contiguous covered span.
+    #[cfg(feature = "disk-cache")]
+    let disk_page = 'disk: {
+        let Some(disk) = state.disk_cache.as_ref() else {
+            break 'disk None;
+        };
+
+        let pagination_position = match query.pagination.as_ref() {
+            None => None,
+            Some(PaginationToken::SlotIndex { slot, idx }) => Some(SignatureSlot {
+                slot: *slot,
+                slot_idx: *idx,
+            }),
+            Some(PaginationToken::Signature(_)) => match query.resolved_pagination {
+                Some(position) => Some(position),
+                None => break 'disk None,
+            },
+        };
+
+        let resolved_filter = match query.signature_filter.as_ref() {
+            None => None,
+            Some(filter) => {
+                let resolved = query.resolved_signature_filter.clone().unwrap_or_default();
+                let fully_resolved = [
+                    (filter.gte.is_some(), resolved.gte.is_some()),
+                    (filter.gt.is_some(), resolved.gt.is_some()),
+                    (filter.lte.is_some(), resolved.lte.is_some()),
+                    (filter.lt.is_some(), resolved.lt.is_some()),
+                ]
+                .iter()
+                .all(|(requested, resolved)| !requested || *resolved);
+                if !fully_resolved {
+                    break 'disk None;
+                }
+                Some(resolved)
+            }
+        };
+
+        if query.sort_order == SortOrder::Asc {
+            let Some((floor, _)) = disk.tip_span() else {
+                break 'disk None;
+            };
+            let mut lower_bound: Option<u64> = pagination_position.map(|position| position.slot);
+            if let Some(filter) = query.slot_filter.as_ref() {
+                for bound in [filter.gt.map(|v| v.saturating_add(1)), filter.gte]
+                    .into_iter()
+                    .flatten()
+                {
+                    lower_bound = Some(lower_bound.map_or(bound, |low| low.max(bound)));
+                }
+            }
+            if let Some(resolved) = resolved_filter.as_ref() {
+                for position in [resolved.gt, resolved.gte].into_iter().flatten() {
+                    lower_bound =
+                        Some(lower_bound.map_or(position.slot, |low| low.max(position.slot)));
+                }
+            }
+            // An ascending page that starts below the floor must come from
+            // ClickHouse in full: its oldest rows lead the page.
+            if lower_bound.is_none_or(|low| low < floor) {
+                break 'disk None;
+            }
+        }
+
+        route.disk_cache_read();
+        disk.transactions_for_address(
+            address_pubkey,
+            crate::disk_cache::index::DiskTfaQuery {
+                limit: limit as usize,
+                sort_order: query.sort_order,
+                pagination: pagination_position,
+                slot_filter: query.slot_filter.clone(),
+                block_time_filter: query.block_time_filter.clone(),
+                signature_filter: resolved_filter,
+                status: query.status,
+                token_accounts: query.token_accounts,
+            },
+        )
         .await
-    {
-        Ok(result) => result,
-        Err(e) => {
-            metrics::backend_error("get_transactions_for_address_signatures");
-            error!("Failed to query ClickHouse: {}", e);
-            return Ok(json_rpc_internal_error_response(id));
+    };
+
+    #[cfg(feature = "disk-cache")]
+    let (skip_clickhouse, clickhouse_query) = match disk_page.as_ref() {
+        Some(page) if !page.reached_floor => (true, None),
+        Some(page) => {
+            // ClickHouse owes only the remainder strictly below the floor.
+            let mut remainder = query.clone();
+            let slot_filter = remainder.slot_filter.get_or_insert_with(Default::default);
+            slot_filter.lt = Some(slot_filter.lt.map_or(page.floor, |lt| lt.min(page.floor)));
+            remainder.limit = limit - page.records.len() as u64;
+            (false, Some(remainder))
+        }
+        None => (false, None),
+    };
+    #[cfg(not(feature = "disk-cache"))]
+    let (skip_clickhouse, clickhouse_query): (bool, Option<TransactionsForAddressQuery>) =
+        (false, None);
+
+    let (signature_records, mut timings) = if skip_clickhouse {
+        (Vec::new(), QueryTimings::zero())
+    } else {
+        route.source_clickhouse();
+        match state
+            .clickhouse
+            .get_transactions_for_address_signatures(clickhouse_query.as_ref().unwrap_or(&query))
+            .await
+        {
+            Ok(result) => result,
+            Err(e) => {
+                metrics::backend_error("get_transactions_for_address_signatures");
+                error!("Failed to query ClickHouse: {}", e);
+                return Ok(json_rpc_internal_error_response(id));
+            }
         }
     };
     timings.add(prequery_timings);
@@ -1227,6 +1371,49 @@ pub(crate) async fn handle_get_transactions_for_address(
     let mut merged_records = merged_records;
     #[cfg(feature = "grpc-head-cache")]
     let mut merged_has_head = false;
+
+    #[cfg(feature = "disk-cache")]
+    let mut merged_has_disk = false;
+    #[cfg(feature = "disk-cache")]
+    if let Some(page) = disk_page {
+        let mut seen = HashSet::with_capacity(merged_records.len() + page.records.len());
+        for record in merged_records.iter() {
+            seen.insert(record.signature.clone());
+        }
+        for record in page.records {
+            if !seen.insert(record.signature.clone()) {
+                continue;
+            }
+            merged_has_disk = true;
+            merged_records.push(MergedRecord {
+                source: RecordSource::Disk,
+                signature: record.signature,
+                slot: record.slot,
+                slot_idx: record.slot_idx,
+                err: record.err,
+                memo: record.memo,
+                block_time: record.block_time,
+                confirmation_status: "finalized".to_string(),
+            });
+        }
+        if merged_has_disk {
+            merged_records.sort_unstable_by(|a, b| match query.sort_order {
+                SortOrder::Desc => b
+                    .slot
+                    .cmp(&a.slot)
+                    .then_with(|| b.slot_idx.cmp(&a.slot_idx))
+                    .then_with(|| b.signature.cmp(&a.signature)),
+                SortOrder::Asc => a
+                    .slot
+                    .cmp(&b.slot)
+                    .then_with(|| a.slot_idx.cmp(&b.slot_idx))
+                    .then_with(|| a.signature.cmp(&b.signature)),
+            });
+            merged_records.truncate(limit as usize);
+        }
+    }
+    #[cfg(all(feature = "grpc-head-cache", not(feature = "disk-cache")))]
+    let merged_has_disk = false;
 
     #[cfg(feature = "grpc-head-cache")]
     if let Some(cache) = head_cache {
@@ -1330,12 +1517,11 @@ pub(crate) async fn handle_get_transactions_for_address(
 
     if transaction_details == TransactionsForAddressDetails::Signatures {
         #[cfg(feature = "grpc-head-cache")]
-        let pagination_token = merged_records.last().map(|record| {
-            if record.source == RecordSource::Head {
-                format!("{}:{}", record.slot, record.slot_idx)
-            } else {
-                record.signature.clone()
-            }
+        let pagination_token = merged_records.last().map(|record| match record.source {
+            RecordSource::ClickHouse => record.signature.clone(),
+            RecordSource::Head => format!("{}:{}", record.slot, record.slot_idx),
+            #[cfg(feature = "disk-cache")]
+            RecordSource::Disk => format!("{}:{}", record.slot, record.slot_idx),
         });
 
         #[cfg(not(feature = "grpc-head-cache"))]
@@ -1360,7 +1546,10 @@ pub(crate) async fn handle_get_transactions_for_address(
         };
 
         #[cfg(feature = "grpc-head-cache")]
-        if clickhouse_records_count == 0 && merged_has_head {
+        if clickhouse_records_count == 0 && merged_has_disk {
+            #[cfg(feature = "disk-cache")]
+            route.source_disk_cache();
+        } else if clickhouse_records_count == 0 && merged_has_head {
             route.source_head_cache();
         } else {
             route.source_clickhouse();
@@ -1397,9 +1586,49 @@ pub(crate) async fn handle_get_transactions_for_address(
 
     let max_supported_transaction_version = options.max_supported_transaction_version;
 
+    #[cfg(feature = "disk-cache")]
+    let mut disk_transaction_map: HashMap<
+        String,
+        Arc<crate::clickhouse::StoredTransactionRecord>,
+    > = {
+        let disk_records: Vec<(u64, u32, String)> = merged_records
+            .iter()
+            .filter(|record| record.source == RecordSource::Disk)
+            .map(|record| (record.slot, record.slot_idx, record.signature.clone()))
+            .collect();
+        if disk_records.is_empty() {
+            HashMap::new()
+        } else {
+            let disk = state
+                .disk_cache
+                .as_ref()
+                .expect("disk records imply disk cache");
+            let positions: Vec<(u64, u32)> = disk_records
+                .iter()
+                .map(|(slot, idx, _)| (*slot, *idx))
+                .collect();
+            let fetched = disk.get_txs_by_position(positions).await;
+            disk_records
+                .into_iter()
+                .zip(fetched)
+                .filter_map(|((_, _, signature), record)| {
+                    record.map(|record| (signature, Arc::new(record)))
+                })
+                .collect()
+        }
+    };
+
+    // Disk-sourced rows whose full record vanished (eviction race) are fetched
+    // from ClickHouse with the rest, so the page never silently drops entries.
     let signature_pairs = merged_records
         .iter()
-        .filter(|record| record.source == RecordSource::ClickHouse)
+        .filter(|record| match record.source {
+            RecordSource::ClickHouse => true,
+            #[cfg(feature = "grpc-head-cache")]
+            RecordSource::Head => false,
+            #[cfg(feature = "disk-cache")]
+            RecordSource::Disk => !disk_transaction_map.contains_key(&record.signature),
+        })
         .map(|record| (record.slot, record.signature.clone()))
         .collect::<Vec<_>>();
 
@@ -1437,13 +1666,17 @@ pub(crate) async fn handle_get_transactions_for_address(
         slot_idx: u32,
         block_time: Option<i64>,
         signature: String,
+        /// Position-shaped pagination token (cache-sourced records have no
+        /// ClickHouse signature cursor).
         #[cfg(feature = "grpc-head-cache")]
-        is_head: bool,
+        position_token: bool,
         stored: Arc<crate::clickhouse::StoredTransactionRecord>,
     }
 
     let mut inputs = Vec::with_capacity(merged_records.len());
     for record in merged_records {
+        #[cfg(feature = "grpc-head-cache")]
+        let position_token = record.source != RecordSource::ClickHouse;
         let stored = match record.source {
             RecordSource::ClickHouse => {
                 let Some(stored) = transaction_map.remove(&record.signature) else {
@@ -1465,6 +1698,16 @@ pub(crate) async fn handle_get_transactions_for_address(
                 };
                 stored
             }
+            #[cfg(feature = "disk-cache")]
+            RecordSource::Disk => {
+                match disk_transaction_map
+                    .remove(&record.signature)
+                    .or_else(|| transaction_map.remove(&record.signature))
+                {
+                    Some(stored) => stored,
+                    None => continue,
+                }
+            }
         };
 
         inputs.push(HydrationInput {
@@ -1473,7 +1716,7 @@ pub(crate) async fn handle_get_transactions_for_address(
             block_time: record.block_time,
             signature: record.signature,
             #[cfg(feature = "grpc-head-cache")]
-            is_head: record.source == RecordSource::Head,
+            position_token,
             stored,
         });
     }
@@ -1525,7 +1768,7 @@ pub(crate) async fn handle_get_transactions_for_address(
 
             #[cfg(feature = "grpc-head-cache")]
             {
-                if input.is_head {
+                if input.position_token {
                     pagination_token = Some(format!("{}:{}", input.slot, input.slot_idx));
                 } else {
                     pagination_token = Some(input.signature);
@@ -1567,7 +1810,10 @@ pub(crate) async fn handle_get_transactions_for_address(
     };
 
     #[cfg(feature = "grpc-head-cache")]
-    if signature_pairs.is_empty() && merged_has_head {
+    if signature_pairs.is_empty() && merged_has_disk {
+        #[cfg(feature = "disk-cache")]
+        route.source_disk_cache();
+    } else if signature_pairs.is_empty() && merged_has_head {
         route.source_head_cache();
     } else {
         route.source_clickhouse();

--- a/crates/superbank-rpc/src/head_cache/convert.rs
+++ b/crates/superbank-rpc/src/head_cache/convert.rs
@@ -4,7 +4,6 @@
  */
 
 use thiserror::Error;
-use yellowstone_grpc_proto::convert_from;
 use yellowstone_grpc_proto::prelude::{
     CompiledInstruction, MessageAddressTableLookup, RewardType, SubscribeUpdateTransactionInfo,
     TokenBalance, TransactionError, TransactionStatusMeta,
@@ -141,13 +140,12 @@ fn decode_transaction_error(err: Option<&TransactionError>) -> (bool, Option<Str
         return (true, None);
     };
 
-    match convert_from::create_tx_error(Some(err)) {
-        Ok(Some(decoded)) => {
+    match bincode::deserialize::<solana_sdk::transaction::TransactionError>(&err.err) {
+        Ok(decoded) => {
             let serialized =
                 serde_json::to_string(&decoded).unwrap_or_else(|_| format!("{decoded:?}"));
             (false, Some(serialized))
         }
-        Ok(None) => (true, None),
         Err(_) => {
             let fallback = hex::encode(&err.err);
             tracing::warn!("head cache: failed to decode transaction error; storing hex fallback");

--- a/crates/superbank-rpc/src/head_cache/dragonsmouth.rs
+++ b/crates/superbank-rpc/src/head_cache/dragonsmouth.rs
@@ -21,6 +21,8 @@ use yellowstone_grpc_proto::prelude::{
 };
 
 use crate::clickhouse::BlockMetadataRecord;
+#[cfg(feature = "disk-cache")]
+use crate::disk_cache::ingest::DiskIngestSink;
 use crate::head_cache::HeadCache;
 use crate::metrics;
 
@@ -30,6 +32,9 @@ pub(crate) struct DragonsmouthHeadCacheConfig {
     pub(crate) x_token: Option<String>,
     pub(crate) max_decoding_bytes: usize,
     pub(crate) min_commitment: CommitmentLevel,
+    /// Receives finalized slots for the disk cache; never blocks the stream.
+    #[cfg(feature = "disk-cache")]
+    pub(crate) disk_sink: Option<Arc<DiskIngestSink>>,
 }
 
 const TRANSACTIONS_FILTER_NAME: &str = "_superbank_rpc";
@@ -58,7 +63,7 @@ async fn run_block_machine_stream(cache: Arc<HeadCache>, cfg: DragonsmouthHeadCa
 
                 while let Some(result) = rx.recv().await {
                     match result {
-                        Ok(output) => handle_output(&cache, output),
+                        Ok(output) => handle_output(&cache, output, &cfg),
                         Err(err) => {
                             warn!("head cache: block-machine error: {err:?}");
                             break;
@@ -182,7 +187,8 @@ async fn run_block_meta_stream(cache: Arc<HeadCache>, cfg: DragonsmouthHeadCache
     }
 }
 
-fn handle_output(cache: &HeadCache, output: BlockMachineOutput) {
+#[cfg_attr(not(feature = "disk-cache"), allow(unused_variables))]
+fn handle_output(cache: &HeadCache, output: BlockMachineOutput, cfg: &DragonsmouthHeadCacheConfig) {
     match output {
         BlockMachineOutput::FrozenBlock(block) => {
             let slot = block.slot;
@@ -220,6 +226,12 @@ fn handle_output(cache: &HeadCache, output: BlockMachineOutput) {
         }
         BlockMachineOutput::SlotCommitmentUpdate(update) => {
             cache.note_slot_commitment(update.slot, update.commitment);
+            #[cfg(feature = "disk-cache")]
+            if update.commitment == CommitmentLevel::Finalized
+                && let Some(sink) = cfg.disk_sink.as_ref()
+            {
+                sink.on_slot_finalized(update.slot, cache);
+            }
         }
         BlockMachineOutput::ForkDetected(fork) => {
             warn!(slot = fork.slot, "head cache: fork detected; dropping slot");

--- a/crates/superbank-rpc/src/head_cache/dragonsmouth.rs
+++ b/crates/superbank-rpc/src/head_cache/dragonsmouth.rs
@@ -12,8 +12,9 @@ use solana_commitment_config::CommitmentLevel;
 use solana_sdk::{hash::Hash, pubkey::Pubkey};
 use tokio::time::sleep;
 use tracing::{info, warn};
-use yellowstone_block_machine::dragonsmouth::client_ext::{
-    BlockMachineOutput, BlockMachineResult, GeyserGrpcExt,
+use yellowstone_block_machine::dragonsmouth::{
+    client_ext::{GeyserBlockStream, GeyserGrpcExt},
+    stream::BlockMachineOutput,
 };
 use yellowstone_grpc_client::{ClientTlsConfig, GeyserGrpcClient};
 use yellowstone_grpc_proto::prelude::{
@@ -53,7 +54,7 @@ async fn run_block_machine_stream(cache: Arc<HeadCache>, cfg: DragonsmouthHeadCa
 
     loop {
         match connect_and_subscribe(&cfg).await {
-            Ok(mut rx) => {
+            Ok(mut stream) => {
                 info!(
                     endpoint = cfg.endpoint.as_str(),
                     min_commitment = ?cfg.min_commitment,
@@ -61,7 +62,7 @@ async fn run_block_machine_stream(cache: Arc<HeadCache>, cfg: DragonsmouthHeadCa
                 );
                 backoff = Duration::from_millis(250);
 
-                while let Some(result) = rx.recv().await {
+                while let Some(result) = stream.next().await {
                     match result {
                         Ok(output) => handle_output(&cache, output, &cfg),
                         Err(err) => {
@@ -450,7 +451,7 @@ fn parse_block_rewards(
 
 async fn connect_and_subscribe(
     cfg: &DragonsmouthHeadCacheConfig,
-) -> Result<tokio::sync::mpsc::Receiver<BlockMachineResult>, String> {
+) -> Result<GeyserBlockStream, String> {
     let mut client = GeyserGrpcClient::build_from_shared(cfg.endpoint.clone().into_bytes())
         .map_err(|e| format!("invalid endpoint: {e}"))?
         .x_token(cfg.x_token.clone())
@@ -548,6 +549,7 @@ mod tests {
                         post_balance: 99,
                         reward_type: yellowstone_grpc_proto::prelude::RewardType::Fee as i32,
                         commission: "7".to_string(),
+                        commission_bps: String::new(),
                     }],
                     num_partitions: Some(yellowstone_grpc_proto::prelude::NumPartitions {
                         num_partitions: 4,

--- a/crates/superbank-rpc/src/head_cache/mod.rs
+++ b/crates/superbank-rpc/src/head_cache/mod.rs
@@ -14,7 +14,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::clickhouse::{
     BlockMetadataRecord, SlotBoundary, StoredAccountsTransactionRecord, StoredBlockPayload,
-    StoredBlockRecord, StoredTransactionRecord,
+    StoredBlockRecord, StoredTransactionRecord, extract_memo,
 };
 
 mod convert;
@@ -805,64 +805,6 @@ fn commitment_to_str(c: CommitmentLevel) -> &'static str {
         CommitmentLevel::Confirmed => "confirmed",
         CommitmentLevel::Finalized => "finalized",
     }
-}
-
-fn extract_memo(record: &StoredTransactionRecord) -> Option<String> {
-    static MEMO_PROGRAM_IDS: once_cell::sync::Lazy<[Pubkey; 2]> =
-        once_cell::sync::Lazy::new(|| {
-            use std::str::FromStr;
-            [
-                Pubkey::from_str("Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo")
-                    .expect("memo program id"),
-                Pubkey::from_str("MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr")
-                    .expect("memo program id"),
-            ]
-        });
-
-    let mut memos = Vec::new();
-    for (program_id_index, data) in record
-        .tx_instructions_program_id_index
-        .iter()
-        .zip(record.tx_instructions_data.iter())
-    {
-        let idx = usize::from(*program_id_index);
-        let Some(program_id) = account_key_at(record, idx) else {
-            continue;
-        };
-        if !MEMO_PROGRAM_IDS.contains(&program_id) {
-            continue;
-        }
-        let Ok(text) = std::str::from_utf8(data) else {
-            continue;
-        };
-        if text.is_empty() {
-            continue;
-        }
-        memos.push(format!("[{}] {}", text.len(), text));
-    }
-
-    if memos.is_empty() {
-        None
-    } else {
-        Some(memos.join("; "))
-    }
-}
-
-fn account_key_at(record: &StoredTransactionRecord, idx: usize) -> Option<Pubkey> {
-    let static_len = record.tx_account_keys.len();
-    if idx < static_len {
-        return Some(Pubkey::from(record.tx_account_keys[idx]));
-    }
-    let idx = idx - static_len;
-    let w_len = record.meta_loaded_addresses_writable.len();
-    if idx < w_len {
-        return Some(Pubkey::from(record.meta_loaded_addresses_writable[idx]));
-    }
-    let idx = idx - w_len;
-    if idx < record.meta_loaded_addresses_readonly.len() {
-        return Some(Pubkey::from(record.meta_loaded_addresses_readonly[idx]));
-    }
-    None
 }
 
 #[cfg(test)]

--- a/crates/superbank-rpc/src/head_cache/mod.rs
+++ b/crates/superbank-rpc/src/head_cache/mod.rs
@@ -415,6 +415,64 @@ impl HeadCache {
         }
     }
 
+    /// Snapshot a complete block for the disk cache without deep-cloning records.
+    ///
+    /// Same completeness rules as [`Self::get_block`] with full details: block
+    /// metadata present, exactly `executed_transaction_count` transactions, all
+    /// positioned in this slot. Returns records ordered by execution index.
+    /// `None` means the head cache holds an incomplete view (or the slot was
+    /// already evicted) and the caller must repair from ClickHouse instead.
+    #[cfg(feature = "disk-cache")]
+    pub(crate) fn finalized_block_snapshot(
+        &self,
+        slot: u64,
+    ) -> Option<(BlockMetadataRecord, Vec<Arc<StoredTransactionRecord>>)> {
+        let mut metadata = self.slot_block_metadata.get(&slot)?.clone();
+        // The block-meta stream can race individual note_* updates; prefer the
+        // per-slot maps where present so the snapshot matches what reads serve.
+        if metadata.block_time.is_none() {
+            metadata.block_time = self.block_time_for_slot(slot);
+        }
+
+        let expected = metadata.executed_transaction_count as usize;
+        let slot_signatures = if expected == 0 {
+            Vec::new()
+        } else {
+            self.sigs_by_slot.get(&slot).map(|entry| entry.clone())?
+        };
+        if slot_signatures.len() != expected {
+            return None;
+        }
+
+        let mut ordered = Vec::with_capacity(expected);
+        for signature in slot_signatures {
+            let meta = self.meta_by_signature.get(&signature)?;
+            if meta.pos.slot != slot {
+                return None;
+            }
+            let record = self.tx_by_signature.get(&signature)?.clone();
+            ordered.push((meta.pos.idx, record));
+        }
+        ordered.sort_unstable_by_key(|(idx, _)| *idx);
+
+        let records = ordered
+            .into_iter()
+            .map(|(_, record)| {
+                // Normalize block_time so disk contents match what ClickHouse
+                // stores for the same transaction.
+                if record.block_time.is_none() && metadata.block_time.is_some() {
+                    let mut fixed = record.as_ref().clone();
+                    fixed.block_time = metadata.block_time;
+                    Arc::new(fixed)
+                } else {
+                    record
+                }
+            })
+            .collect();
+
+        Some((metadata, records))
+    }
+
     pub(crate) fn signatures_for_address(
         &self,
         address: &Pubkey,

--- a/crates/superbank-rpc/src/lib.rs
+++ b/crates/superbank-rpc/src/lib.rs
@@ -10,6 +10,8 @@ mod metrics;
 mod processing;
 
 mod config;
+#[cfg(feature = "disk-cache")]
+mod disk_cache;
 mod handlers;
 #[cfg(feature = "grpc-head-cache")]
 mod head_cache;

--- a/crates/superbank-rpc/src/metrics.rs
+++ b/crates/superbank-rpc/src/metrics.rs
@@ -350,6 +350,7 @@ struct RouteLabels {
     scope: String,
     source: String,
     head_cache_read: String,
+    disk_cache_read: String,
     outcome: String,
     x_endpoint: Option<String>,
     x_rpc_node: Option<String>,
@@ -368,6 +369,11 @@ impl EncodeLabelSetTrait for RouteLabels {
             "head_cache_read",
             self.head_cache_read.as_str(),
         )?;
+        encode_required_label(
+            &mut encoder,
+            "disk_cache_read",
+            self.disk_cache_read.as_str(),
+        )?;
         encode_required_label(&mut encoder, "outcome", self.outcome.as_str())?;
         encode_request_header_labels(
             &mut encoder,
@@ -385,6 +391,7 @@ pub(crate) struct RouteMetricLabels<'a> {
     pub(crate) scope: &'a str,
     pub(crate) source: &'a str,
     pub(crate) head_cache_read: bool,
+    pub(crate) disk_cache_read: bool,
     pub(crate) outcome: &'a str,
     pub(crate) x_endpoint: Option<&'a str>,
     pub(crate) x_rpc_node: Option<&'a str>,
@@ -1285,6 +1292,11 @@ impl Metrics {
                 scope: labels.scope.to_string(),
                 source: labels.source.to_string(),
                 head_cache_read: if labels.head_cache_read {
+                    "true".to_string()
+                } else {
+                    "false".to_string()
+                },
+                disk_cache_read: if labels.disk_cache_read {
                     "true".to_string()
                 } else {
                     "false".to_string()

--- a/crates/superbank-rpc/src/metrics.rs
+++ b/crates/superbank-rpc/src/metrics.rs
@@ -399,6 +399,25 @@ struct SlotSourceLabels {
     commitment: String,
 }
 
+#[cfg(feature = "disk-cache")]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct DiskCacheReadLabels {
+    operation: String,
+    outcome: String,
+}
+
+#[cfg(feature = "disk-cache")]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct DiskCacheReasonLabels {
+    reason: String,
+}
+
+#[cfg(feature = "disk-cache")]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct DiskCacheSourceLabels {
+    source: String,
+}
+
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 struct BatchRejectLabels {
     reason: String,
@@ -504,6 +523,39 @@ pub struct Metrics {
     head_cache_address_entries: Gauge,
     #[cfg(feature = "grpc-head-cache")]
     head_cache_slot_entries: Gauge,
+
+    #[cfg(feature = "disk-cache")]
+    disk_cache_active: Gauge,
+    #[cfg(feature = "disk-cache")]
+    disk_cache_reads_total: Family<DiskCacheReadLabels, Counter>,
+    #[cfg(feature = "disk-cache")]
+    disk_cache_covered_min_slot: Gauge,
+    #[cfg(feature = "disk-cache")]
+    disk_cache_covered_max_slot: Gauge,
+    #[cfg(feature = "disk-cache")]
+    disk_cache_contiguous_floor_slot: Gauge,
+    #[cfg(feature = "disk-cache")]
+    disk_cache_size_bytes: Gauge,
+    #[cfg(feature = "disk-cache")]
+    disk_cache_writes_total: Family<DiskCacheSourceLabels, Counter>,
+    #[cfg(feature = "disk-cache")]
+    disk_cache_written_transactions_total: Counter,
+    #[cfg(feature = "disk-cache")]
+    disk_cache_write_latency_seconds: Histogram,
+    #[cfg(feature = "disk-cache")]
+    disk_cache_write_errors_total: Counter,
+    #[cfg(feature = "disk-cache")]
+    disk_cache_dropped_to_repair_total: Family<DiskCacheReasonLabels, Counter>,
+    #[cfg(feature = "disk-cache")]
+    disk_cache_evicted_slots_total: Family<DiskCacheReasonLabels, Counter>,
+    #[cfg(feature = "disk-cache")]
+    disk_cache_backfill_slots_remaining: Gauge,
+    #[cfg(feature = "disk-cache")]
+    disk_cache_fill_errors_total: Counter,
+    #[cfg(feature = "disk-cache")]
+    disk_cache_poisoned_slots_total: Counter,
+    #[cfg(feature = "disk-cache")]
+    disk_cache_wipes_total: Counter,
 }
 
 impl Metrics {
@@ -560,6 +612,39 @@ impl Metrics {
         let head_cache_address_entries = Gauge::default();
         #[cfg(feature = "grpc-head-cache")]
         let head_cache_slot_entries = Gauge::default();
+
+        #[cfg(feature = "disk-cache")]
+        let disk_cache_active = Gauge::default();
+        #[cfg(feature = "disk-cache")]
+        let disk_cache_reads_total = Family::default();
+        #[cfg(feature = "disk-cache")]
+        let disk_cache_covered_min_slot = Gauge::default();
+        #[cfg(feature = "disk-cache")]
+        let disk_cache_covered_max_slot = Gauge::default();
+        #[cfg(feature = "disk-cache")]
+        let disk_cache_contiguous_floor_slot = Gauge::default();
+        #[cfg(feature = "disk-cache")]
+        let disk_cache_size_bytes = Gauge::default();
+        #[cfg(feature = "disk-cache")]
+        let disk_cache_writes_total = Family::default();
+        #[cfg(feature = "disk-cache")]
+        let disk_cache_written_transactions_total = Counter::default();
+        #[cfg(feature = "disk-cache")]
+        let disk_cache_write_latency_seconds = latency_histogram();
+        #[cfg(feature = "disk-cache")]
+        let disk_cache_write_errors_total = Counter::default();
+        #[cfg(feature = "disk-cache")]
+        let disk_cache_dropped_to_repair_total = Family::default();
+        #[cfg(feature = "disk-cache")]
+        let disk_cache_evicted_slots_total = Family::default();
+        #[cfg(feature = "disk-cache")]
+        let disk_cache_backfill_slots_remaining = Gauge::default();
+        #[cfg(feature = "disk-cache")]
+        let disk_cache_fill_errors_total = Counter::default();
+        #[cfg(feature = "disk-cache")]
+        let disk_cache_poisoned_slots_total = Counter::default();
+        #[cfg(feature = "disk-cache")]
+        let disk_cache_wipes_total = Counter::default();
 
         let mut registry = Registry::with_prefix("superbank");
 
@@ -723,6 +808,90 @@ impl Metrics {
             );
         }
 
+        #[cfg(feature = "disk-cache")]
+        {
+            registry.register(
+                "disk_cache_active",
+                "Whether the disk cache is open and serving (1) or disabled (0)",
+                disk_cache_active.clone(),
+            );
+            registry.register(
+                "disk_cache_reads",
+                "Disk-cache read outcomes per operation",
+                disk_cache_reads_total.clone(),
+            );
+            registry.register(
+                "disk_cache_covered_min_slot",
+                "Oldest slot covered by the disk cache",
+                disk_cache_covered_min_slot.clone(),
+            );
+            registry.register(
+                "disk_cache_covered_max_slot",
+                "Newest slot covered by the disk cache",
+                disk_cache_covered_max_slot.clone(),
+            );
+            registry.register(
+                "disk_cache_contiguous_floor_slot",
+                "Floor of the contiguous tip span (the gSFA-safe boundary)",
+                disk_cache_contiguous_floor_slot.clone(),
+            );
+            registry.register(
+                "disk_cache_size_bytes",
+                "Live SST bytes across all disk-cache column families",
+                disk_cache_size_bytes.clone(),
+            );
+            registry.register(
+                "disk_cache_writes",
+                "Slots committed to the disk cache by source",
+                disk_cache_writes_total.clone(),
+            );
+            registry.register(
+                "disk_cache_written_transactions",
+                "Transactions written to the disk cache",
+                disk_cache_written_transactions_total.clone(),
+            );
+            registry.register(
+                "disk_cache_write_latency_seconds",
+                "Per slot-batch commit latency",
+                disk_cache_write_latency_seconds.clone(),
+            );
+            registry.register(
+                "disk_cache_write_errors",
+                "RocksDB write failures",
+                disk_cache_write_errors_total.clone(),
+            );
+            registry.register(
+                "disk_cache_dropped_to_repair",
+                "Live slots deferred to the repair queue by reason",
+                disk_cache_dropped_to_repair_total.clone(),
+            );
+            registry.register(
+                "disk_cache_evicted_slots",
+                "Slots evicted below the retention floor by reason",
+                disk_cache_evicted_slots_total.clone(),
+            );
+            registry.register(
+                "disk_cache_backfill_slots_remaining",
+                "Holes remaining inside the retention window",
+                disk_cache_backfill_slots_remaining.clone(),
+            );
+            registry.register(
+                "disk_cache_fill_errors",
+                "ClickHouse fetch failures in the backfill/repair filler",
+                disk_cache_fill_errors_total.clone(),
+            );
+            registry.register(
+                "disk_cache_poisoned_slots",
+                "Slots dropped from coverage after decode/consistency failures",
+                disk_cache_poisoned_slots_total.clone(),
+            );
+            registry.register(
+                "disk_cache_wipes",
+                "Times the disk cache database was destroyed and rebuilt",
+                disk_cache_wipes_total.clone(),
+            );
+        }
+
         // Register process metrics to expose basic runtime health info (CPU, memory).
         if let Err(err) =
             kubert_prometheus_process::register(registry.sub_registry_with_prefix("process"))
@@ -774,6 +943,38 @@ impl Metrics {
             head_cache_address_entries,
             #[cfg(feature = "grpc-head-cache")]
             head_cache_slot_entries,
+            #[cfg(feature = "disk-cache")]
+            disk_cache_active,
+            #[cfg(feature = "disk-cache")]
+            disk_cache_reads_total,
+            #[cfg(feature = "disk-cache")]
+            disk_cache_covered_min_slot,
+            #[cfg(feature = "disk-cache")]
+            disk_cache_covered_max_slot,
+            #[cfg(feature = "disk-cache")]
+            disk_cache_contiguous_floor_slot,
+            #[cfg(feature = "disk-cache")]
+            disk_cache_size_bytes,
+            #[cfg(feature = "disk-cache")]
+            disk_cache_writes_total,
+            #[cfg(feature = "disk-cache")]
+            disk_cache_written_transactions_total,
+            #[cfg(feature = "disk-cache")]
+            disk_cache_write_latency_seconds,
+            #[cfg(feature = "disk-cache")]
+            disk_cache_write_errors_total,
+            #[cfg(feature = "disk-cache")]
+            disk_cache_dropped_to_repair_total,
+            #[cfg(feature = "disk-cache")]
+            disk_cache_evicted_slots_total,
+            #[cfg(feature = "disk-cache")]
+            disk_cache_backfill_slots_remaining,
+            #[cfg(feature = "disk-cache")]
+            disk_cache_fill_errors_total,
+            #[cfg(feature = "disk-cache")]
+            disk_cache_poisoned_slots_total,
+            #[cfg(feature = "disk-cache")]
+            disk_cache_wipes_total,
         })
     }
 
@@ -1402,6 +1603,127 @@ pub(crate) fn head_cache_drop_slot(
         metrics
             .head_cache_slot_entries
             .set(clamp_i64_usize(slot_entries));
+    }
+}
+
+#[cfg(feature = "disk-cache")]
+pub(crate) fn disk_cache_set_active(active: bool) {
+    if let Some(metrics) = metrics() {
+        metrics.disk_cache_active.set(i64::from(active));
+    }
+}
+
+#[cfg(feature = "disk-cache")]
+pub(crate) fn disk_cache_read(operation: &'static str, outcome: &'static str) {
+    if let Some(metrics) = metrics() {
+        metrics
+            .disk_cache_reads_total
+            .get_or_create(&DiskCacheReadLabels {
+                operation: operation.to_string(),
+                outcome: outcome.to_string(),
+            })
+            .inc();
+    }
+}
+
+#[cfg(feature = "disk-cache")]
+pub(crate) fn disk_cache_coverage(min_covered: u64, max_covered: u64, contiguous_floor: u64) {
+    if let Some(metrics) = metrics() {
+        metrics
+            .disk_cache_covered_min_slot
+            .set(clamp_i64(min_covered));
+        metrics
+            .disk_cache_covered_max_slot
+            .set(clamp_i64(max_covered));
+        metrics
+            .disk_cache_contiguous_floor_slot
+            .set(clamp_i64(contiguous_floor));
+    }
+}
+
+#[cfg(feature = "disk-cache")]
+pub(crate) fn disk_cache_size_bytes(bytes: u64) {
+    if let Some(metrics) = metrics() {
+        metrics.disk_cache_size_bytes.set(clamp_i64(bytes));
+    }
+}
+
+#[cfg(feature = "disk-cache")]
+pub(crate) fn disk_cache_write(source: &'static str, transactions: u64, latency_seconds: f64) {
+    if let Some(metrics) = metrics() {
+        metrics
+            .disk_cache_writes_total
+            .get_or_create(&DiskCacheSourceLabels {
+                source: source.to_string(),
+            })
+            .inc();
+        metrics
+            .disk_cache_written_transactions_total
+            .inc_by(transactions);
+        metrics
+            .disk_cache_write_latency_seconds
+            .observe(latency_seconds);
+    }
+}
+
+#[cfg(feature = "disk-cache")]
+pub(crate) fn disk_cache_write_error() {
+    if let Some(metrics) = metrics() {
+        metrics.disk_cache_write_errors_total.inc();
+    }
+}
+
+#[cfg(feature = "disk-cache")]
+pub(crate) fn disk_cache_dropped_to_repair(reason: &'static str) {
+    if let Some(metrics) = metrics() {
+        metrics
+            .disk_cache_dropped_to_repair_total
+            .get_or_create(&DiskCacheReasonLabels {
+                reason: reason.to_string(),
+            })
+            .inc();
+    }
+}
+
+#[cfg(feature = "disk-cache")]
+pub(crate) fn disk_cache_evicted(reason: &'static str, slots: u64) {
+    if let Some(metrics) = metrics() {
+        metrics
+            .disk_cache_evicted_slots_total
+            .get_or_create(&DiskCacheReasonLabels {
+                reason: reason.to_string(),
+            })
+            .inc_by(slots);
+    }
+}
+
+#[cfg(feature = "disk-cache")]
+pub(crate) fn disk_cache_backfill_remaining(slots: u64) {
+    if let Some(metrics) = metrics() {
+        metrics
+            .disk_cache_backfill_slots_remaining
+            .set(clamp_i64(slots));
+    }
+}
+
+#[cfg(feature = "disk-cache")]
+pub(crate) fn disk_cache_fill_error() {
+    if let Some(metrics) = metrics() {
+        metrics.disk_cache_fill_errors_total.inc();
+    }
+}
+
+#[cfg(feature = "disk-cache")]
+pub(crate) fn disk_cache_poisoned_slot() {
+    if let Some(metrics) = metrics() {
+        metrics.disk_cache_poisoned_slots_total.inc();
+    }
+}
+
+#[cfg(feature = "disk-cache")]
+pub(crate) fn disk_cache_wipe() {
+    if let Some(metrics) = metrics() {
+        metrics.disk_cache_wipes_total.inc();
     }
 }
 

--- a/crates/superbank-rpc/src/server.rs
+++ b/crates/superbank-rpc/src/server.rs
@@ -29,6 +29,11 @@ use crate::metrics::metrics_handler;
 use crate::processing::ProcessingError;
 use crate::state::{AppState, LatestBlockHeightCache, LatestSlotCache, MetricsHeaderCaptureConfig};
 
+#[cfg(feature = "disk-cache")]
+use crate::disk_cache::{
+    DiskCache, DiskCacheConfig, filler, ingest::DiskIngestSink, ingest::RepairQueue,
+    writer::DiskWriterHandle,
+};
 #[cfg(feature = "grpc-head-cache")]
 use crate::head_cache::dragonsmouth::DragonsmouthHeadCacheConfig;
 #[cfg(feature = "grpc-head-cache")]
@@ -92,6 +97,8 @@ pub enum RpcError {
     Bind(#[from] std::io::Error),
     #[error("Server error: {0}")]
     Server(#[from] HyperError),
+    #[error("Invalid configuration: {0}")]
+    Config(String),
 }
 
 pub async fn run_server(args: RpcConfig) -> RpcResult<()> {
@@ -173,6 +180,37 @@ pub async fn run_server(args: RpcConfig) -> RpcResult<()> {
     #[cfg(feature = "pyroscope")]
     let pyroscope_agent = crate::profiling::start_pyroscope(&args);
 
+    #[cfg(feature = "disk-cache")]
+    if args.disk_cache_enabled {
+        let endpoint_usable = args
+            .dragonsmouth_endpoint
+            .as_deref()
+            .map(str::trim)
+            .is_some_and(|endpoint| !endpoint.is_empty());
+        if !args.head_cache_enabled || !endpoint_usable {
+            return Err(RpcError::Config(
+                "DISK_CACHE_ENABLED=true requires HEAD_CACHE_ENABLED=true and a usable \
+                 DRAGONSMOUTH_ENDPOINT (the DragonsMouth stream is the live ingestion source)"
+                    .to_string(),
+            ));
+        }
+        if args
+            .disk_cache_path
+            .as_deref()
+            .map(str::trim)
+            .is_none_or(str::is_empty)
+        {
+            return Err(RpcError::Config(
+                "DISK_CACHE_ENABLED=true requires DISK_CACHE_PATH".to_string(),
+            ));
+        }
+    }
+
+    let (shutdown_tx, _) = tokio::sync::broadcast::channel::<()>(1);
+
+    #[cfg(feature = "disk-cache")]
+    let mut disk_runtime: Option<DiskCacheRuntime> = None;
+
     #[cfg(feature = "grpc-head-cache")]
     let (head_cache, head_cache_task): (Option<Arc<HeadCache>>, Option<JoinHandle<()>>) = if args
         .head_cache_enabled
@@ -184,18 +222,39 @@ pub async fn run_server(args: RpcConfig) -> RpcResult<()> {
             .filter(|v| !v.is_empty())
         {
             let min_commitment = parse_commitment_level(&args.head_cache_min_commitment);
-            let retain_slots = args.head_cache_retain_slots.max(1);
+            #[allow(unused_mut)]
+            let mut retain_slots = args.head_cache_retain_slots.max(1);
+            #[cfg(feature = "disk-cache")]
+            if args.disk_cache_enabled && retain_slots < DISK_CACHE_MIN_HEAD_RETAIN_SLOTS {
+                warn!(
+                    configured = retain_slots,
+                    clamped = DISK_CACHE_MIN_HEAD_RETAIN_SLOTS,
+                    "HEAD_CACHE_RETAIN_SLOTS is below the mainnet finalization lag; raising it \
+                     so finalized slots are still resident when the disk cache snapshots them"
+                );
+                retain_slots = DISK_CACHE_MIN_HEAD_RETAIN_SLOTS;
+            }
             let max_per_address = args.max_signatures_limit as usize;
 
             let cache = Arc::new(HeadCache::new(retain_slots, max_per_address));
+
+            #[cfg(feature = "disk-cache")]
+            let disk_sink = if args.disk_cache_enabled {
+                let runtime = start_disk_cache(&args, &clickhouse, &cache, &shutdown_tx).await?;
+                let sink = runtime.sink.clone();
+                disk_runtime = Some(runtime);
+                Some(sink)
+            } else {
+                None
+            };
+
             let cfg = DragonsmouthHeadCacheConfig {
                 endpoint: endpoint.to_string(),
                 x_token: args.dragonsmouth_x_token.clone(),
                 max_decoding_bytes: args.grpc_max_decoding_bytes,
                 min_commitment,
-                // Wired up when the disk cache is constructed (disk-cache config phase).
                 #[cfg(feature = "disk-cache")]
-                disk_sink: None,
+                disk_sink,
             };
 
             let task = tokio::spawn(dragonsmouth::run(cache.clone(), cfg));
@@ -232,6 +291,8 @@ pub async fn run_server(args: RpcConfig) -> RpcResult<()> {
         )),
         #[cfg(feature = "grpc-head-cache")]
         head_cache,
+        #[cfg(feature = "disk-cache")]
+        disk_cache: disk_runtime.as_ref().map(|runtime| runtime.cache.clone()),
     });
 
     // Build the router
@@ -265,7 +326,6 @@ pub async fn run_server(args: RpcConfig) -> RpcResult<()> {
         metrics_addr
     );
 
-    let (shutdown_tx, _) = tokio::sync::broadcast::channel::<()>(1);
     let shutdown_signal_tx = shutdown_tx.clone();
     tokio::spawn(async move {
         shutdown_signal().await;
@@ -301,7 +361,110 @@ pub async fn run_server(args: RpcConfig) -> RpcResult<()> {
 
     tokio::try_join!(rpc_server, metrics_server)?;
 
+    // The filler heard the shutdown broadcast; stop the writer thread last so
+    // every queued slot drains and the WAL is flushed. A timeout only costs a
+    // hole that the next start repairs from ClickHouse.
+    #[cfg(feature = "disk-cache")]
+    if let Some(runtime) = disk_runtime {
+        let writer = runtime.writer;
+        let shutdown = tokio::task::spawn_blocking(move || writer.shutdown());
+        if tokio::time::timeout(Duration::from_secs(10), shutdown)
+            .await
+            .is_err()
+        {
+            warn!("disk cache: writer shutdown timed out; holes will be repaired at next start");
+        }
+        metrics::disk_cache_set_active(false);
+    }
+
     Ok(())
+}
+
+#[cfg(feature = "disk-cache")]
+const DISK_CACHE_MIN_HEAD_RETAIN_SLOTS: u64 = 64;
+
+#[cfg(feature = "disk-cache")]
+struct DiskCacheRuntime {
+    cache: Arc<DiskCache>,
+    writer: DiskWriterHandle,
+    sink: Arc<DiskIngestSink>,
+}
+
+/// Open the disk cache and start its writer thread and backfill/repair filler.
+/// Corruption and schema mismatches are handled inside `DiskCache::open`
+/// (wipe-and-rebuild); any other open failure is an operator error that fails
+/// startup loudly.
+#[cfg(feature = "disk-cache")]
+async fn start_disk_cache(
+    args: &RpcConfig,
+    clickhouse: &ClickHouseClient,
+    head_cache: &Arc<HeadCache>,
+    shutdown_tx: &tokio::sync::broadcast::Sender<()>,
+) -> Result<DiskCacheRuntime, RpcError> {
+    let path = args
+        .disk_cache_path
+        .as_deref()
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .expect("validated above");
+
+    let disk_cfg = DiskCacheConfig {
+        path: path.into(),
+        retain_slots: args.disk_cache_retain_slots.max(1),
+        max_bytes: args.disk_cache_max_bytes,
+        block_cache_bytes: args.disk_cache_block_cache_bytes,
+        read_concurrency: args.disk_cache_read_concurrency.max(1),
+    };
+    info!(
+        path,
+        retain_slots = disk_cfg.retain_slots,
+        max_bytes = disk_cfg.max_bytes,
+        backfill_enabled = args.disk_cache_backfill_enabled,
+        "disk cache: starting"
+    );
+
+    let cache = tokio::task::spawn_blocking(move || DiskCache::open(disk_cfg))
+        .await
+        .map_err(|err| RpcError::Config(format!("disk cache open task panicked: {err}")))?
+        .map_err(|err| RpcError::Config(format!("disk cache open failed: {err}")))?;
+    let cache = Arc::new(cache);
+
+    let repair = Arc::new(RepairQueue::new(100_000));
+    let writer = cache.spawn_writer(repair.clone(), args.disk_cache_write_queue_slots.max(1));
+
+    if args.disk_cache_backfill_enabled {
+        let filler_cfg = filler::FillerConfig {
+            retain_slots: args.disk_cache_retain_slots.max(1),
+            slots_per_query: args.disk_cache_backfill_slots_per_query,
+            max_slots_per_sec: args.disk_cache_backfill_max_slots_per_sec,
+            query_timeout: Duration::from_millis(args.disk_cache_backfill_query_timeout_ms),
+            repair_interval: Duration::from_millis(args.disk_cache_repair_interval_ms),
+            repair_min_lag_slots: args.disk_cache_repair_min_lag_slots,
+            ..Default::default()
+        };
+        tokio::spawn(filler::run(
+            cache.clone(),
+            clickhouse.clone(),
+            writer.bulk.clone(),
+            repair.clone(),
+            Some(head_cache.clone()),
+            filler_cfg,
+            shutdown_tx.subscribe(),
+        ));
+    }
+
+    let sink = Arc::new(DiskIngestSink::new(
+        cache.clone(),
+        writer.sender.clone(),
+        repair,
+    ));
+    metrics::disk_cache_set_active(true);
+
+    Ok(DiskCacheRuntime {
+        cache,
+        writer,
+        sink,
+    })
 }
 
 async fn shutdown_signal() {

--- a/crates/superbank-rpc/src/server.rs
+++ b/crates/superbank-rpc/src/server.rs
@@ -193,6 +193,9 @@ pub async fn run_server(args: RpcConfig) -> RpcResult<()> {
                 x_token: args.dragonsmouth_x_token.clone(),
                 max_decoding_bytes: args.grpc_max_decoding_bytes,
                 min_commitment,
+                // Wired up when the disk cache is constructed (disk-cache config phase).
+                #[cfg(feature = "disk-cache")]
+                disk_sink: None,
             };
 
             let task = tokio::spawn(dragonsmouth::run(cache.clone(), cfg));

--- a/crates/superbank-rpc/src/state.rs
+++ b/crates/superbank-rpc/src/state.rs
@@ -16,6 +16,8 @@ use crate::metrics;
 use crate::processing::ProcessingError;
 use crate::util::{current_time_millis, ttl_millis};
 
+#[cfg(feature = "disk-cache")]
+use crate::disk_cache::DiskCache;
 #[cfg(feature = "grpc-head-cache")]
 use crate::head_cache::HeadCache;
 
@@ -39,6 +41,13 @@ pub(crate) struct AppState {
     pub(crate) hydration_sem: Arc<Semaphore>,
     #[cfg(feature = "grpc-head-cache")]
     pub(crate) head_cache: Option<Arc<HeadCache>>,
+    /// Finalized recent-slot cache on local disk; consulted between the head
+    /// cache and ClickHouse. Intentionally not part of latest-slot resolution:
+    /// its tip never leads the head cache, so it adds nothing there.
+    // Consumed once the handler read tiers land; remove the allow then.
+    #[allow(dead_code)]
+    #[cfg(feature = "disk-cache")]
+    pub(crate) disk_cache: Option<Arc<DiskCache>>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/superbank-rpc/src/state.rs
+++ b/crates/superbank-rpc/src/state.rs
@@ -44,8 +44,6 @@ pub(crate) struct AppState {
     /// Finalized recent-slot cache on local disk; consulted between the head
     /// cache and ClickHouse. Intentionally not part of latest-slot resolution:
     /// its tip never leads the head cache, so it adds nothing there.
-    // Consumed once the handler read tiers land; remove the allow then.
-    #[allow(dead_code)]
     #[cfg(feature = "disk-cache")]
     pub(crate) disk_cache: Option<Arc<DiskCache>>,
 }

--- a/crates/superbank-rpc/src/tests/mod.rs
+++ b/crates/superbank-rpc/src/tests/mod.rs
@@ -5700,3 +5700,296 @@ async fn handle_json_rpc_batch_response_aggregates_clickhouse_metrics_header() {
     let items = value.as_array().expect("batch response array");
     assert_eq!(items.len(), 2);
 }
+
+#[cfg(feature = "disk-cache")]
+mod disk_cache_tier {
+    //! Read-tier tests for the disk cache. The unreachable ClickHouse URL
+    //! (`http://127.0.0.1:1`) proves a request was answered without ClickHouse:
+    //! any fallthrough surfaces as an internal/storage error instead.
+
+    use super::*;
+    use crate::disk_cache::tests::{block_metadata, transaction};
+    use crate::disk_cache::{DiskCache, DiskCacheConfig};
+    use crate::handlers::signatures::handle_get_signature_statuses;
+    use crate::handlers::transactions::handle_get_transaction;
+
+    const UNREACHABLE_CLICKHOUSE: &str = "http://127.0.0.1:1";
+
+    fn open_disk_cache(dir: &tempfile::TempDir) -> Arc<DiskCache> {
+        Arc::new(
+            DiskCache::open(DiskCacheConfig {
+                path: dir.path().join("db"),
+                retain_slots: 1_000_000,
+                max_bytes: 0,
+                block_cache_bytes: 8 << 20,
+                read_concurrency: 4,
+            })
+            .expect("open disk cache"),
+        )
+    }
+
+    fn state_with_disk_cache(disk: Arc<DiskCache>) -> Arc<AppState> {
+        let mut state =
+            match Arc::try_unwrap(test_state_with_clickhouse_url(UNREACHABLE_CLICKHOUSE)) {
+                Ok(state) => state,
+                Err(_) => panic!("test state should have a single Arc owner"),
+            };
+        state.disk_cache = Some(disk);
+        Arc::new(state)
+    }
+
+    /// Block at `slot` with `tx_count` transactions; returns the signatures.
+    fn write_block(disk: &DiskCache, slot: u64, parent: u64, tx_count: u32) -> Vec<String> {
+        let meta = block_metadata(slot, parent, u64::from(tx_count));
+        let txs: Vec<_> = (0..tx_count)
+            .map(|idx| Arc::new(transaction(slot, idx)))
+            .collect();
+        let signatures = txs
+            .iter()
+            .map(|tx| bs58::encode(tx.signature).into_string())
+            .collect();
+        disk.write_finalized_slot(&meta, &txs, crate::disk_cache::schema::COVERAGE_SOURCE_LIVE)
+            .expect("write block");
+        signatures
+    }
+
+    #[tokio::test]
+    async fn get_transaction_served_from_disk_without_clickhouse() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let disk = open_disk_cache(&dir);
+        let signatures = write_block(&disk, 100, 99, 2);
+        let state = state_with_disk_cache(disk);
+
+        let response = handle_get_transaction(state, json!(1), Some(vec![json!(signatures[1])]))
+            .await
+            .expect("response");
+        let parsed = parse_json_rpc_response(response).await;
+        assert!(
+            parsed.error.is_none(),
+            "expected success: {:?}",
+            parsed.error
+        );
+        let result = parsed.result.expect("result");
+        assert_eq!(result.get("slot").and_then(Value::as_u64), Some(100));
+    }
+
+    #[tokio::test]
+    async fn get_transaction_conclusive_null_for_covered_slot() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let disk = open_disk_cache(&dir);
+        write_block(&disk, 100, 99, 1);
+        let state = state_with_disk_cache(disk);
+
+        // Signature unknown anywhere, but the request pins a slot the disk
+        // fully covers: conclusively null, no ClickHouse.
+        let unknown = bs58::encode([42u8; 64]).into_string();
+        let response = handle_get_transaction(
+            state,
+            json!(1),
+            Some(vec![json!(unknown), json!({ "slot": 100 })]),
+        )
+        .await
+        .expect("response");
+        let parsed = parse_json_rpc_response(response).await;
+        assert!(parsed.error.is_none(), "expected null: {:?}", parsed.error);
+        assert_eq!(parsed.result, Some(Value::Null));
+    }
+
+    #[tokio::test]
+    async fn get_transaction_miss_still_consults_clickhouse() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let disk = open_disk_cache(&dir);
+        write_block(&disk, 100, 99, 1);
+        let state = state_with_disk_cache(disk);
+
+        // No slot pin: a disk miss proves nothing, so the handler must try
+        // ClickHouse — which is unreachable here.
+        let unknown = bs58::encode([42u8; 64]).into_string();
+        let response = handle_get_transaction(state, json!(1), Some(vec![json!(unknown)]))
+            .await
+            .expect("response");
+        let parsed = parse_json_rpc_response(response).await;
+        assert!(parsed.error.is_some(), "fallthrough should hit ClickHouse");
+    }
+
+    #[tokio::test]
+    async fn get_block_served_from_disk_at_all_detail_levels() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let disk = open_disk_cache(&dir);
+        let signatures = write_block(&disk, 100, 99, 2);
+        let state = state_with_disk_cache(disk);
+
+        for details in ["none", "signatures", "accounts", "full"] {
+            let response = handle_get_block(
+                state.clone(),
+                json!(1),
+                Some(vec![
+                    json!(100),
+                    json!({ "transactionDetails": details, "commitment": "finalized" }),
+                ]),
+            )
+            .await
+            .expect("response");
+            let parsed = parse_json_rpc_response(response).await;
+            assert!(
+                parsed.error.is_none(),
+                "details={details}: {:?}",
+                parsed.error
+            );
+            let result = parsed.result.expect("result");
+            match details {
+                "none" => {
+                    assert!(result.get("signatures").is_none());
+                    assert!(result.get("transactions").is_none());
+                }
+                "signatures" => {
+                    let listed = result
+                        .get("signatures")
+                        .and_then(Value::as_array)
+                        .expect("signatures");
+                    assert_eq!(listed.len(), 2);
+                    assert_eq!(listed[0].as_str(), Some(signatures[0].as_str()));
+                }
+                _ => {
+                    let transactions = result
+                        .get("transactions")
+                        .and_then(Value::as_array)
+                        .expect("transactions");
+                    assert_eq!(transactions.len(), 2);
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn get_block_skipped_slot_is_conclusive() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let disk = open_disk_cache(&dir);
+        write_block(&disk, 100, 99, 1);
+        // Parent link proves 101..=104 were skipped.
+        write_block(&disk, 105, 100, 1);
+        let state = state_with_disk_cache(disk);
+
+        let response = handle_get_block(state, json!(1), Some(vec![json!(103)]))
+            .await
+            .expect("response");
+        let parsed = parse_json_rpc_response(response).await;
+        let error = parsed.error.expect("skipped-slot error");
+        assert_eq!(
+            error.code,
+            solana_rpc_client_api::custom_error::JSON_RPC_SERVER_ERROR_LONG_TERM_STORAGE_SLOT_SKIPPED
+                as i32
+        );
+    }
+
+    #[tokio::test]
+    async fn get_block_uncovered_slot_falls_to_clickhouse() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let disk = open_disk_cache(&dir);
+        write_block(&disk, 100, 99, 1);
+        let state = state_with_disk_cache(disk);
+
+        let response = handle_get_block(state, json!(1), Some(vec![json!(50)]))
+            .await
+            .expect("response");
+        let parsed = parse_json_rpc_response(response).await;
+        let error = parsed
+            .error
+            .expect("uncovered slot must consult ClickHouse");
+        assert_eq!(error.code, -32603);
+    }
+
+    #[tokio::test]
+    async fn get_block_time_from_disk() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let disk = open_disk_cache(&dir);
+        write_block(&disk, 100, 99, 1);
+        write_block(&disk, 105, 100, 1);
+        let state = state_with_disk_cache(disk);
+
+        let response = handle_get_block_time(state.clone(), json!(1), Some(vec![json!(100)]))
+            .await
+            .expect("response");
+        let parsed = parse_json_rpc_response(response).await;
+        assert!(parsed.error.is_none(), "{:?}", parsed.error);
+        assert_eq!(parsed.result.and_then(|v| v.as_i64()), Some(1_700_000_100));
+
+        // Skipped slot: conclusive error without ClickHouse.
+        let response = handle_get_block_time(state, json!(1), Some(vec![json!(102)]))
+            .await
+            .expect("response");
+        let parsed = parse_json_rpc_response(response).await;
+        let error = parsed.error.expect("skipped-slot error");
+        assert_eq!(error.code, -32009);
+    }
+
+    #[tokio::test]
+    async fn get_blocks_range_within_disk_coverage() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let disk = open_disk_cache(&dir);
+        for slot in 100..=105u64 {
+            write_block(&disk, slot, slot - 1, 1);
+        }
+        let state = state_with_disk_cache(disk);
+
+        let response = handle_get_blocks(state, json!(1), Some(vec![json!(100), json!(105)]))
+            .await
+            .expect("response");
+        let parsed = parse_json_rpc_response(response).await;
+        assert!(parsed.error.is_none(), "{:?}", parsed.error);
+        let slots: Vec<u64> = parsed
+            .result
+            .and_then(|v| {
+                v.as_array()
+                    .map(|values| values.iter().filter_map(Value::as_u64).collect())
+            })
+            .expect("slot list");
+        assert_eq!(slots, vec![100, 101, 102, 103, 104, 105]);
+    }
+
+    #[tokio::test]
+    async fn get_signature_statuses_served_from_disk() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let disk = open_disk_cache(&dir);
+        let signatures = write_block(&disk, 100, 99, 2);
+        let state = state_with_disk_cache(disk);
+
+        let response = handle_get_signature_statuses(
+            state,
+            json!(1),
+            Some(vec![json!([signatures[0], signatures[1]])]),
+        )
+        .await
+        .expect("response");
+        let parsed = parse_json_rpc_response(response).await;
+        assert!(parsed.error.is_none(), "{:?}", parsed.error);
+        let value = parsed
+            .result
+            .and_then(|mut result| result.get_mut("value").map(Value::take))
+            .expect("statuses");
+        let statuses = value.as_array().expect("array");
+        assert_eq!(statuses.len(), 2);
+        for status in statuses {
+            assert_eq!(
+                status.get("confirmationStatus").and_then(Value::as_str),
+                Some("finalized")
+            );
+            assert_eq!(status.get("slot").and_then(Value::as_u64), Some(100));
+        }
+    }
+
+    #[tokio::test]
+    async fn get_signature_statuses_unknown_signature_consults_clickhouse() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let disk = open_disk_cache(&dir);
+        write_block(&disk, 100, 99, 1);
+        let state = state_with_disk_cache(disk);
+
+        let unknown = bs58::encode([7u8; 64]).into_string();
+        let response = handle_get_signature_statuses(state, json!(1), Some(vec![json!([unknown])]))
+            .await
+            .expect("response");
+        let parsed = parse_json_rpc_response(response).await;
+        assert!(parsed.error.is_some(), "fallthrough should hit ClickHouse");
+    }
+}

--- a/crates/superbank-rpc/src/tests/mod.rs
+++ b/crates/superbank-rpc/src/tests/mod.rs
@@ -162,6 +162,8 @@ fn test_state_with_token_owner_activity_available(available: bool) -> Arc<AppSta
         hydration_sem: Arc::new(Semaphore::new(8)),
         #[cfg(feature = "grpc-head-cache")]
         head_cache: None,
+        #[cfg(feature = "disk-cache")]
+        disk_cache: None,
     })
 }
 
@@ -229,6 +231,8 @@ fn test_state_with_clickhouse_url(clickhouse_url: &str) -> Arc<AppState> {
         hydration_sem: Arc::new(Semaphore::new(8)),
         #[cfg(feature = "grpc-head-cache")]
         head_cache: None,
+        #[cfg(feature = "disk-cache")]
+        disk_cache: None,
     })
 }
 
@@ -281,6 +285,8 @@ async fn test_state_with_clickhouse_cached_signature_slot(
         hydration_sem: Arc::new(Semaphore::new(8)),
         #[cfg(feature = "grpc-head-cache")]
         head_cache: None,
+        #[cfg(feature = "disk-cache")]
+        disk_cache: None,
     })
 }
 
@@ -324,6 +330,8 @@ fn test_state_with_head_cache(head_cache: Arc<HeadCache>) -> Arc<AppState> {
         metrics_header_capture: Default::default(),
         hydration_sem: Arc::new(Semaphore::new(8)),
         head_cache: Some(head_cache),
+        #[cfg(feature = "disk-cache")]
+        disk_cache: None,
     })
 }
 
@@ -370,6 +378,8 @@ fn test_state_with_head_cache_and_clickhouse_url(
         metrics_header_capture: Default::default(),
         hydration_sem: Arc::new(Semaphore::new(8)),
         head_cache: Some(head_cache),
+        #[cfg(feature = "disk-cache")]
+        disk_cache: None,
     })
 }
 
@@ -423,6 +433,8 @@ async fn test_state_with_head_cache_and_cached_signature_slot(
         metrics_header_capture: Default::default(),
         hydration_sem: Arc::new(Semaphore::new(8)),
         head_cache: Some(head_cache),
+        #[cfg(feature = "disk-cache")]
+        disk_cache: None,
     })
 }
 

--- a/crates/superbank-rpc/src/tests/mod.rs
+++ b/crates/superbank-rpc/src/tests/mod.rs
@@ -5978,6 +5978,388 @@ mod disk_cache_tier {
         }
     }
 
+    fn state_with_head_and_disk(head: Arc<HeadCache>, disk: Arc<DiskCache>) -> Arc<AppState> {
+        let mut state = match Arc::try_unwrap(test_state_with_head_cache_and_clickhouse_url(
+            head,
+            UNREACHABLE_CLICKHOUSE,
+        )) {
+            Ok(state) => state,
+            Err(_) => panic!("test state should have a single Arc owner"),
+        };
+        state.disk_cache = Some(disk);
+        Arc::new(state)
+    }
+
+    /// Block at `slot` whose single transaction touches `address`; returns the
+    /// signature string.
+    fn write_block_for_address(
+        disk: &DiskCache,
+        slot: u64,
+        parent: u64,
+        address: [u8; 32],
+        failed: bool,
+    ) -> String {
+        let meta = block_metadata(slot, parent, 1);
+        let mut tx = transaction(slot, 0);
+        tx.tx_account_keys = vec![address];
+        if failed {
+            tx.meta_status_ok = false;
+            tx.meta_err = Some("\"AccountNotFound\"".to_string());
+        }
+        let signature = bs58::encode(tx.signature).into_string();
+        disk.write_finalized_slot(
+            &meta,
+            &[Arc::new(tx)],
+            crate::disk_cache::schema::COVERAGE_SOURCE_LIVE,
+        )
+        .expect("write block");
+        signature
+    }
+
+    fn empty_head_cache() -> Arc<HeadCache> {
+        Arc::new(HeadCache::new(64, TEST_MAX_LIMIT as usize))
+    }
+
+    #[tokio::test]
+    async fn gsfa_disk_serves_within_coverage_without_clickhouse() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let disk = open_disk_cache(&dir);
+        let address = [50u8; 32];
+        let mut signatures = Vec::new();
+        for slot in 100..=105u64 {
+            signatures.push(write_block_for_address(
+                &disk,
+                slot,
+                slot - 1,
+                address,
+                false,
+            ));
+        }
+        let state = state_with_head_and_disk(empty_head_cache(), disk);
+        let address_str = bs58::encode(address).into_string();
+
+        // Limit satisfied from disk: no ClickHouse.
+        let response = handle_get_signatures_for_address(
+            state.clone(),
+            json!(1),
+            Some(vec![json!(address_str), json!({ "limit": 3 })]),
+        )
+        .await
+        .expect("response");
+        let parsed = parse_json_rpc_response(response).await;
+        assert!(parsed.error.is_none(), "{:?}", parsed.error);
+        let rows = parsed.result.expect("rows");
+        let rows = rows.as_array().expect("array");
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0].get("slot").and_then(Value::as_u64), Some(105));
+        assert_eq!(rows[2].get("slot").and_then(Value::as_u64), Some(103));
+        assert_eq!(
+            rows[0].get("confirmationStatus").and_then(Value::as_str),
+            Some("finalized")
+        );
+
+        // until inside coverage: fully answered even though fewer than limit.
+        let response = handle_get_signatures_for_address(
+            state.clone(),
+            json!(1),
+            Some(vec![
+                json!(address_str),
+                json!({ "limit": 100, "untilSlot": 102 }),
+            ]),
+        )
+        .await
+        .expect("response");
+        let parsed = parse_json_rpc_response(response).await;
+        assert!(parsed.error.is_none(), "{:?}", parsed.error);
+        let rows = parsed.result.expect("rows");
+        assert_eq!(rows.as_array().map(Vec::len), Some(3)); // 105, 104, 103
+
+        // before resolved by the disk signature index, until keeps the scan
+        // inside coverage: still no ClickHouse.
+        let response = handle_get_signatures_for_address(
+            state.clone(),
+            json!(1),
+            Some(vec![
+                json!(address_str),
+                json!({ "limit": 100, "before": signatures[4], "untilSlot": 101 }),
+            ]),
+        )
+        .await
+        .expect("response");
+        let parsed = parse_json_rpc_response(response).await;
+        assert!(parsed.error.is_none(), "{:?}", parsed.error);
+        let rows = parsed.result.expect("rows");
+        let rows = rows.as_array().expect("array");
+        assert_eq!(rows.len(), 2); // 103, 102
+        assert_eq!(rows[0].get("slot").and_then(Value::as_u64), Some(103));
+
+        // Limit straddles the coverage floor: ClickHouse must be consulted and
+        // is unreachable here.
+        let response = handle_get_signatures_for_address(
+            state,
+            json!(1),
+            Some(vec![json!(address_str), json!({ "limit": 100 })]),
+        )
+        .await
+        .expect("response");
+        let parsed = parse_json_rpc_response(response).await;
+        assert!(parsed.error.is_some(), "floor escape must hit ClickHouse");
+    }
+
+    #[tokio::test]
+    async fn gsfa_deduplicates_head_and_disk_rows() {
+        use solana_commitment_config::CommitmentLevel;
+        use solana_sdk::signature::Signature as SdkSignature;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let disk = open_disk_cache(&dir);
+        let address = [51u8; 32];
+        let signature = write_block_for_address(&disk, 100, 99, address, false);
+
+        // The same transaction is still resident in the head cache.
+        let head = empty_head_cache();
+        let mut tx = transaction(100, 0);
+        tx.tx_account_keys = vec![address];
+        head.insert_for_tests(
+            SdkSignature::from(tx.signature),
+            tx,
+            0,
+            &[solana_sdk::pubkey::Pubkey::from(address)],
+            CommitmentLevel::Finalized,
+        );
+
+        let state = state_with_head_and_disk(head, disk);
+        let response = handle_get_signatures_for_address(
+            state,
+            json!(1),
+            Some(vec![
+                json!(bs58::encode(address).into_string()),
+                json!({ "limit": 10, "untilSlot": 99 }),
+            ]),
+        )
+        .await
+        .expect("response");
+        let parsed = parse_json_rpc_response(response).await;
+        assert!(parsed.error.is_none(), "{:?}", parsed.error);
+        let rows = parsed.result.expect("rows");
+        let rows = rows.as_array().expect("array");
+        assert_eq!(rows.len(), 1, "head+disk duplicate must collapse");
+        assert_eq!(
+            rows[0].get("signature").and_then(Value::as_str),
+            Some(signature.as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn gtfa_desc_served_from_disk_with_filters() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let disk = open_disk_cache(&dir);
+        let address = [52u8; 32];
+        for slot in 100..=105u64 {
+            // Odd slots fail.
+            write_block_for_address(&disk, slot, slot - 1, address, slot % 2 == 1);
+        }
+        let state = state_with_disk_cache(disk);
+        let address_str = bs58::encode(address).into_string();
+
+        // slot.gte above the floor: fully covered, status filter on disk.
+        let response = handle_get_transactions_for_address(
+            state.clone(),
+            json!(1),
+            Some(vec![
+                json!(address_str),
+                json!({
+                    "limit": 10,
+                    "filters": { "slot": { "gte": 101 }, "status": "failed" }
+                }),
+            ]),
+        )
+        .await
+        .expect("response");
+        let parsed = parse_json_rpc_response(response).await;
+        assert!(parsed.error.is_none(), "{:?}", parsed.error);
+        let result = parsed.result.expect("result");
+        let data = result.get("data").and_then(Value::as_array).expect("data");
+        let slots: Vec<u64> = data
+            .iter()
+            .filter_map(|row| row.get("slot").and_then(Value::as_u64))
+            .collect();
+        assert_eq!(slots, vec![105, 103, 101]);
+        // Disk-sourced pagination tokens are position-shaped.
+        assert_eq!(
+            result.get("paginationToken").and_then(Value::as_str),
+            Some("101:0")
+        );
+
+        // Small limit fills from disk: no ClickHouse even without slot bounds.
+        let response = handle_get_transactions_for_address(
+            state.clone(),
+            json!(1),
+            Some(vec![json!(address_str), json!({ "limit": 2 })]),
+        )
+        .await
+        .expect("response");
+        let parsed = parse_json_rpc_response(response).await;
+        assert!(parsed.error.is_none(), "{:?}", parsed.error);
+
+        // Unbounded request larger than coverage: ClickHouse owes the
+        // remainder and is unreachable.
+        let response = handle_get_transactions_for_address(
+            state,
+            json!(1),
+            Some(vec![json!(address_str), json!({ "limit": 100 })]),
+        )
+        .await
+        .expect("response");
+        let parsed = parse_json_rpc_response(response).await;
+        assert!(parsed.error.is_some(), "floor escape must hit ClickHouse");
+    }
+
+    #[tokio::test]
+    async fn gtfa_asc_pages_only_within_coverage() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let disk = open_disk_cache(&dir);
+        let address = [53u8; 32];
+        for slot in 100..=104u64 {
+            write_block_for_address(&disk, slot, slot - 1, address, false);
+        }
+        let state = state_with_disk_cache(disk);
+        let address_str = bs58::encode(address).into_string();
+
+        // Ascending with a lower bound inside coverage: disk only.
+        let response = handle_get_transactions_for_address(
+            state.clone(),
+            json!(1),
+            Some(vec![
+                json!(address_str),
+                json!({
+                    "limit": 10,
+                    "sortOrder": "asc",
+                    "filters": { "slot": { "gte": 101 } }
+                }),
+            ]),
+        )
+        .await
+        .expect("response");
+        let parsed = parse_json_rpc_response(response).await;
+        assert!(parsed.error.is_none(), "{:?}", parsed.error);
+        let result = parsed.result.expect("result");
+        let slots: Vec<u64> = result
+            .get("data")
+            .and_then(Value::as_array)
+            .expect("data")
+            .iter()
+            .filter_map(|row| row.get("slot").and_then(Value::as_u64))
+            .collect();
+        assert_eq!(slots, vec![101, 102, 103, 104]);
+
+        // Ascending from below the floor: the oldest rows lead the page, so
+        // ClickHouse must serve it (unreachable here).
+        let response = handle_get_transactions_for_address(
+            state,
+            json!(1),
+            Some(vec![
+                json!(address_str),
+                json!({ "limit": 10, "sortOrder": "asc" }),
+            ]),
+        )
+        .await
+        .expect("response");
+        let parsed = parse_json_rpc_response(response).await;
+        assert!(
+            parsed.error.is_some(),
+            "asc below floor must hit ClickHouse"
+        );
+    }
+
+    #[tokio::test]
+    async fn gtfa_token_accounts_filter_unions_owner_index() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let disk = open_disk_cache(&dir);
+        let owner = [54u8; 32];
+
+        // Slot 100: owner only via token-owner index, balance changed.
+        let meta = block_metadata(100, 99, 1);
+        let mut tx = transaction(100, 0);
+        tx.tx_account_keys = vec![[1u8; 32], [2u8; 32]];
+        tx.meta_post_token_account_index = vec![1];
+        tx.meta_post_token_owner = vec![Some(owner)];
+        tx.meta_post_token_amount = vec!["5".to_string()];
+        disk.write_finalized_slot(
+            &meta,
+            &[Arc::new(tx)],
+            crate::disk_cache::schema::COVERAGE_SOURCE_LIVE,
+        )
+        .expect("write");
+
+        // Slot 101: owner only via token-owner index, balance unchanged.
+        let meta = block_metadata(101, 100, 1);
+        let mut tx = transaction(101, 0);
+        tx.tx_account_keys = vec![[1u8; 32], [2u8; 32]];
+        tx.meta_pre_token_account_index = vec![1];
+        tx.meta_pre_token_owner = vec![Some(owner)];
+        tx.meta_pre_token_amount = vec!["7".to_string()];
+        tx.meta_post_token_account_index = vec![1];
+        tx.meta_post_token_owner = vec![Some(owner)];
+        tx.meta_post_token_amount = vec!["7".to_string()];
+        disk.write_finalized_slot(
+            &meta,
+            &[Arc::new(tx)],
+            crate::disk_cache::schema::COVERAGE_SOURCE_LIVE,
+        )
+        .expect("write");
+
+        // Slot 102: owner directly in the account keys (gsfa side of the union).
+        write_block_for_address(&disk, 102, 101, owner, false);
+
+        let state = state_with_disk_cache(disk);
+        let address_str = bs58::encode(owner).into_string();
+
+        async fn fetch_slots(
+            state: Arc<AppState>,
+            address_str: &str,
+            token_accounts: &str,
+        ) -> Vec<u64> {
+            let response = handle_get_transactions_for_address(
+                state,
+                json!(1),
+                Some(vec![
+                    json!(address_str),
+                    json!({
+                        "limit": 10,
+                        "filters": { "slot": { "gte": 100 }, "tokenAccounts": token_accounts }
+                    }),
+                ]),
+            )
+            .await
+            .expect("response");
+            let parsed = parse_json_rpc_response(response).await;
+            assert!(parsed.error.is_none(), "{:?}", parsed.error);
+            parsed
+                .result
+                .expect("result")
+                .get("data")
+                .and_then(Value::as_array)
+                .expect("data")
+                .iter()
+                .filter_map(|row| row.get("slot").and_then(Value::as_u64))
+                .collect::<Vec<u64>>()
+        }
+
+        // All: both token rows plus the gsfa row.
+        let slots = fetch_slots(state.clone(), &address_str, "all").await;
+        assert_eq!(slots, vec![102, 101, 100]);
+
+        // BalanceChanged: the unchanged-balance token row drops out; the gsfa
+        // row stays (the union filters only the token side).
+        let slots = fetch_slots(state.clone(), &address_str, "balanceChanged").await;
+        assert_eq!(slots, vec![102, 100]);
+
+        // None: only the gsfa row.
+        let slots = fetch_slots(state, &address_str, "none").await;
+        assert_eq!(slots, vec![102]);
+    }
+
     #[tokio::test]
     async fn get_signature_statuses_unknown_signature_consults_clickhouse() {
         let dir = tempfile::tempdir().expect("tempdir");

--- a/tests/k6/README.md
+++ b/tests/k6/README.md
@@ -1,7 +1,7 @@
 # superbank-rpc k6 Load Tests
 
 Comprehensive load testing suite for superbank-rpc methods, including stress tests for many supported RPCs.
-Includes basic tests plus validation tests for `getSignaturesForAddress`, `getTransaction`, `getBlock`, `getTransactionCount`, `getInflationReward`, a dedicated endpoint-comparison scenario for `getTransactionsForAddress`, and a disk-cache parity scenario (`superbank-rpc-disk-cache-parity.js`) that diffs a disk-cache-enabled target against a reference across every method the disk tier serves.
+Includes basic tests plus validation tests for `getSignaturesForAddress`, `getTransaction`, `getBlock`, `getTransactionCount`, `getInflationReward`, a dedicated endpoint-comparison scenario for `getTransactionsForAddress`, a disk-cache parity scenario (`superbank-rpc-disk-cache-parity.js`) that diffs a disk-cache-enabled target against a reference across every method the disk tier serves, and a disk-cache performance comparison scenario (`superbank-rpc-disk-cache-compare.js`) that reports latency deltas and speedup ratios versus a non-disk reference.
 
 ## Quick Start
 
@@ -74,6 +74,14 @@ k6 run tests/k6/scenarios/validation/superbank-rpc-validate-get-transactions-for
 
 # Validation test for JSON-RPC batch semantics (no reference RPC required)
 k6 run tests/k6/scenarios/validation/superbank-rpc-validate-batch.js -e RPC_URL=http://localhost:8899
+
+# Disk-cache performance comparison against a non-disk reference
+k6 run tests/k6/scenarios/performance/superbank-rpc-disk-cache-compare.js \
+  -e RPC_URL=http://disk-enabled:8899 \
+  -e REFERENCE_RPC_URL=http://disk-disabled:8899 \
+  -e ADDRESS_FILE=./tests/k6/data/pools/addresses.txt \
+  -e VUS=10 \
+  -e DURATION=60s
 
 # Stress test for getBlock
 k6 run tests/k6/scenarios/stress/stress-test-get-block.js -e RPC_URL=http://localhost:8899 -e SLOT_FILE=./tests/k6/data/pools/slots.txt
@@ -225,6 +233,34 @@ k6 run tests/k6/scenarios/validation/superbank-rpc-validate-get-transactions-for
 k6 run tests/k6/scenarios/validation/superbank-rpc-validate-batch.js \
   -e RPC_URL=http://localhost:8899
 ```
+
+### Disk-Cache Performance Comparison (`superbank-rpc-disk-cache-compare.js`)
+
+Compare a disk-cache-enabled target (`RPC_URL`) with the same server build running without disk
+cache (`REFERENCE_RPC_URL`). The setup phase probes recent finalized slots, derives stable
+`getSignaturesForAddress` signature cursors from the target coverage span, and keeps only requests
+whose target response reports `X-Superbank-Sources: disk-cache`. The measured
+`getSignaturesForAddress` workload uses standard Solana `before`/`until` cursors. The load phase
+alternates call order between the two endpoints and reports per-method target/reference latency,
+latency delta, and speedup ratio.
+
+```bash
+k6 run tests/k6/scenarios/performance/superbank-rpc-disk-cache-compare.js \
+  -e RPC_URL=http://disk-enabled:8899 \
+  -e REFERENCE_RPC_URL=http://disk-disabled:8899 \
+  -e ADDRESS_FILE=./tests/k6/data/pools/addresses.txt \
+  -e VUS=10 \
+  -e DURATION=60s
+```
+
+Useful knobs:
+- `PERF_SLOT_SPAN` / `PERF_BLOCK_SAMPLES`: recent finalized slot window and sampled block count.
+- `PERF_ADDRESS_SAMPLES` / `PERF_PAGE_SIZE`: address workload size for gSFA/gTFA.
+- `PERF_METHODS`: comma-separated labels such as `get_block_full,get_transaction`.
+- `PERF_ALLOW_MIXED_SOURCES=1`: accepts `disk-cache,clickhouse` responses when intentionally testing tier-boundary paths. `head-cache,disk-cache` is accepted by default because the source header reports every tier touched.
+- `PERF_NORMALIZE_PROVIDER_DIFFS=0`: disables default normalization for live-reference differences. By default the comparator ignores `getSignatureStatuses.context.slot` drift and token-balance `uiTokenAmount.uiAmount` null-vs-number differences when canonical token fields are present.
+- `PERF_DEBUG_MISMATCHES=1`: logs mismatched request params, source headers, first differing JSON path, and trimmed target/reference result snippets.
+- `PERF_DEBUG_MISMATCHES_MAX` / `PERF_DEBUG_BODY_CHARS`: cap mismatch log count and result snippet size.
 
 ### Stress Test (`stress-test.js`)
 

--- a/tests/k6/README.md
+++ b/tests/k6/README.md
@@ -1,7 +1,7 @@
 # superbank-rpc k6 Load Tests
 
 Comprehensive load testing suite for superbank-rpc methods, including stress tests for many supported RPCs.
-Includes basic tests plus validation tests for `getSignaturesForAddress`, `getTransaction`, `getBlock`, `getTransactionCount`, `getInflationReward`, and a dedicated endpoint-comparison scenario for `getTransactionsForAddress`.
+Includes basic tests plus validation tests for `getSignaturesForAddress`, `getTransaction`, `getBlock`, `getTransactionCount`, `getInflationReward`, a dedicated endpoint-comparison scenario for `getTransactionsForAddress`, and a disk-cache parity scenario (`superbank-rpc-disk-cache-parity.js`) that diffs a disk-cache-enabled target against a reference across every method the disk tier serves.
 
 ## Quick Start
 

--- a/tests/k6/scenarios/performance/superbank-rpc-disk-cache-compare.js
+++ b/tests/k6/scenarios/performance/superbank-rpc-disk-cache-compare.js
@@ -1,0 +1,944 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+/*
+ * Copyright 2025-2026 Triton One Limited. All rights reserved.
+ */
+
+// Disk-cache performance comparison for superbank-rpc.
+//
+// Purpose: compare a disk-cache-enabled target against the same service with
+// disk cache disabled, while proving the target requests are real disk-cache
+// hits via X-Superbank-Sources. The summary reports target/reference latency,
+// latency deltas, and speedup ratios per disk-served method.
+//
+// Usage:
+//   k6 run tests/k6/scenarios/performance/superbank-rpc-disk-cache-compare.js \
+//     -e RPC_URL=http://disk-enabled:8899 \
+//     -e REFERENCE_RPC_URL=http://disk-disabled:8899 \
+//     -e ADDRESS_FILE=tests/k6/data/pools/addresses.txt
+//
+// Tuning:
+//   PERF_SLOT_SPAN          slots below shared tip to scan (default 512)
+//   PERF_BLOCK_SAMPLES      max block slots to retain (default 32)
+//   PERF_ADDRESS_SAMPLES    max addresses to probe (default 20)
+//   PERF_PAGE_SIZE          address page size (default 100)
+//   PERF_METHODS            comma list of method labels to include
+//   PERF_ALLOW_MIXED_SOURCES=1 accepts disk-cache plus ClickHouse
+//   PERF_VALIDATE_RESULTS=0 disables response parity checks
+//   PERF_NORMALIZE_PROVIDER_DIFFS=0 disables live-reference normalization
+//   PERF_DEBUG_MISMATCHES=1 logs mismatch metadata and result snippets
+
+import http from 'k6/http';
+import { check, fail } from 'k6';
+import { Counter, Rate, Trend } from 'k6/metrics';
+import { config, parseNonNegativeIntEnv, scenarios } from '../../lib/config.js';
+import { initAddressPool } from '../../lib/addresses.js';
+import { deepEqual } from '../../lib/compare.js';
+
+const rpcUrl = config.rpcUrl;
+const referenceUrl = config.referenceRpcUrl;
+const slotSpan = parsePositiveIntEnv('PERF_SLOT_SPAN', 512);
+const blockSamples = parsePositiveIntEnv('PERF_BLOCK_SAMPLES', 32);
+const addressSamples = parseNonNegativeIntEnv('PERF_ADDRESS_SAMPLES', 20);
+const pageSize = parsePositiveIntEnv('PERF_PAGE_SIZE', 100);
+const signaturesPerBlock = parsePositiveIntEnv('PERF_SIGNATURES_PER_BLOCK', 4);
+const signatureStatusBatch = parsePositiveIntEnv('PERF_SIGNATURE_STATUS_BATCH', 16);
+const blocksRange = parsePositiveIntEnv('PERF_BLOCKS_RANGE', 32);
+const blocksLimit = parsePositiveIntEnv('PERF_BLOCKS_LIMIT', 32);
+const tipLag = parseNonNegativeIntEnv('PERF_TIP_LAG', 64);
+const setupTimeout = __ENV.PERF_SETUP_TIMEOUT || '30s';
+const requestTimeout = __ENV.PERF_REQUEST_TIMEOUT || '30s';
+const validateResults = __ENV.PERF_VALIDATE_RESULTS !== '0';
+const normalizeProviderDiffs = __ENV.PERF_NORMALIZE_PROVIDER_DIFFS !== '0';
+const allowMixedSources =
+  __ENV.PERF_ALLOW_MIXED_SOURCES === '1' ||
+  __ENV.PERF_ALLOW_MIXED_SOURCES === 'true';
+const debugMismatches =
+  __ENV.PERF_DEBUG_MISMATCHES === '1' ||
+  __ENV.PERF_DEBUG_MISMATCHES === 'true';
+const debugMismatchesMax = parseNonNegativeIntEnv('PERF_DEBUG_MISMATCHES_MAX', 10);
+const debugBodyChars = parseNonNegativeIntEnv('PERF_DEBUG_BODY_CHARS', 2000);
+
+const methodLabels = [
+  'get_block_full',
+  'get_block_signatures',
+  'get_block_time',
+  'get_blocks',
+  'get_blocks_with_limit',
+  'get_transaction',
+  'get_signature_statuses',
+  'get_signatures_for_address',
+  'get_transactions_for_address',
+];
+
+const gsfaIgnoredAddresses = new Set([
+  '11111111111111111111111111111111',
+  'Vote111111111111111111111111111111111111111',
+  'SysvarC1ock11111111111111111111111111111111',
+  'SysvarS1otHashes111111111111111111111111111',
+]);
+
+const defaultMethods = new Set(methodLabels);
+const enabledMethods = parseMethodSet(__ENV.PERF_METHODS || '');
+const addressMethodsEnabled =
+  enabledMethods.has('get_signatures_for_address') ||
+  enabledMethods.has('get_transactions_for_address');
+const addressPool =
+  addressMethodsEnabled && addressSamples > 0 ? initAddressPool() : [];
+
+const metricByMethod = {
+  get_block_full: makeMethodMetrics('get_block_full'),
+  get_block_signatures: makeMethodMetrics('get_block_signatures'),
+  get_block_time: makeMethodMetrics('get_block_time'),
+  get_blocks: makeMethodMetrics('get_blocks'),
+  get_blocks_with_limit: makeMethodMetrics('get_blocks_with_limit'),
+  get_transaction: makeMethodMetrics('get_transaction'),
+  get_signature_statuses: makeMethodMetrics('get_signature_statuses'),
+  get_signatures_for_address: makeMethodMetrics('get_signatures_for_address'),
+  get_transactions_for_address: makeMethodMetrics('get_transactions_for_address'),
+};
+
+const targetDiskHitRate = new Rate('diskcache_perf_target_disk_hit_rate');
+const targetClickhouseTouchRate = new Rate('diskcache_perf_target_clickhouse_touch_rate');
+const referenceDiskCacheRate = new Rate('diskcache_perf_reference_disk_cache_rate');
+const responseParityRate = new Rate('diskcache_perf_response_parity_rate');
+const targetSuccessRate = new Rate('diskcache_perf_target_success_rate');
+const referenceSuccessRate = new Rate('diskcache_perf_reference_success_rate');
+const comparisonsTotal = new Counter('diskcache_perf_comparisons_total');
+const speedupWinsTotal = new Counter('diskcache_perf_speedup_wins_total');
+
+let requestId = 0;
+let mismatchLogs = 0;
+
+export const options = {
+  vus: scenarios.basic.vus,
+  duration: scenarios.basic.duration,
+  thresholds: {
+    http_req_failed: [`rate<${config.thresholds.httpFailRate}`],
+    diskcache_perf_target_success_rate: ['rate>=0.99'],
+    diskcache_perf_reference_success_rate: ['rate>=0.99'],
+    diskcache_perf_target_disk_hit_rate: [
+      allowMixedSources ? 'rate>=0.99' : 'rate==1.0',
+    ],
+    diskcache_perf_reference_disk_cache_rate: ['rate==0.0'],
+    diskcache_perf_response_parity_rate: [
+      validateResults ? 'rate>=0.99' : 'rate>=0.0',
+    ],
+  },
+};
+
+function parsePositiveIntEnv(name, defaultValue) {
+  const raw = __ENV[name];
+  if (raw === undefined || raw === null || raw === '') {
+    return defaultValue;
+  }
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    return defaultValue;
+  }
+  return parsed;
+}
+
+function parseMethodSet(raw) {
+  if (!raw) {
+    return defaultMethods;
+  }
+  const requested = new Set(
+    raw
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean),
+  );
+  const unknown = Array.from(requested).filter((entry) => !defaultMethods.has(entry));
+  if (unknown.length > 0) {
+    throw new Error(`Unknown PERF_METHODS entries: ${unknown.join(', ')}`);
+  }
+  return requested;
+}
+
+function makeMethodMetrics(label) {
+  return {
+    targetLatency: new Trend(`diskcache_perf_${label}_target_ms`, true),
+    referenceLatency: new Trend(`diskcache_perf_${label}_reference_ms`, true),
+    delta: new Trend(`diskcache_perf_${label}_delta_ms`, true),
+    speedup: new Trend(`diskcache_perf_${label}_speedup_ratio`),
+    targetRequests: new Counter(`diskcache_perf_${label}_target_requests_total`),
+    referenceRequests: new Counter(`diskcache_perf_${label}_reference_requests_total`),
+    diskHits: new Counter(`diskcache_perf_${label}_disk_hits_total`),
+    parityMismatches: new Counter(`diskcache_perf_${label}_parity_mismatches_total`),
+  };
+}
+
+function getHeaderValue(headers, ...keys) {
+  if (!headers) {
+    return null;
+  }
+  for (const key of keys) {
+    const value = headers[key] ?? headers[key.toLowerCase()];
+    if (value !== undefined && value !== null) {
+      return Array.isArray(value) ? value[0] : value;
+    }
+  }
+  return null;
+}
+
+function sourceContains(source, token) {
+  const normalized = String(source || '').toLowerCase().trim();
+  if (normalized === 'all') {
+    return ['head-cache', 'disk-cache', 'clickhouse'].includes(token);
+  }
+  return normalized
+    .split(',')
+    .map((entry) => entry.trim())
+    .includes(token);
+}
+
+function isAcceptedDiskSource(source) {
+  if (!sourceContains(source, 'disk-cache')) {
+    return false;
+  }
+  if (!allowMixedSources && sourceContains(source, 'clickhouse')) {
+    return false;
+  }
+  if (allowMixedSources) {
+    return true;
+  }
+  return true;
+}
+
+function rpc(url, method, params, timeout = requestTimeout) {
+  requestId += 1;
+  const response = http.post(
+    url,
+    JSON.stringify({ jsonrpc: '2.0', id: requestId, method, params }),
+    { headers: { 'Content-Type': 'application/json' }, timeout },
+  );
+  let body = null;
+  try {
+    body = JSON.parse(response.body);
+  } catch (_) {
+    body = null;
+  }
+  return {
+    response,
+    body,
+    source: getHeaderValue(
+      response.headers,
+      'X-Superbank-Sources',
+      'x-superbank-sources',
+    ),
+    duration: response.timings.duration,
+    ok: response.status === 200 && body !== null && !body.error,
+  };
+}
+
+function setupRpc(url, method, params) {
+  return rpc(url, method, params, setupTimeout);
+}
+
+function resultForComparison(task, body) {
+  const result = body?.result ?? null;
+  if (task.label === 'get_transactions_for_address') {
+    return result && typeof result === 'object' ? result.data ?? null : result;
+  }
+  return result;
+}
+
+function hasOwn(value, key) {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function isTokenUiAmount(value) {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    hasOwn(value, 'amount') &&
+    hasOwn(value, 'decimals') &&
+    hasOwn(value, 'uiAmountString') &&
+    hasOwn(value, 'uiAmount')
+  );
+}
+
+function normalizeProviderComparable(task, value, path = '$') {
+  if (!normalizeProviderDiffs) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry, idx) =>
+      normalizeProviderComparable(task, entry, `${path}[${idx}]`),
+    );
+  }
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+
+  const output = {};
+  const ignoreContextSlot =
+    task.label === 'get_signature_statuses' && path === '$.context';
+  const ignoreTokenUiAmount = isTokenUiAmount(value);
+
+  for (const key of Object.keys(value)) {
+    if (ignoreContextSlot && key === 'slot') {
+      continue;
+    }
+    if (ignoreTokenUiAmount && key === 'uiAmount') {
+      continue;
+    }
+    output[key] = normalizeProviderComparable(task, value[key], `${path}.${key}`);
+  }
+  return output;
+}
+
+function comparableResult(task, body) {
+  return normalizeProviderComparable(task, resultForComparison(task, body));
+}
+
+function valueKind(value) {
+  if (value === null) {
+    return 'null';
+  }
+  if (Array.isArray(value)) {
+    return 'array';
+  }
+  return typeof value;
+}
+
+function firstDiff(left, right, path = '$') {
+  if (left === right) {
+    return null;
+  }
+  if (valueKind(left) !== valueKind(right)) {
+    return {
+      path,
+      reason: 'type_mismatch',
+      targetKind: valueKind(left),
+      referenceKind: valueKind(right),
+    };
+  }
+  if (Array.isArray(left)) {
+    if (left.length !== right.length) {
+      return {
+        path,
+        reason: 'array_length_mismatch',
+        targetLength: left.length,
+        referenceLength: right.length,
+      };
+    }
+    for (let idx = 0; idx < left.length; idx += 1) {
+      const diff = firstDiff(left[idx], right[idx], `${path}[${idx}]`);
+      if (diff) {
+        return diff;
+      }
+    }
+    return null;
+  }
+  if (left && typeof left === 'object') {
+    const leftKeys = Object.keys(left).sort();
+    const rightKeys = Object.keys(right).sort();
+    const leftJoined = leftKeys.join('\u0000');
+    const rightJoined = rightKeys.join('\u0000');
+    if (leftJoined !== rightJoined) {
+      return {
+        path,
+        reason: 'object_keys_mismatch',
+        targetOnlyKeys: leftKeys.filter((key) => !rightKeys.includes(key)).slice(0, 20),
+        referenceOnlyKeys: rightKeys.filter((key) => !leftKeys.includes(key)).slice(0, 20),
+      };
+    }
+    for (const key of leftKeys) {
+      const diff = firstDiff(left[key], right[key], `${path}.${key}`);
+      if (diff) {
+        return diff;
+      }
+    }
+    return null;
+  }
+  return {
+    path,
+    reason: 'value_mismatch',
+    targetValue: left,
+    referenceValue: right,
+  };
+}
+
+function snippet(value) {
+  const text = JSON.stringify(value);
+  if (debugBodyChars === 0 || text.length <= debugBodyChars) {
+    return text;
+  }
+  return `${text.slice(0, debugBodyChars)}...<truncated ${text.length - debugBodyChars} chars>`;
+}
+
+function resultsMatch(task, target, reference) {
+  if (!target.body || !reference.body) {
+    return false;
+  }
+  if (Boolean(target.body.error) || Boolean(reference.body.error)) {
+    return (
+      Boolean(target.body.error) === Boolean(reference.body.error) &&
+      target.body.error?.code === reference.body.error?.code
+    );
+  }
+  return deepEqual(
+    comparableResult(task, target.body),
+    comparableResult(task, reference.body),
+  );
+}
+
+function taskKey(task) {
+  return `${task.label}:${JSON.stringify(task.params)}`;
+}
+
+function addTask(tasks, seen, task, probe = null) {
+  if (!enabledMethods.has(task.label)) {
+    return false;
+  }
+  const key = taskKey(task);
+  if (seen.has(key)) {
+    return false;
+  }
+  const target = probe || setupRpc(rpcUrl, task.method, task.params);
+  if (!target.ok || !isAcceptedDiskSource(target.source)) {
+    return false;
+  }
+  seen.add(key);
+  tasks.push(task);
+  return true;
+}
+
+function blockOptions(transactionDetails, rewards) {
+  return {
+    transactionDetails,
+    rewards,
+    maxSupportedTransactionVersion: config.blockMaxSupportedTransactionVersion ?? 0,
+    commitment: 'finalized',
+  };
+}
+
+function transactionOptions() {
+  return {
+    encoding: config.transactionEncoding || 'json',
+    maxSupportedTransactionVersion: config.maxSupportedTransactionVersion ?? 0,
+    commitment: 'finalized',
+  };
+}
+
+function signaturesForAddressOptions(before = null, until = null) {
+  const opts = {
+    limit: pageSize,
+    commitment: 'finalized',
+  };
+  if (before) {
+    opts.before = before;
+  }
+  if (until) {
+    opts.until = until;
+  }
+  return opts;
+}
+
+function tfaWindowOptions(startSlot, endSlot) {
+  return {
+    limit: pageSize,
+    transactionDetails: 'signatures',
+    beforeSlot: endSlot + 1,
+    untilSlot: startSlot,
+  };
+}
+
+function extractSignatures(blockResult) {
+  const signatures = [];
+  const txs = blockResult?.transactions;
+  if (!Array.isArray(txs)) {
+    return signatures;
+  }
+  for (const tx of txs) {
+    const signature = tx?.transaction?.signatures?.[0];
+    if (signature) {
+      signatures.push(signature);
+    }
+    if (signatures.length >= signaturesPerBlock) {
+      break;
+    }
+  }
+  return signatures;
+}
+
+function accountKeyToString(key) {
+  if (typeof key === 'string') {
+    return key;
+  }
+  if (key && typeof key === 'object' && typeof key.pubkey === 'string') {
+    return key.pubkey;
+  }
+  return null;
+}
+
+function extractAddressSignaturePairs(blockResult) {
+  const pairs = [];
+  const txs = blockResult?.transactions;
+  if (!Array.isArray(txs)) {
+    return pairs;
+  }
+
+  for (const tx of txs) {
+    const signature = tx?.transaction?.signatures?.[0];
+    if (!signature) {
+      continue;
+    }
+
+    const txAddresses = [];
+    const accountKeys = tx?.transaction?.message?.accountKeys;
+    if (Array.isArray(accountKeys)) {
+      for (const key of accountKeys) {
+        const address = accountKeyToString(key);
+        if (address) {
+          txAddresses.push(address);
+        }
+      }
+    }
+
+    const loaded = tx?.meta?.loadedAddresses;
+    for (const key of loaded?.writable || []) {
+      if (typeof key === 'string') {
+        txAddresses.push(key);
+      }
+    }
+    for (const key of loaded?.readonly || []) {
+      if (typeof key === 'string') {
+        txAddresses.push(key);
+      }
+    }
+
+    const seen = new Set();
+    for (const address of txAddresses) {
+      if (!seen.has(address)) {
+        seen.add(address);
+        pairs.push({ address, signature });
+      }
+    }
+  }
+  return pairs;
+}
+
+function addAddressCandidate(candidates, seen, address) {
+  if (
+    typeof address !== 'string' ||
+    gsfaIgnoredAddresses.has(address) ||
+    seen.has(address)
+  ) {
+    return false;
+  }
+  seen.add(address);
+  candidates.push(address);
+  return true;
+}
+
+function addAddressSignatureHint(hints, address, signature) {
+  if (
+    typeof address !== 'string' ||
+    gsfaIgnoredAddresses.has(address) ||
+    typeof signature !== 'string'
+  ) {
+    return;
+  }
+  let signatures = hints.get(address);
+  if (!signatures) {
+    signatures = [];
+    hints.set(address, signatures);
+  }
+  if (!signatures.includes(signature)) {
+    signatures.push(signature);
+  }
+}
+
+function addBlockTasks(tasks, seen, slot, fullProbe) {
+  addTask(
+    tasks,
+    seen,
+    {
+      label: 'get_block_full',
+      method: 'getBlock',
+      params: [slot, blockOptions('full', true)],
+    },
+    fullProbe,
+  );
+  addTask(tasks, seen, {
+    label: 'get_block_signatures',
+    method: 'getBlock',
+    params: [slot, blockOptions('signatures', false)],
+  });
+  addTask(tasks, seen, {
+    label: 'get_block_time',
+    method: 'getBlockTime',
+    params: [slot],
+  });
+}
+
+function addRangeTasks(tasks, seen, startSlot, endSlot) {
+  addTask(tasks, seen, {
+    label: 'get_blocks',
+    method: 'getBlocks',
+    params: [startSlot, endSlot],
+  });
+  addTask(tasks, seen, {
+    label: 'get_blocks_with_limit',
+    method: 'getBlocksWithLimit',
+    params: [startSlot, Math.min(blocksLimit, endSlot - startSlot + 1)],
+  });
+}
+
+function addSignatureTasks(tasks, seen, signatures) {
+  for (const signature of signatures) {
+    addTask(tasks, seen, {
+      label: 'get_transaction',
+      method: 'getTransaction',
+      params: [signature, transactionOptions()],
+    });
+  }
+
+  for (let idx = 0; idx < signatures.length; idx += signatureStatusBatch) {
+    const batch = signatures.slice(idx, idx + signatureStatusBatch);
+    if (batch.length === 0) {
+      continue;
+    }
+    addTask(tasks, seen, {
+      label: 'get_signature_statuses',
+      method: 'getSignatureStatuses',
+      params: [batch],
+    });
+  }
+}
+
+function addSignaturesForAddressTask(tasks, seen, address, signatureHints) {
+  const signatures = signatureHints.get(address) || [];
+  const before = signatures[0];
+  const until = signatures.length > 1 ? signatures[signatures.length - 1] : null;
+  if (!before) {
+    return false;
+  }
+
+  return addTask(tasks, seen, {
+    label: 'get_signatures_for_address',
+    method: 'getSignaturesForAddress',
+    params: [address, signaturesForAddressOptions(before, before === until ? null : until)],
+  });
+}
+
+function addAddressTasks(tasks, seen, addresses, startSlot, endSlot, signatureHints) {
+  for (const address of addresses.slice(0, addressSamples)) {
+    addSignaturesForAddressTask(tasks, seen, address, signatureHints);
+    addTask(tasks, seen, {
+      label: 'get_transactions_for_address',
+      method: 'getTransactionsForAddress',
+      params: [address, tfaWindowOptions(startSlot, endSlot)],
+    });
+  }
+}
+
+export function setup() {
+  if (!referenceUrl) {
+    fail('REFERENCE_RPC_URL is required for disk-cache performance comparison');
+  }
+
+  const targetTip = setupRpc(rpcUrl, 'getSlot', [{ commitment: 'finalized' }]);
+  const referenceTip = setupRpc(referenceUrl, 'getSlot', [{ commitment: 'finalized' }]);
+  if (!targetTip.ok || !referenceTip.ok) {
+    fail('could not resolve finalized tips for target and reference');
+  }
+
+  const tip = Math.min(targetTip.body.result, referenceTip.body.result) - tipLag;
+  if (!Number.isFinite(tip) || tip <= 0) {
+    fail(`invalid shared finalized tip after PERF_TIP_LAG=${tipLag}`);
+  }
+  const startSlot = Math.max(0, tip - slotSpan);
+  const step = Math.max(1, Math.floor(slotSpan / blockSamples));
+
+  const tasks = [];
+  const seen = new Set();
+  const blockSlots = [];
+  const signatures = [];
+  const signatureSet = new Set();
+  const addressCandidates = [];
+  const addressCandidateSet = new Set();
+  const addressSignatureHints = new Map();
+
+  for (let slot = tip; slot >= startSlot && blockSlots.length < blockSamples; slot -= step) {
+    const probe = setupRpc(rpcUrl, 'getBlock', [slot, blockOptions('full', true)]);
+    if (!probe.ok || !isAcceptedDiskSource(probe.source) || probe.body?.result === null) {
+      continue;
+    }
+    blockSlots.push(slot);
+    addBlockTasks(tasks, seen, slot, probe);
+    for (const signature of extractSignatures(probe.body.result)) {
+      if (!signatureSet.has(signature)) {
+        signatureSet.add(signature);
+        signatures.push(signature);
+      }
+    }
+    if (addressMethodsEnabled) {
+      for (const { address, signature } of extractAddressSignaturePairs(probe.body.result)) {
+        addAddressSignatureHint(addressSignatureHints, address, signature);
+      }
+    }
+
+    const rangeEnd = slot;
+    const rangeStart = Math.max(startSlot, rangeEnd - blocksRange + 1);
+    addRangeTasks(tasks, seen, rangeStart, rangeEnd);
+  }
+
+  addSignatureTasks(tasks, seen, signatures);
+  if (addressMethodsEnabled) {
+    const hintedAddresses = Array.from(addressSignatureHints.entries())
+      .sort((left, right) => right[1].length - left[1].length)
+      .map(([address]) => address);
+    for (const address of hintedAddresses) {
+      addAddressCandidate(addressCandidates, addressCandidateSet, address);
+    }
+    for (const address of addressPool) {
+      addAddressCandidate(addressCandidates, addressCandidateSet, address);
+    }
+    if (addressCandidates.length > 0) {
+      addAddressTasks(
+        tasks,
+        seen,
+        addressCandidates,
+        startSlot,
+        tip,
+        addressSignatureHints,
+      );
+    }
+  }
+
+  if (tasks.length === 0) {
+    fail(
+      'No disk-cache-hit workload items found. Ensure the target disk cache is warmed, ' +
+        'RPC_URL points at the disk-enabled server, and PERF_ALLOW_MIXED_SOURCES=1 is set ' +
+        'if you intentionally want to include requests that also touch ClickHouse.',
+    );
+  }
+
+  const taskCounts = {};
+  for (const task of tasks) {
+    taskCounts[task.label] = (taskCounts[task.label] || 0) + 1;
+  }
+
+  console.log(
+    `Prepared ${tasks.length} disk-cache performance tasks: ${JSON.stringify(taskCounts)}`,
+  );
+
+  return {
+    tip,
+    startSlot,
+    taskCounts,
+    tasks,
+    blockSlots,
+    signatureCount: signatures.length,
+  };
+}
+
+function recordMetrics(task, target, reference, parityOk, diskHit) {
+  const metrics = metricByMethod[task.label];
+  metrics.targetRequests.add(1);
+  metrics.referenceRequests.add(1);
+  metrics.targetLatency.add(target.duration);
+  metrics.referenceLatency.add(reference.duration);
+
+  if (Number.isFinite(target.duration) && Number.isFinite(reference.duration)) {
+    metrics.delta.add(reference.duration - target.duration);
+    if (target.duration > 0) {
+      const speedup = reference.duration / target.duration;
+      metrics.speedup.add(speedup);
+      if (speedup > 1) {
+        speedupWinsTotal.add(1);
+      }
+    }
+  }
+  if (diskHit) {
+    metrics.diskHits.add(1);
+  }
+  if (!parityOk) {
+    metrics.parityMismatches.add(1);
+  }
+}
+
+function maybeLogMismatch(task, target, reference, parityOk, diskHit) {
+  if (!debugMismatches || mismatchLogs >= debugMismatchesMax) {
+    return;
+  }
+  if (parityOk && diskHit && target.ok && reference.ok) {
+    return;
+  }
+  mismatchLogs += 1;
+  const targetComparable = comparableResult(task, target.body);
+  const referenceComparable = comparableResult(task, reference.body);
+  console.warn(
+    `DISK_CACHE_PERF_MISMATCH ${JSON.stringify({
+      task,
+      targetStatus: target.response.status,
+      referenceStatus: reference.response.status,
+      targetSource: target.source,
+      referenceSource: reference.source,
+      targetError: target.body?.error ?? null,
+      referenceError: reference.body?.error ?? null,
+      parityOk,
+      diskHit,
+      firstDiff: firstDiff(targetComparable, referenceComparable),
+      targetResult: snippet(targetComparable),
+      referenceResult: snippet(referenceComparable),
+    })}`,
+  );
+}
+
+export default function (data) {
+  const task = data.tasks[((__ITER * 997) + (__VU - 1)) % data.tasks.length];
+  const targetFirst = (__ITER + __VU) % 2 === 0;
+  const first = targetFirst
+    ? { name: 'target', url: rpcUrl }
+    : { name: 'reference', url: referenceUrl };
+  const second = targetFirst
+    ? { name: 'reference', url: referenceUrl }
+    : { name: 'target', url: rpcUrl };
+
+  const firstResult = rpc(first.url, task.method, task.params);
+  const secondResult = rpc(second.url, task.method, task.params);
+  const target = first.name === 'target' ? firstResult : secondResult;
+  const reference = first.name === 'reference' ? firstResult : secondResult;
+
+  const diskHit = isAcceptedDiskSource(target.source);
+  const referenceDisk = sourceContains(reference.source, 'disk-cache');
+  const parityOk = !validateResults || resultsMatch(task, target, reference);
+
+  comparisonsTotal.add(1);
+  targetDiskHitRate.add(diskHit ? 1 : 0);
+  targetClickhouseTouchRate.add(sourceContains(target.source, 'clickhouse') ? 1 : 0);
+  referenceDiskCacheRate.add(referenceDisk ? 1 : 0);
+  responseParityRate.add(parityOk ? 1 : 0);
+  targetSuccessRate.add(target.ok ? 1 : 0);
+  referenceSuccessRate.add(reference.ok ? 1 : 0);
+  recordMetrics(task, target, reference, parityOk, diskHit);
+
+  check(null, {
+    'target request succeeded': () => target.ok,
+    'reference request succeeded': () => reference.ok,
+    'target was served by disk cache': () => diskHit,
+    'reference is not disk-cache enabled': () => !referenceDisk,
+    'target/reference response parity': () => parityOk,
+  });
+
+  maybeLogMismatch(task, target, reference, parityOk, diskHit);
+}
+
+function trendSummary(data, name) {
+  const values = data.metrics[name]?.values;
+  if (!values) {
+    return null;
+  }
+  return {
+    avg: values.avg || 0,
+    med: values.med || 0,
+    p90: values['p(90)'] || 0,
+    p95: values['p(95)'] || 0,
+    p99: values['p(99)'] || 0,
+    max: values.max || 0,
+  };
+}
+
+function countSummary(data, name) {
+  return data.metrics[name]?.values?.count || 0;
+}
+
+function rateSummary(data, name) {
+  return data.metrics[name]?.values?.rate || 0;
+}
+
+function summarizeMethod(data, label) {
+  const target = trendSummary(data, `diskcache_perf_${label}_target_ms`);
+  const reference = trendSummary(data, `diskcache_perf_${label}_reference_ms`);
+  if (!target && !reference) {
+    return null;
+  }
+  const speedup = trendSummary(data, `diskcache_perf_${label}_speedup_ratio`);
+  const delta = trendSummary(data, `diskcache_perf_${label}_delta_ms`);
+  const p95Speedup =
+    target?.p95 && reference?.p95 ? reference.p95 / target.p95 : 0;
+  const avgSpeedup =
+    target?.avg && reference?.avg ? reference.avg / target.avg : 0;
+  return {
+    requests: {
+      target: countSummary(data, `diskcache_perf_${label}_target_requests_total`),
+      reference: countSummary(data, `diskcache_perf_${label}_reference_requests_total`),
+      diskHits: countSummary(data, `diskcache_perf_${label}_disk_hits_total`),
+      parityMismatches: countSummary(
+        data,
+        `diskcache_perf_${label}_parity_mismatches_total`,
+      ),
+    },
+    targetLatencyMs: target,
+    referenceLatencyMs: reference,
+    deltaMs: delta,
+    speedupRatio: {
+      trend: speedup,
+      avgFromAverages: avgSpeedup,
+      p95FromP95s: p95Speedup,
+    },
+  };
+}
+
+export function handleSummary(data) {
+  const byMethod = {};
+  for (const label of methodLabels) {
+    const summary = summarizeMethod(data, label);
+    if (summary) {
+      byMethod[label] = summary;
+    }
+  }
+
+  const summary = {
+    testType: 'disk-cache-performance-compare',
+    timestamp: new Date().toISOString(),
+    config: {
+      rpcUrl,
+      referenceRpcUrl: referenceUrl,
+      vus: scenarios.basic.vus,
+      duration: scenarios.basic.duration,
+      slotSpan,
+      blockSamples,
+      addressSamples,
+      pageSize,
+      signaturesPerBlock,
+      signatureStatusBatch,
+      blocksRange,
+      blocksLimit,
+      tipLag,
+      validateResults,
+      normalizeProviderDiffs,
+      allowMixedSources,
+      enabledMethods: Array.from(enabledMethods),
+    },
+    totals: {
+      comparisons: countSummary(data, 'diskcache_perf_comparisons_total'),
+      speedupWins: countSummary(data, 'diskcache_perf_speedup_wins_total'),
+      targetDiskHitRate: rateSummary(data, 'diskcache_perf_target_disk_hit_rate'),
+      targetClickhouseTouchRate: rateSummary(
+        data,
+        'diskcache_perf_target_clickhouse_touch_rate',
+      ),
+      referenceDiskCacheRate: rateSummary(
+        data,
+        'diskcache_perf_reference_disk_cache_rate',
+      ),
+      responseParityRate: rateSummary(data, 'diskcache_perf_response_parity_rate'),
+      targetSuccessRate: rateSummary(data, 'diskcache_perf_target_success_rate'),
+      referenceSuccessRate: rateSummary(
+        data,
+        'diskcache_perf_reference_success_rate',
+      ),
+    },
+    byMethod,
+  };
+
+  return {
+    stdout: JSON.stringify(summary, null, 2) + '\n',
+  };
+}

--- a/tests/k6/scenarios/validation/superbank-rpc-disk-cache-parity.js
+++ b/tests/k6/scenarios/validation/superbank-rpc-disk-cache-parity.js
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+/*
+ * Copyright 2025-2026 Triton One Limited. All rights reserved.
+ */
+
+// Disk-cache parity validation for superbank-rpc.
+//
+// Purpose: prove that a disk-cache-enabled superbank-rpc returns byte-identical
+// results to a reference target (the same build with the disk cache disabled,
+// or any trusted RPC) for every method the disk tier serves: getBlock (all
+// transactionDetails levels), getTransaction, getSignatureStatuses, getBlocks,
+// getBlockTime, getSignaturesForAddress, and getTransactionsForAddress —
+// including pagination walks that cross the disk coverage floor, which is
+// where tier-boundary duplicates or gaps would show up.
+//
+// Pagination tokens themselves are NOT compared for getTransactionsForAddress:
+// disk- and head-sourced rows intentionally emit position-shaped tokens while
+// ClickHouse rows emit signature tokens. Each walk continues with its own
+// target's token; the concatenated data pages must still match exactly.
+//
+// Usage:
+//   k6 run tests/k6/scenarios/validation/superbank-rpc-disk-cache-parity.js \
+//     -e RPC_URL=http://disk-enabled:8899 \
+//     -e REFERENCE_RPC_URL=http://reference:8899 \
+//     -e ADDRESS_FILE=tests/k6/data/pools/addresses.txt
+//
+// Tuning:
+//   PARITY_SLOT_SPAN      how far below the shared tip to sample blocks (default 256)
+//   PARITY_BLOCK_SAMPLES  how many slots to sample in that span (default 12)
+//   PARITY_ADDRESSES      how many pool addresses to walk (default 5)
+//   PARITY_PAGE_SIZE      gSFA/gTFA page size (default 100)
+//   PARITY_MAX_PAGES      page cap per address walk (default 10)
+
+import http from 'k6/http';
+import { check, fail } from 'k6';
+import { config } from '../../lib/config.js';
+import { deepEqual } from '../../lib/compare.js';
+import { initAddressPool, getAddressPool } from '../../lib/addresses.js';
+
+const rpcUrl = config.rpcUrl;
+const referenceUrl = config.referenceRpcUrl;
+const slotSpan = Number(__ENV.PARITY_SLOT_SPAN || 256);
+const blockSamples = Number(__ENV.PARITY_BLOCK_SAMPLES || 12);
+const addressCount = Number(__ENV.PARITY_ADDRESSES || 5);
+const pageSize = Number(__ENV.PARITY_PAGE_SIZE || 100);
+const maxPages = Number(__ENV.PARITY_MAX_PAGES || 10);
+
+export const options = {
+  vus: 1,
+  iterations: 1,
+  thresholds: {
+    checks: ['rate==1'],
+  },
+};
+
+let requestId = 0;
+
+function rpc(url, method, params) {
+  requestId += 1;
+  const response = http.post(
+    url,
+    JSON.stringify({ jsonrpc: '2.0', id: requestId, method, params }),
+    { headers: { 'Content-Type': 'application/json' }, timeout: '30s' },
+  );
+  if (response.status !== 200) {
+    return { transport_error: `${method}: HTTP ${response.status}` };
+  }
+  try {
+    return JSON.parse(response.body);
+  } catch (_) {
+    return { transport_error: `${method}: unparsable body` };
+  }
+}
+
+/**
+ * Issue the same call against both targets and require identical outcomes:
+ * equal results, or equal error codes.
+ */
+function compareCall(label, method, params) {
+  const target = rpc(rpcUrl, method, params);
+  const reference = rpc(referenceUrl, method, params);
+
+  const ok = check(null, {
+    [`${label}: no transport errors`]: () =>
+      !target.transport_error && !reference.transport_error,
+    [`${label}: error parity`]: () =>
+      Boolean(target.error) === Boolean(reference.error) &&
+      (!target.error || target.error.code === reference.error.code),
+    [`${label}: result parity`]: () =>
+      Boolean(target.error) || deepEqual(target.result ?? null, reference.result ?? null),
+  });
+  if (!ok) {
+    console.error(
+      `${label} mismatch\n  params: ${JSON.stringify(params)}\n` +
+        `  target: ${JSON.stringify(target).slice(0, 2000)}\n` +
+        `  reference: ${JSON.stringify(reference).slice(0, 2000)}`,
+    );
+  }
+  return target;
+}
+
+export function setup() {
+  if (!referenceUrl) {
+    fail('REFERENCE_RPC_URL is required for parity validation');
+  }
+  initAddressPool();
+
+  // Anchor on a finalized tip both targets have passed.
+  const target = rpc(rpcUrl, 'getSlot', [{ commitment: 'finalized' }]);
+  const reference = rpc(referenceUrl, 'getSlot', [{ commitment: 'finalized' }]);
+  if (target.error || reference.error || !target.result || !reference.result) {
+    fail('could not resolve finalized tips for both targets');
+  }
+  const tip = Math.min(target.result, reference.result) - 32;
+  return { tip, addresses: getAddressPool().slice(0, addressCount) };
+}
+
+export default function (data) {
+  const { tip, addresses } = data;
+  const span = Math.min(slotSpan, tip);
+  const harvestedSignatures = [];
+
+  // --- Block-shaped methods over sampled recent slots -----------------------
+  const step = Math.max(1, Math.floor(span / blockSamples));
+  for (let slot = tip; slot > tip - span; slot -= step) {
+    const full = compareCall('getBlock full', 'getBlock', [
+      slot,
+      {
+        transactionDetails: 'full',
+        rewards: true,
+        maxSupportedTransactionVersion: 0,
+        commitment: 'finalized',
+      },
+    ]);
+    for (const details of ['none', 'signatures', 'accounts']) {
+      compareCall(`getBlock ${details}`, 'getBlock', [
+        slot,
+        {
+          transactionDetails: details,
+          rewards: details !== 'none',
+          maxSupportedTransactionVersion: 0,
+          commitment: 'finalized',
+        },
+      ]);
+    }
+    compareCall('getBlockTime', 'getBlockTime', [slot]);
+
+    if (!full.error && full.result && Array.isArray(full.result.transactions)) {
+      for (const tx of full.result.transactions.slice(0, 3)) {
+        const signature = tx?.transaction?.signatures?.[0];
+        if (signature) {
+          harvestedSignatures.push(signature);
+        }
+      }
+    }
+  }
+
+  // Range listing straddling the sampled span.
+  compareCall('getBlocks', 'getBlocks', [tip - span, tip]);
+  compareCall('getBlocksWithLimit', 'getBlocksWithLimit', [tip - span, 50]);
+
+  // --- Signature-shaped methods over harvested signatures -------------------
+  for (const signature of harvestedSignatures.slice(0, 25)) {
+    compareCall('getTransaction', 'getTransaction', [
+      signature,
+      { maxSupportedTransactionVersion: 0, commitment: 'finalized' },
+    ]);
+  }
+  if (harvestedSignatures.length > 0) {
+    compareCall('getSignatureStatuses', 'getSignatureStatuses', [
+      harvestedSignatures.slice(0, 50),
+    ]);
+  }
+
+  // --- Address walks across the coverage floor ------------------------------
+  for (const address of addresses) {
+    // getSignaturesForAddress: walk with before=<last signature>, identical
+    // cursors on both sides (signatures are target-independent).
+    let before = null;
+    for (let page = 0; page < maxPages; page += 1) {
+      const params = [address, before ? { limit: pageSize, before } : { limit: pageSize }];
+      const target = compareCall('gSFA walk', 'getSignaturesForAddress', params);
+      const rows = !target.error && Array.isArray(target.result) ? target.result : [];
+      if (rows.length < pageSize) {
+        break;
+      }
+      before = rows[rows.length - 1].signature;
+    }
+
+    // getTransactionsForAddress: each target walks with its own pagination
+    // token; the data pages must match page-for-page.
+    let targetToken = null;
+    let referenceToken = null;
+    for (let page = 0; page < maxPages; page += 1) {
+      const optionsFor = (token) => {
+        const opts = { limit: pageSize, transactionDetails: 'signatures' };
+        if (token) {
+          opts.paginationToken = token;
+        }
+        return opts;
+      };
+      const target = rpc(rpcUrl, 'getTransactionsForAddress', [
+        address,
+        optionsFor(targetToken),
+      ]);
+      const reference = rpc(referenceUrl, 'getTransactionsForAddress', [
+        address,
+        optionsFor(referenceToken),
+      ]);
+
+      const ok = check(null, {
+        'gTFA walk: no transport errors': () =>
+          !target.transport_error && !reference.transport_error,
+        'gTFA walk: error parity': () =>
+          Boolean(target.error) === Boolean(reference.error) &&
+          (!target.error || target.error.code === reference.error.code),
+        'gTFA walk: page data parity': () =>
+          Boolean(target.error) ||
+          deepEqual(target.result?.data ?? null, reference.result?.data ?? null),
+      });
+      if (!ok) {
+        console.error(
+          `gTFA page ${page} mismatch for ${address}\n` +
+            `  target: ${JSON.stringify(target).slice(0, 2000)}\n` +
+            `  reference: ${JSON.stringify(reference).slice(0, 2000)}`,
+        );
+      }
+      if (target.error || !target.result) {
+        break;
+      }
+
+      const rows = Array.isArray(target.result.data) ? target.result.data : [];
+      targetToken = target.result.paginationToken ?? null;
+      referenceToken = reference.result?.paginationToken ?? null;
+      if (rows.length < pageSize || !targetToken || !referenceToken) {
+        break;
+      }
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds a new optional RocksDB-backed disk cache feature to `superbank-rpc`, allowing recent finalized slots to be cached and served from local disk instead of ClickHouse. This feature is enabled via the `disk-cache` feature flag (which also enables `grpc-head-cache`), and includes configuration options, documentation, and test support. The PR also updates dependencies and developer/test instructions to include this new feature.

The most important changes are:

**Disk Cache Feature Implementation:**

* Added the `disk-cache` feature to `superbank-rpc`, which uses RocksDB to cache recent finalized slots on disk and serve them in place of ClickHouse for supported RPC methods. This includes feature flag wiring, dependency additions, and configuration options. [[1]](diffhunk://#diff-39049890566f5678cbe52d53c4bb5b5b41c86e27dad526f327d81c0f0aa100baR19-R21) [[2]](diffhunk://#diff-39049890566f5678cbe52d53c4bb5b5b41c86e27dad526f327d81c0f0aa100baR63-R77)
* Implemented ClickHouse query and fetch helpers for slot range queries needed for disk cache hydration and repair, gated behind the `disk-cache` feature. [[1]](diffhunk://#diff-d096863cdf86c597f7d28d2e522dcd9ea21ca24d4420899e3a81dfdfa5d50244R18-R19) [[2]](diffhunk://#diff-d096863cdf86c597f7d28d2e522dcd9ea21ca24d4420899e3a81dfdfa5d50244R31-R32) [[3]](diffhunk://#diff-d096863cdf86c597f7d28d2e522dcd9ea21ca24d4420899e3a81dfdfa5d50244R77-R121) [[4]](diffhunk://#diff-d096863cdf86c597f7d28d2e522dcd9ea21ca24d4420899e3a81dfdfa5d50244R228-R263) [[5]](diffhunk://#diff-d096863cdf86c597f7d28d2e522dcd9ea21ca24d4420899e3a81dfdfa5d50244R330-R387)

**Documentation and Developer Experience:**

* Added comprehensive documentation for the disk cache feature, including configuration, sizing, runtime requirements, observability, and validation/performance testing instructions in `crates/superbank-rpc/README.md`.
* Updated the main `README.md` to mention the disk cache feature, document its usage, and add a helper script for local testing. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R24) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L251-R252) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R261-R273)
* Updated developer and CI instructions (`CONTRIBUTING.md`, `CLAUDE.md`, `AGENTS.md`, `.github/workflows/ci.yml`) to test with the `disk-cache` feature enabled. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L249-R249) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L56-R56) [[3]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L26-R26) [[4]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL89-R89)

**Build and Environment Configuration:**

* Added a workaround for a libc++ bounds assertion issue when building `librocksdb-sys` in hardened Nix dev shells, by setting `CXXFLAGS` in `.cargo/config.toml`.