### PR TITLE
feat: retry ClickHouse inserts with exponential backoff for stateless

### DIFF
--- a/crates/superbank/src/cli.rs
+++ b/crates/superbank/src/cli.rs
@@ -416,6 +416,18 @@ struct CliArgs {
     /// Flush after every block update (disables batching)
     #[arg(long, env = "FLUSH_EVERY_BLOCK", default_value_t = false)]
     flush_every_block: bool,
+
+    /// Max ClickHouse insert retry attempts before giving up (stateless sources only)
+    #[arg(long, env = "CLICKHOUSE_INSERT_MAX_RETRIES", default_value_t = 5)]
+    insert_max_retries: u32,
+
+    /// Initial backoff for ClickHouse insert retries (milliseconds)
+    #[arg(long, env = "CLICKHOUSE_INSERT_RETRY_BASE_MS", default_value_t = 1_000)]
+    insert_retry_base_ms: u64,
+
+    /// Maximum backoff cap for ClickHouse insert retries (milliseconds)
+    #[arg(long, env = "CLICKHOUSE_INSERT_RETRY_MAX_MS", default_value_t = 30_000)]
+    insert_retry_max_ms: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -480,6 +492,9 @@ pub(crate) struct Args {
     pub(crate) blocks_flush_rows: usize,
     pub(crate) flush_interval_secs: u64,
     pub(crate) flush_every_block: bool,
+    pub(crate) insert_max_retries: u32,
+    pub(crate) insert_retry_base_ms: u64,
+    pub(crate) insert_retry_max_ms: u64,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -604,6 +619,12 @@ struct FileConfig {
     flush_interval_secs: Option<u64>,
     #[serde(alias = "flush_every_block")]
     flush_every_block: Option<bool>,
+    #[serde(alias = "insert_max_retries")]
+    insert_max_retries: Option<u32>,
+    #[serde(alias = "insert_retry_base_ms")]
+    insert_retry_base_ms: Option<u64>,
+    #[serde(alias = "insert_retry_max_ms")]
+    insert_retry_max_ms: Option<u64>,
 }
 
 pub(crate) fn resolve_args() -> Result<Args> {
@@ -957,6 +978,24 @@ pub(crate) fn resolve_args() -> Result<Args> {
             "flush_every_block",
             cli.flush_every_block,
             file_config.flush_every_block,
+        ),
+        insert_max_retries: merge_value(
+            &matches,
+            "insert_max_retries",
+            cli.insert_max_retries,
+            file_config.insert_max_retries,
+        ),
+        insert_retry_base_ms: merge_value(
+            &matches,
+            "insert_retry_base_ms",
+            cli.insert_retry_base_ms,
+            file_config.insert_retry_base_ms,
+        ),
+        insert_retry_max_ms: merge_value(
+            &matches,
+            "insert_retry_max_ms",
+            cli.insert_retry_max_ms,
+            file_config.insert_retry_max_ms,
         ),
     };
 
@@ -1682,6 +1721,9 @@ rpc-from-slot: 456
             blocks_flush_rows: 2_000,
             flush_interval_secs: 5,
             flush_every_block: false,
+            insert_max_retries: 5,
+            insert_retry_base_ms: 1_000,
+            insert_retry_max_ms: 30_000,
         }
     }
 }

--- a/crates/superbank/src/clickhouse.rs
+++ b/crates/superbank/src/clickhouse.rs
@@ -8,8 +8,9 @@ use clickhouse::{Client as ClickHouseClient, Row};
 use serde::{Deserialize, Serialize};
 use serde_big_array::Array;
 use serde_bytes::ByteBuf;
-use std::time::Instant;
-use tracing::info;
+use std::time::{Duration, Instant};
+use tokio::time::sleep;
+use tracing::{info, warn};
 
 use crate::cli::Args;
 use crate::metrics;
@@ -212,6 +213,42 @@ pub(crate) async fn flush_buffers(
     }
 
     Ok(())
+}
+
+pub(crate) struct RetryConfig {
+    pub(crate) max_retries: u32,
+    pub(crate) base_ms: u64,
+    pub(crate) max_ms: u64,
+}
+
+pub(crate) async fn flush_buffers_with_retry(
+    client: &ClickHouseClient,
+    tables: &InsertTables,
+    transaction_rows: &mut Vec<TransactionRow>,
+    block_rows: &mut Vec<BlockMetadataRow>,
+    entry_rows: &mut Vec<EntryRow>,
+    progress: Option<ProgressSnapshot>,
+    retry: &RetryConfig,
+) -> Result<()> {
+    let mut attempt = 0u32;
+    loop {
+        match flush_buffers(client, tables, transaction_rows, block_rows, entry_rows, progress).await {
+            Ok(()) => return Ok(()),
+            Err(err) if attempt < retry.max_retries => {
+                attempt += 1;
+                let delay_ms = retry.base_ms.saturating_mul(1u64 << (attempt - 1).min(62)).min(retry.max_ms);
+                warn!(
+                    attempt,
+                    max_retries = retry.max_retries,
+                    delay_ms,
+                    error = %err,
+                    "ClickHouse insert failed, retrying"
+                );
+                sleep(Duration::from_millis(delay_ms)).await;
+            }
+            Err(err) => return Err(err),
+        }
+    }
 }
 
 fn split_qualified_table(name: &str) -> Option<(&str, &str)> {

--- a/crates/superbank/src/clickhouse.rs
+++ b/crates/superbank/src/clickhouse.rs
@@ -232,11 +232,23 @@ pub(crate) async fn flush_buffers_with_retry(
 ) -> Result<()> {
     let mut attempt = 0u32;
     loop {
-        match flush_buffers(client, tables, transaction_rows, block_rows, entry_rows, progress).await {
+        match flush_buffers(
+            client,
+            tables,
+            transaction_rows,
+            block_rows,
+            entry_rows,
+            progress,
+        )
+        .await
+        {
             Ok(()) => return Ok(()),
             Err(err) if attempt < retry.max_retries => {
                 attempt += 1;
-                let delay_ms = retry.base_ms.saturating_mul(1u64 << (attempt - 1).min(62)).min(retry.max_ms);
+                let delay_ms = retry
+                    .base_ms
+                    .saturating_mul(1u64 << (attempt - 1).min(62))
+                    .min(retry.max_ms);
                 warn!(
                     attempt,
                     max_retries = retry.max_retries,
@@ -246,7 +258,15 @@ pub(crate) async fn flush_buffers_with_retry(
                 );
                 sleep(Duration::from_millis(delay_ms)).await;
             }
-            Err(err) => return Err(err),
+            Err(err) => {
+                warn!(
+                    attempt,
+                    max_retries = retry.max_retries,
+                    error = %err,
+                    "ClickHouse insert failed, giving up"
+                );
+                return Err(err);
+            }
         }
     }
 }
@@ -553,6 +573,9 @@ mod tests {
             blocks_flush_rows: 2_000,
             flush_interval_secs: 5,
             flush_every_block: false,
+            insert_max_retries: 5,
+            insert_retry_base_ms: 1_000,
+            insert_retry_max_ms: 30_000,
         }
     }
 

--- a/crates/superbank/src/ingest/bigtable.rs
+++ b/crates/superbank/src/ingest/bigtable.rs
@@ -27,7 +27,8 @@ use tracing::{info, warn};
 
 use crate::cli::Args;
 use crate::clickhouse::{
-    BlockMetadataRow, InsertTables, TransactionRow, build_clickhouse_client, flush_buffers,
+    BlockMetadataRow, InsertTables, RetryConfig, TransactionRow, build_clickhouse_client,
+    flush_buffers_with_retry,
 };
 use crate::commitment::parse_commitment_config;
 use crate::ingest::rpc::{map_bigtable_block_metadata, map_bigtable_transactions};
@@ -75,6 +76,7 @@ struct BigtableInserterArgs {
     result_rx: mpsc::Receiver<Result<BigtableBatch>>,
     shutdown_rx: watch::Receiver<u64>,
     fatal: Arc<AtomicBool>,
+    retry_config: Arc<RetryConfig>,
 }
 
 async fn load_slot_list(path: &Path) -> Result<Vec<u64>> {
@@ -145,6 +147,11 @@ pub(crate) async fn run_bigtable_ingest(args: &Args) -> Result<()> {
     let storage = Arc::new(build_bigtable_storage(args).await?);
     let clickhouse = build_clickhouse_client(args);
     let insert_tables = InsertTables::from_args(args);
+    let retry_config = Arc::new(RetryConfig {
+        max_retries: args.insert_max_retries,
+        base_ms: args.insert_retry_base_ms,
+        max_ms: args.insert_retry_max_ms,
+    });
     let flush_config = BigtableFlushConfig {
         transactions_flush_rows: args.transactions_flush_rows,
         blocks_flush_rows: args.blocks_flush_rows,
@@ -204,6 +211,7 @@ pub(crate) async fn run_bigtable_ingest(args: &Args) -> Result<()> {
         result_rx,
         shutdown_rx: shutdown_rx.clone(),
         fatal: fatal.clone(),
+        retry_config: retry_config.clone(),
     }));
 
     let semaphore = Arc::new(Semaphore::new(fetch_concurrency));
@@ -507,6 +515,7 @@ async fn run_bigtable_inserter(args: BigtableInserterArgs) -> Result<BigtableIns
         mut result_rx,
         mut shutdown_rx,
         fatal,
+        retry_config,
     } = args;
     let clickhouse = Arc::new(clickhouse);
     let insert_tables = Arc::new(insert_tables);
@@ -568,6 +577,7 @@ async fn run_bigtable_inserter(args: BigtableInserterArgs) -> Result<BigtableIns
                 batch,
                 &mut shutdown_rx,
                 shutdown_requested,
+                retry_config.clone(),
             )
             .await
             .inspect_err(|_| {
@@ -593,6 +603,7 @@ async fn run_bigtable_inserter(args: BigtableInserterArgs) -> Result<BigtableIns
             batch,
             &mut shutdown_rx,
             shutdown_requested,
+            retry_config.clone(),
         )
         .await
         .inspect_err(|_| {
@@ -660,16 +671,18 @@ async fn flush_bigtable_batch(
     clickhouse: &clickhouse::Client,
     insert_tables: &InsertTables,
     mut batch: BigtableFlushBatch,
+    retry: &RetryConfig,
 ) -> Result<()> {
     sort_bigtable_rows(&mut batch.transaction_rows, &mut batch.block_rows);
     let mut entry_rows = Vec::new();
-    flush_buffers(
+    flush_buffers_with_retry(
         clickhouse,
         insert_tables,
         &mut batch.transaction_rows,
         &mut batch.block_rows,
         &mut entry_rows,
         None,
+        retry,
     )
     .await
 }
@@ -682,6 +695,7 @@ async fn enqueue_bigtable_flush(
     batch: BigtableFlushBatch,
     shutdown_rx: &mut watch::Receiver<u64>,
     allow_abort: bool,
+    retry: Arc<RetryConfig>,
 ) -> Result<bool> {
     let max_inflight = insert_concurrency.max(1);
     while insert_tasks.len() >= max_inflight {
@@ -714,7 +728,7 @@ async fn enqueue_bigtable_flush(
     }
 
     insert_tasks.spawn(async move {
-        flush_bigtable_batch(clickhouse.as_ref(), insert_tables.as_ref(), batch).await
+        flush_bigtable_batch(clickhouse.as_ref(), insert_tables.as_ref(), batch, &retry).await
     });
 
     Ok(false)

--- a/crates/superbank/src/ingest/bigtable.rs
+++ b/crates/superbank/src/ingest/bigtable.rs
@@ -687,6 +687,7 @@ async fn flush_bigtable_batch(
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn enqueue_bigtable_flush(
     insert_tasks: &mut JoinSet<Result<()>>,
     insert_concurrency: usize,

--- a/crates/superbank/src/ingest/fumarole.rs
+++ b/crates/superbank/src/ingest/fumarole.rs
@@ -159,6 +159,7 @@ pub(crate) async fn run_fumarole_ingest(args: &Args) -> Result<()> {
                                     &insert_tables,
                                     &clickhouse,
                                     &mut buffered_rows,
+                                    None,
                                 )
                                 .await?
                                 {
@@ -177,6 +178,7 @@ pub(crate) async fn run_fumarole_ingest(args: &Args) -> Result<()> {
                                 &insert_tables,
                                 &clickhouse,
                                 &mut buffered_rows,
+                                None,
                             )
                             .await?
                             {

--- a/crates/superbank/src/ingest/grpc.rs
+++ b/crates/superbank/src/ingest/grpc.rs
@@ -26,8 +26,8 @@ use yellowstone_grpc_proto::prelude::{
 
 use crate::cli::{Args, FromSlotSpec};
 use crate::clickhouse::{
-    BlockMetadataRow, EntryRow, InsertTables, TransactionRow, build_clickhouse_client,
-    fetch_latest_slot_from_blocks, flush_buffers,
+    BlockMetadataRow, EntryRow, InsertTables, RetryConfig, TransactionRow, build_clickhouse_client,
+    fetch_latest_slot_from_blocks, flush_buffers, flush_buffers_with_retry,
 };
 use crate::commitment::parse_commitment_level;
 use crate::metrics;
@@ -120,6 +120,32 @@ impl BufferedRows {
         }
         Ok(())
     }
+
+    pub(crate) async fn flush_with_retry(
+        &mut self,
+        clickhouse: &ClickHouseClient,
+        insert_tables: &InsertTables,
+        retry: &RetryConfig,
+    ) -> Result<()> {
+        let flushed_block_slot = max_block_slot(&self.block_rows);
+        flush_buffers_with_retry(
+            clickhouse,
+            insert_tables,
+            &mut self.transaction_rows,
+            &mut self.block_rows,
+            &mut self.entry_rows,
+            None,
+            retry,
+        )
+        .await?;
+        if let Some(slot) = flushed_block_slot {
+            self.last_durable_block_slot = Some(
+                self.last_durable_block_slot
+                    .map_or(slot, |prev| prev.max(slot)),
+            );
+        }
+        Ok(())
+    }
 }
 
 pub(crate) async fn run_grpc_ingest(args: &Args) -> Result<()> {
@@ -147,6 +173,11 @@ pub(crate) async fn run_grpc_ingest(args: &Args) -> Result<()> {
 
     let mut buffered_rows = BufferedRows::new(args);
     let insert_tables = InsertTables::from_args(args);
+    let retry_config = RetryConfig {
+        max_retries: args.insert_max_retries,
+        base_ms: args.insert_retry_base_ms,
+        max_ms: args.insert_retry_max_ms,
+    };
     let include_entries = args.entries_table.is_some();
 
     let mut flush_timer = interval(Duration::from_secs(args.flush_interval_secs));
@@ -219,7 +250,7 @@ pub(crate) async fn run_grpc_ingest(args: &Args) -> Result<()> {
                 break;
             }
             _ = flush_timer.tick() => {
-                buffered_rows.flush(&clickhouse, &insert_tables).await?;
+                buffered_rows.flush_with_retry(&clickhouse, &insert_tables, &retry_config).await?;
             }
             health_failure = health_failure_rx.recv() => {
                 let reason = health_failure
@@ -337,7 +368,7 @@ pub(crate) async fn run_grpc_ingest(args: &Args) -> Result<()> {
     }
     let shutdown_count = *shutdown_rx.borrow();
     tokio::select! {
-        result = buffered_rows.flush(&clickhouse, &insert_tables) => {
+        result = buffered_rows.flush_with_retry(&clickhouse, &insert_tables, &retry_config) => {
             result?;
         }
         _ = shutdown_rx.changed() => {

--- a/crates/superbank/src/ingest/grpc.rs
+++ b/crates/superbank/src/ingest/grpc.rs
@@ -235,6 +235,7 @@ pub(crate) async fn run_grpc_ingest(args: &Args) -> Result<()> {
             &insert_tables,
             &clickhouse,
             &mut buffered_rows,
+            Some(&retry_config),
         )
         .await?;
     }
@@ -309,6 +310,7 @@ pub(crate) async fn run_grpc_ingest(args: &Args) -> Result<()> {
                             &insert_tables,
                             &clickhouse,
                             &mut buffered_rows,
+                            Some(&retry_config),
                         )
                         .await?;
                     }
@@ -740,6 +742,7 @@ pub(crate) async fn process_update(
     insert_tables: &InsertTables,
     clickhouse: &ClickHouseClient,
     buffered_rows: &mut BufferedRows,
+    retry: Option<&RetryConfig>,
 ) -> Result<bool> {
     let mut flushed = false;
     match update.update_oneof {
@@ -762,7 +765,14 @@ pub(crate) async fn process_update(
                 || buffered_rows.block_rows.len() >= args.blocks_flush_rows
                 || buffered_rows.entry_rows.len() >= args.transactions_flush_rows
             {
-                buffered_rows.flush(clickhouse, insert_tables).await?;
+                match retry {
+                    Some(r) => {
+                        buffered_rows
+                            .flush_with_retry(clickhouse, insert_tables, r)
+                            .await?
+                    }
+                    None => buffered_rows.flush(clickhouse, insert_tables).await?,
+                }
                 flushed = true;
             }
         }

--- a/crates/superbank/src/ingest/rpc.rs
+++ b/crates/superbank/src/ingest/rpc.rs
@@ -40,8 +40,8 @@ use tracing::{info, warn};
 
 use crate::cli::{Args, FromSlotSpec};
 use crate::clickhouse::{
-    BlockMetadataRow, InsertTables, ProgressSnapshot, TransactionRow, build_clickhouse_client,
-    fetch_latest_slot_from_blocks, flush_buffers,
+    BlockMetadataRow, InsertTables, ProgressSnapshot, RetryConfig, TransactionRow,
+    build_clickhouse_client, fetch_latest_slot_from_blocks, flush_buffers_with_retry,
 };
 use crate::commitment::parse_commitment_config;
 use crate::metrics;
@@ -341,6 +341,7 @@ async fn enqueue_flush(
     clickhouse: Arc<clickhouse::Client>,
     insert_tables: Arc<InsertTables>,
     batch: FlushBatch,
+    retry: Arc<RetryConfig>,
 ) -> Result<()> {
     let max_inflight = insert_concurrency.max(1);
     while insert_tasks.len() >= max_inflight {
@@ -353,13 +354,14 @@ async fn enqueue_flush(
         let mut transaction_rows = batch.transaction_rows;
         let mut block_rows = batch.block_rows;
         let mut entry_rows = Vec::new();
-        flush_buffers(
+        flush_buffers_with_retry(
             clickhouse.as_ref(),
             insert_tables.as_ref(),
             &mut transaction_rows,
             &mut block_rows,
             &mut entry_rows,
             batch.progress,
+            &retry,
         )
         .await
     });
@@ -480,6 +482,11 @@ async fn run_rpc_inserter(args: RpcInserterArgs<'_>) -> Result<RpcInserterOutcom
         range,
         start_time,
     } = args;
+    let retry_config = Arc::new(RetryConfig {
+        max_retries: cli_args.insert_max_retries,
+        base_ms: cli_args.insert_retry_base_ms,
+        max_ms: cli_args.insert_retry_max_ms,
+    });
     let mut transaction_rows: Vec<TransactionRow> =
         Vec::with_capacity(cli_args.transactions_flush_rows);
     let mut block_rows: Vec<BlockMetadataRow> = Vec::with_capacity(cli_args.blocks_flush_rows);
@@ -526,6 +533,7 @@ async fn run_rpc_inserter(args: RpcInserterArgs<'_>) -> Result<RpcInserterOutcom
                         clickhouse.clone(),
                         insert_tables.clone(),
                         batch,
+                        retry_config.clone(),
                     )
                     .await?;
                     last_progress = None;
@@ -580,6 +588,7 @@ async fn run_rpc_inserter(args: RpcInserterArgs<'_>) -> Result<RpcInserterOutcom
                                 clickhouse.clone(),
                                 insert_tables.clone(),
                                 batch,
+                                retry_config.clone(),
                             )
                             .await?;
                         }
@@ -595,6 +604,7 @@ async fn run_rpc_inserter(args: RpcInserterArgs<'_>) -> Result<RpcInserterOutcom
                             clickhouse.clone(),
                             insert_tables.clone(),
                             batch,
+                            retry_config.clone(),
                         )
                         .await?;
                     }

--- a/superbank.example.yaml
+++ b/superbank.example.yaml
@@ -75,3 +75,8 @@ transactions-flush-rows: 25000
 blocks-flush-rows: 2000
 flush-interval-secs: 5
 flush-every-block: false
+
+# ClickHouse insert retry (stateless sources: grpc, rpc, bigtable only — fumarole is excluded)
+# insert-max-retries: 5
+# insert-retry-base-ms: 1000
+# insert-retry-max-ms: 30000


### PR DESCRIPTION
  *PR Title:* 
  feat: retry ClickHouse inserts with exponential backoff (gRPC, RPC, Bigtable)

  *PR Description:*
  Closes #12

  Adds retry with exponential backoff to ClickHouse inserts for stateless ingest sources (gRPC, RPC, Bigtable). Fumarole is intentionally excluded as it's stateful and prefers fail-fast behaviour.

  ## Changes

  - Added `RetryConfig` struct and `flush_buffers_with_retry` in `clickhouse.rs`
  - `BufferedRows` gets a `flush_with_retry` method used by gRPC
  - RPC and Bigtable inserters thread `RetryConfig` through their task args
  - Three new config knobs (all optional, sensible defaults):

  | env var | default |
  |---|---|
  | `CLICKHOUSE_INSERT_MAX_RETRIES` | `5` |
  | `CLICKHOUSE_INSERT_RETRY_BASE_MS` | `1000` |
  | `CLICKHOUSE_INSERT_RETRY_MAX_MS` | `30000` |

  Backoff doubles each attempt and is capped at `insert_retry_max_ms`.
  A `warn!` is logged on each failed attempt before giving up.
  
  cc @notwedtm 