### PR TITLE
fix: add rpc prefix to rpc src options

### DIFF
--- a/crates/superbank/README.md
+++ b/crates/superbank/README.md
@@ -155,8 +155,8 @@ cargo run -p superbank -- --config path/to/superbank.yaml
 - `--rpc-url` / `RPC_URL` (required for rpc source)
 - `--rpc-from-slot` / `RPC_FROM_SLOT` (required for rpc source; use `*` for latest slot in
   `blocks_metadata`, `0` to start from earliest available slot)
-- `--to-slot` / `RPC_TO_SLOT` (required for rpc source if `--slot-count` not set)
-- `--slot-count` / `RPC_SLOT_COUNT` (required for rpc source if `--to-slot` not set)
+- `--rpc-to-slot` / `RPC_TO_SLOT` (required for rpc source if `--rpc-slot-count` not set)
+- `--rpc-slot-count` / `RPC_SLOT_COUNT` (required for rpc source if `--rpc-to-slot` not set)
 - `--rpc-timeout-secs` / `RPC_TIMEOUT_SECS` (default: 30)
 - `--rpc-retry-backoff-ms` / `RPC_RETRY_BACKOFF_MS` (default: 500)
 - `--rpc-max-inflight` / `RPC_MAX_INFLIGHT` (default: 64)

--- a/crates/superbank/src/cli.rs
+++ b/crates/superbank/src/cli.rs
@@ -253,7 +253,7 @@ struct CliArgs {
     #[arg(long, env = "RPC_TO_SLOT")]
     rpc_to_slot: Option<u64>,
 
-    /// Slot count for rpc source (exclusive with --to-slot)
+    /// Slot count for rpc source (exclusive with --rpc-to-slot)
     #[arg(long, env = "RPC_SLOT_COUNT")]
     rpc_slot_count: Option<u64>,
 
@@ -1043,12 +1043,12 @@ fn validate_args(args: &Args) -> Result<()> {
             }
             if args.rpc_to_slot.is_some() && args.rpc_slot_count.is_some() {
                 return Err(anyhow!(
-                    "rpc source requires either --to-slot or --slot-count (not both)"
+                    "rpc source requires either --rpc-to-slot or --rpc-slot-count (not both)"
                 ));
             }
             if args.rpc_to_slot.is_none() && args.rpc_slot_count.is_none() {
                 return Err(anyhow!(
-                    "rpc source requires --to-slot or --slot-count to define a range"
+                    "rpc source requires --rpc-to-slot or --rpc-slot-count to define a range"
                 ));
             }
             if let Some(count) = args.rpc_slot_count
@@ -1241,6 +1241,9 @@ fn load_config(path: Option<&Path>) -> Result<Option<FileConfig>> {
         .with_context(|| format!("read config file {}", path.display()))?;
     let config = serde_yaml::from_str::<FileConfig>(&contents)
         .with_context(|| format!("parse config file {}", path.display()))?;
+    println!("Loaded config from {}", path.display());
+    println!("Config: {:#?}", config);
+    println!("CLI args override config file values if specified");
     Ok(Some(config))
 }
 

--- a/crates/superbank/src/cli.rs
+++ b/crates/superbank/src/cli.rs
@@ -1241,9 +1241,6 @@ fn load_config(path: Option<&Path>) -> Result<Option<FileConfig>> {
         .with_context(|| format!("read config file {}", path.display()))?;
     let config = serde_yaml::from_str::<FileConfig>(&contents)
         .with_context(|| format!("parse config file {}", path.display()))?;
-    println!("Loaded config from {}", path.display());
-    println!("Config: {:#?}", config);
-    println!("CLI args override config file values if specified");
     Ok(Some(config))
 }
 

--- a/crates/superbank/src/ingest/rpc.rs
+++ b/crates/superbank/src/ingest/rpc.rs
@@ -694,12 +694,12 @@ async fn resolve_rpc_range(
         }
         (Some(_), Some(_)) => {
             return Err(anyhow!(
-                "rpc source requires either --to-slot or --slot-count (not both)"
+                "rpc source requires either --rpc-to-slot or --rpc-slot-count (not both)"
             ));
         }
         (None, None) => {
             return Err(anyhow!(
-                "rpc source requires --to-slot or --slot-count to define a range"
+                "rpc source requires --rpc-to-slot or --rpc-slot-count to define a range"
             ));
         }
     };

--- a/superbank.example.yaml
+++ b/superbank.example.yaml
@@ -30,8 +30,8 @@ grpc-slot-notifications: true
 # RPC source options (required when source is "rpc")
 # rpc-url: "https://api.mainnet-beta.solana.com"
 # rpc-from-slot: 0
-# to-slot: 0
-# slot-count: 1000
+# rpc-to-slot: 0
+# rpc-slot-count: 1000
 # rpc-timeout-secs: 30
 # rpc-retry-backoff-ms: 500
 # rpc-max-inflight: 64


### PR DESCRIPTION
Fix the `superbank.example.yaml` to actually match the `FileConfig` rust struct in:

```rs
#[serde(alias = "rpc_to_slot")]
rpc_to_slot: Option<u64>,
#[serde(alias = "rpc_slot_count")]
rpc_slot_count: Option<u64>,
```

Also fixed it in the `README.md`, in comments, and in error messages.

