### PR TITLE
docs: document grpc-slot-notifications and superbank_ingest_chain_tip_lag metric

### DIFF
--- a/crates/superbank/README.md
+++ b/crates/superbank/README.md
@@ -151,6 +151,7 @@ cargo run -p superbank -- --config path/to/superbank.yaml
 - `--grpc-http2-adaptive-window[=true|false]` / `GRPC_HTTP2_ADAPTIVE_WINDOW` (default: false)
 - `--grpc-idle-timeout-secs` / `GRPC_IDLE_TIMEOUT_SECS` (default: 30; grpc source exits if no messages arrive before the timeout)
 - `--grpc-health-watch-enabled[=true|false]` / `GRPC_HEALTH_WATCH_ENABLED` (default: true; grpc source exits if health is not `SERVING`)
+- `--grpc-slot-notifications[=true|false]` / `GRPC_SLOT_NOTIFICATIONS` (default: true; subscribe to slot notifications on the gRPC stream to populate `superbank_ingest_chain_tip_lag`)
 - `--rpc-url` / `RPC_URL` (required for rpc source)
 - `--rpc-from-slot` / `RPC_FROM_SLOT` (required for rpc source; use `*` for latest slot in
   `blocks_metadata`, `0` to start from earliest available slot)

--- a/superbank.example.yaml
+++ b/superbank.example.yaml
@@ -13,6 +13,7 @@ grpc-max-decoding-bytes: 67108864
 grpc-http2-adaptive-window: false
 grpc-idle-timeout-secs: 30
 grpc-health-watch-enabled: true
+grpc-slot-notifications: true
 
 # Fumarole source options (required when source is "fumarole")
 # fumarole-endpoint: "https://your.fumarole.endpoint:443"


### PR DESCRIPTION
PR #4 added `--grpc-slot-notifications` and `superbank_ingest_chain_tip_lag` but did not update the operator-facing docs. This PR closes that gap.

- Add `--grpc-slot-notifications` / `GRPC_SLOT_NOTIFICATIONS` to the crate README's Options section
- Add `grpc-slot-notifications` as a commented option in `superbank.example.yaml` next to the other gRPC options
