### PR TITLE
feat: add /health liveness endpoint to ingestor metrics server

### DIFF
--- a/crates/superbank/README.md
+++ b/crates/superbank/README.md
@@ -58,9 +58,12 @@ CLICKHOUSE_ENTRIES_TABLE=default.entries \
 cargo run -p superbank --
 ```
 
-Prometheus metrics are served at `/metrics` on `METRICS_HOST:METRICS_PORT` (defaults:
-`0.0.0.0:9901` for the ingestor).
-Set `METRICS_CLUSTER_LABEL` to attach a static `cluster="..."` label to every ingestor metric.
+Prometheus metrics are served at `/metrics` and a liveness health check at `/health` on
+`METRICS_HOST:METRICS_PORT` (defaults: `0.0.0.0:9901`). `/health` returns `200 OK` while the
+ingestor is flushing normally, and `503 Service Unavailable` when no successful ClickHouse flush
+has occurred within `HEALTH_STALE_SECS` seconds (default: 120). Set `HEALTH_STALE_SECS=0` to
+disable staleness checking. Set `METRICS_CLUSTER_LABEL` to attach a static `cluster="..."` label
+to every ingestor metric.
 
 Minimal example (RPC source):
 

--- a/crates/superbank/src/cli.rs
+++ b/crates/superbank/src/cli.rs
@@ -357,6 +357,10 @@ struct CliArgs {
     #[arg(long, env = "METRICS_PORT", default_value = "9901")]
     metrics_port: u16,
 
+    /// Seconds since the last successful ClickHouse flush before /health returns 503.
+    #[arg(long, env = "HEALTH_STALE_SECS", default_value_t = 120)]
+    health_stale_secs: u64,
+
     /// Optional static cluster label added to all Prometheus metrics.
     #[arg(long, env = "METRICS_CLUSTER_LABEL")]
     metrics_cluster_label: Option<String>,
@@ -468,6 +472,7 @@ pub(crate) struct Args {
     pub(crate) clickhouse_url: String,
     pub(crate) metrics_host: String,
     pub(crate) metrics_port: u16,
+    pub(crate) health_stale_secs: u64,
     pub(crate) metrics_cluster_label: Option<String>,
     pub(crate) clickhouse_database: String,
     pub(crate) clickhouse_user: String,
@@ -580,6 +585,8 @@ struct FileConfig {
     metrics_host: Option<String>,
     #[serde(alias = "metrics_port")]
     metrics_port: Option<u16>,
+    #[serde(alias = "health_stale_secs")]
+    health_stale_secs: Option<u64>,
     #[serde(alias = "metrics_cluster_label")]
     metrics_cluster_label: Option<String>,
     #[serde(alias = "clickhouse_database")]
@@ -885,6 +892,12 @@ pub(crate) fn resolve_args() -> Result<Args> {
             "metrics_port",
             cli.metrics_port,
             file_config.metrics_port,
+        ),
+        health_stale_secs: merge_value(
+            &matches,
+            "health_stale_secs",
+            cli.health_stale_secs,
+            file_config.health_stale_secs,
         ),
         metrics_cluster_label: merge_option(
             &matches,
@@ -1670,6 +1683,7 @@ rpc-from-slot: 456
             clickhouse_url: "http://localhost:8123".to_string(),
             metrics_host: "0.0.0.0".to_string(),
             metrics_port: 9901,
+            health_stale_secs: 120,
             metrics_cluster_label: None,
             clickhouse_database: "default".to_string(),
             clickhouse_user: "default".to_string(),

--- a/crates/superbank/src/clickhouse.rs
+++ b/crates/superbank/src/clickhouse.rs
@@ -504,6 +504,7 @@ mod tests {
             clickhouse_url: "http://localhost:8123".to_string(),
             metrics_host: "0.0.0.0".to_string(),
             metrics_port: 9901,
+            health_stale_secs: 120,
             metrics_cluster_label: None,
             clickhouse_database: "default".to_string(),
             clickhouse_user: "default".to_string(),

--- a/crates/superbank/src/main.rs
+++ b/crates/superbank/src/main.rs
@@ -44,8 +44,14 @@ async fn main() -> Result<()> {
         "Ingest metrics server listening on http://{}/metrics",
         metrics_addr
     );
+    let health_stale_secs = args.health_stale_secs;
     let metrics_server = tokio::spawn(async move {
-        let app = Router::new().route("/metrics", get(metrics::metrics_handler));
+        let app = Router::new()
+            .route("/metrics", get(metrics::metrics_handler))
+            .route(
+                "/health",
+                get(move || metrics::health_handler(health_stale_secs)),
+            );
         axum::serve(metrics_listener, app).await
     });
 

--- a/crates/superbank/src/metrics.rs
+++ b/crates/superbank/src/metrics.rs
@@ -343,6 +343,18 @@ pub(crate) fn export_metrics() -> Result<Vec<u8>, String> {
     metrics().export()
 }
 
+pub async fn health_handler(stale_secs: u64) -> impl IntoResponse {
+    let last_flush = metrics().last_successful_flush_timestamp_seconds.get();
+    let stale = stale_secs > 0
+        && last_flush > 0
+        && current_timestamp_seconds().saturating_sub(last_flush) > stale_secs as i64;
+    if stale {
+        StatusCode::SERVICE_UNAVAILABLE
+    } else {
+        StatusCode::OK
+    }
+}
+
 pub async fn metrics_handler() -> impl IntoResponse {
     match export_metrics() {
         Ok(buffer) => (

--- a/deploy/k8s/31-superbank-ingest-grpc.yaml
+++ b/deploy/k8s/31-superbank-ingest-grpc.yaml
@@ -55,3 +55,15 @@ spec:
             secretKeyRef:
               name: superbank-clickhouse
               key: CLICKHOUSE_PASSWORD
+        ports:
+        - name: metrics
+          containerPort: 9901
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 9901
+          initialDelaySeconds: 30
+          periodSeconds: 15
+          timeoutSeconds: 5
+          failureThreshold: 3

--- a/superbank.example.yaml
+++ b/superbank.example.yaml
@@ -60,6 +60,8 @@ grpc-slot-notifications: true
 clickhouse-url: "http://localhost:8123"
 metrics-host: "0.0.0.0"
 metrics-port: 9901
+# Seconds without a successful ClickHouse flush before /health returns 503. Set to 0 to disable.
+# health-stale-secs: 120
 # Optional static label added to all ingestor metrics, e.g. the ClickHouse cluster name.
 # metrics-cluster-label: "mainnet-west"
 clickhouse-database: "default"


### PR DESCRIPTION
this PR adds a `/health` liveness endpoint on the same port, useful for k8s liveness probes and load-balancer health checks.

- Returns 200 OK when last_successful_flush_timestamp_seconds is within the
  staleness window (default 120 s), or before the first flush (startup grace).
- Returns 503 Service Unavailable when the ingestor has not flushed to
ClickHouse within HEALTH_STALE_SECS seconds.
- Set HEALTH_STALE_SECS=0 to disable staleness checking (always 200).

Closes: #9 