### PR TITLE
fix: add backpressure tunables for fumarole ingest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6317,6 +6317,7 @@ dependencies = [
  "once_cell",
  "prometheus-client",
  "prometheus-client-derive-encode",
+ "prost 0.14.3",
  "prost-types 0.14.3",
  "reqwest 0.12.28",
  "serde",

--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ curl -sS http://localhost:8899 \
 - `superbank` supports YAML config, CLI flags, and environment variables.
   Precedence is: flags > env > config file > defaults.
   See `crates/superbank/README.md` and `superbank.example.yaml`.
+  Fumarole ingest includes a default memory soft-limit backpressure guard; set
+  `fumarole-memory-soft-limit-bytes: 0` only if you want to disable it.
 - `superbank-rpc` is configured via CLI flags and environment variables.
   See `crates/superbank-rpc/README.md`.
 

--- a/crates/superbank/Cargo.toml
+++ b/crates/superbank/Cargo.toml
@@ -19,6 +19,7 @@ once_cell = "1.21.3"
 prometheus-client = "0.23.1"
 prometheus-client-derive-encode = "0.4.2"
 kubert-prometheus-process = "0.2.3"
+prost = "0.14.3"
 prost-types = "0.14.3"
 serde = { version = "1.0.219", features = ["derive"] }
 serde-big-array = "0.5"

--- a/crates/superbank/README.md
+++ b/crates/superbank/README.md
@@ -138,6 +138,7 @@ cargo run -p superbank -- --config path/to/superbank.yaml
 - `--fumarole-data-plane-tcp-connections` / `FUMAROLE_DATA_PLANE_TCP_CONNECTIONS` (default: 4; maximum: 20)
 - `--fumarole-concurrent-download-limit-per-tcp` / `FUMAROLE_CONCURRENT_DOWNLOAD_LIMIT_PER_TCP` (default: 2)
 - `--fumarole-data-channel-capacity` / `FUMAROLE_DATA_CHANNEL_CAPACITY` (default: 4096; Fumarole client data channel capacity)
+- `--fumarole-memory-soft-limit-bytes` / `FUMAROLE_MEMORY_SOFT_LIMIT_BYTES` (default: 25769803776; Fumarole backpressure guard soft limit, set 0 to disable)
 - `--fumarole-commit-interval-secs` / `FUMAROLE_COMMIT_INTERVAL_SECS` (default: 10)
 - `--fumarole-no-commit[=true|false]` / `FUMAROLE_NO_COMMIT` (default: false)
 - `--endpoint` / `DRAGONSMOUTH_ENDPOINT` (required for grpc source)
@@ -200,6 +201,10 @@ cargo run -p superbank -- --config path/to/superbank.yaml
 - For Fumarole and gRPC ingest, apply `entries.sql` or set `CLICKHOUSE_ENTRIES_TABLE` to a table that exists before starting Superbank.
 - The ingestor writes **distributed** tables by default. Set table names if you want shard-local writes.
 - Fumarole ingest commits consumer-group progress only after pending ClickHouse rows have been flushed. Set `fumarole-no-commit: true` only for diagnostics.
+- Fumarole ingest applies a memory soft limit guard by default. When sampled RSS or Superbank's
+  estimated Fumarole assembler bytes reach `fumarole-memory-soft-limit-bytes`, Superbank stops
+  polling new Fumarole events while it flushes completed rows to ClickHouse, which backpressures
+  upstream downloads instead of letting memory grow unbounded.
 - `fumarole-from-slot` only initializes a Fumarole consumer group when
   `fumarole-create-consumer-group: true`; existing groups resume from the Fumarole-managed offset.
 - `dragonsmouth-from-slot: 0` attempts slot 0; if unavailable, superbank parses the gRPC error to

--- a/crates/superbank/src/cli.rs
+++ b/crates/superbank/src/cli.rs
@@ -20,6 +20,8 @@ fn default_bigtable_decode_concurrency() -> usize {
         .unwrap_or(4)
 }
 
+pub(crate) const DEFAULT_FUMAROLE_MEMORY_SOFT_LIMIT_BYTES: u64 = 24 * 1024 * 1024 * 1024;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum FromSlotSpec {
     Slot(u64),
@@ -172,6 +174,14 @@ struct CliArgs {
     /// Fumarole stream output channel capacity
     #[arg(long, env = "FUMAROLE_DATA_CHANNEL_CAPACITY", default_value_t = 4096)]
     fumarole_data_channel_capacity: usize,
+
+    /// Fumarole memory pressure soft limit in bytes (0 disables)
+    #[arg(
+        long,
+        env = "FUMAROLE_MEMORY_SOFT_LIMIT_BYTES",
+        default_value_t = DEFAULT_FUMAROLE_MEMORY_SOFT_LIMIT_BYTES
+    )]
+    fumarole_memory_soft_limit_bytes: u64,
 
     /// Fumarole offset commit interval (seconds)
     #[arg(long, env = "FUMAROLE_COMMIT_INTERVAL_SECS", default_value_t = 10)]
@@ -430,6 +440,7 @@ pub(crate) struct Args {
     pub(crate) fumarole_data_plane_tcp_connections: u8,
     pub(crate) fumarole_concurrent_download_limit_per_tcp: usize,
     pub(crate) fumarole_data_channel_capacity: usize,
+    pub(crate) fumarole_memory_soft_limit_bytes: u64,
     pub(crate) fumarole_commit_interval_secs: u64,
     pub(crate) fumarole_no_commit: bool,
     pub(crate) commitment: String,
@@ -503,6 +514,8 @@ struct FileConfig {
     fumarole_concurrent_download_limit_per_tcp: Option<usize>,
     #[serde(alias = "fumarole_data_channel_capacity")]
     fumarole_data_channel_capacity: Option<usize>,
+    #[serde(alias = "fumarole_memory_soft_limit_bytes")]
+    fumarole_memory_soft_limit_bytes: Option<u64>,
     #[serde(alias = "fumarole_commit_interval_secs")]
     fumarole_commit_interval_secs: Option<u64>,
     #[serde(alias = "fumarole_no_commit")]
@@ -662,6 +675,12 @@ pub(crate) fn resolve_args() -> Result<Args> {
             "fumarole_data_channel_capacity",
             cli.fumarole_data_channel_capacity,
             file_config.fumarole_data_channel_capacity,
+        ),
+        fumarole_memory_soft_limit_bytes: merge_value(
+            &matches,
+            "fumarole_memory_soft_limit_bytes",
+            cli.fumarole_memory_soft_limit_bytes,
+            file_config.fumarole_memory_soft_limit_bytes,
         ),
         fumarole_commit_interval_secs: merge_value(
             &matches,
@@ -1356,6 +1375,8 @@ grpc-health-watch-enabled: false
             "3",
             "--fumarole-data-channel-capacity",
             "1234",
+            "--fumarole-memory-soft-limit-bytes",
+            "987654321",
             "--fumarole-commit-interval-secs",
             "2",
         ]);
@@ -1375,6 +1396,7 @@ grpc-health-watch-enabled: false
         assert_eq!(cli.fumarole_data_plane_tcp_connections, 8);
         assert_eq!(cli.fumarole_concurrent_download_limit_per_tcp, 3);
         assert_eq!(cli.fumarole_data_channel_capacity, 1234);
+        assert_eq!(cli.fumarole_memory_soft_limit_bytes, 987654321);
         assert_eq!(cli.fumarole_commit_interval_secs, 2);
     }
 
@@ -1390,6 +1412,7 @@ fumarole-create-consumer-group: true
 fumarole-data-plane-tcp-connections: 8
 fumarole-concurrent-download-limit-per-tcp: 3
 fumarole-data-channel-capacity: 1234
+fumarole-memory-soft-limit-bytes: 987654321
 fumarole-commit-interval-secs: 2
 fumarole-no-commit: true
 "#,
@@ -1410,8 +1433,34 @@ fumarole-no-commit: true
         assert_eq!(config.fumarole_data_plane_tcp_connections, Some(8));
         assert_eq!(config.fumarole_concurrent_download_limit_per_tcp, Some(3));
         assert_eq!(config.fumarole_data_channel_capacity, Some(1234));
+        assert_eq!(config.fumarole_memory_soft_limit_bytes, Some(987654321));
         assert_eq!(config.fumarole_commit_interval_secs, Some(2));
         assert_eq!(config.fumarole_no_commit, Some(true));
+    }
+
+    #[test]
+    fn fumarole_memory_soft_limit_defaults_to_twenty_four_gib() {
+        let matches = CliArgs::command().get_matches_from(["superbank", "--source", "fumarole"]);
+        let cli = CliArgs::from_arg_matches(&matches).expect("parse cli args");
+
+        assert_eq!(
+            cli.fumarole_memory_soft_limit_bytes,
+            DEFAULT_FUMAROLE_MEMORY_SOFT_LIMIT_BYTES
+        );
+    }
+
+    #[test]
+    fn cli_accepts_zero_fumarole_memory_soft_limit() {
+        let matches = CliArgs::command().get_matches_from([
+            "superbank",
+            "--source",
+            "fumarole",
+            "--fumarole-memory-soft-limit-bytes",
+            "0",
+        ]);
+        let cli = CliArgs::from_arg_matches(&matches).expect("parse cli args");
+
+        assert_eq!(cli.fumarole_memory_soft_limit_bytes, 0);
     }
 
     #[test]
@@ -1632,6 +1681,7 @@ rpc-from-slot: 456
             fumarole_data_plane_tcp_connections: 4,
             fumarole_concurrent_download_limit_per_tcp: 2,
             fumarole_data_channel_capacity: 4096,
+            fumarole_memory_soft_limit_bytes: DEFAULT_FUMAROLE_MEMORY_SOFT_LIMIT_BYTES,
             fumarole_commit_interval_secs: 10,
             fumarole_no_commit: false,
             commitment: "finalized".to_string(),

--- a/crates/superbank/src/clickhouse.rs
+++ b/crates/superbank/src/clickhouse.rs
@@ -466,6 +466,7 @@ mod tests {
             fumarole_data_plane_tcp_connections: 4,
             fumarole_concurrent_download_limit_per_tcp: 2,
             fumarole_data_channel_capacity: 4096,
+            fumarole_memory_soft_limit_bytes: crate::cli::DEFAULT_FUMAROLE_MEMORY_SOFT_LIMIT_BYTES,
             fumarole_commit_interval_secs: 10,
             fumarole_no_commit: false,
             commitment: "finalized".to_string(),

--- a/crates/superbank/src/ingest/fumarole.rs
+++ b/crates/superbank/src/ingest/fumarole.rs
@@ -87,7 +87,8 @@ pub(crate) async fn run_fumarole_ingest(args: &Args) -> Result<()> {
         .with_context(|| format!("subscribe to Fumarole consumer group {consumer_group}"))?;
     let (_sink, stream) = subscription.split();
     let mut stream = stream;
-    let mut block_assembler = FumaroleBlockAssembler::default();
+    let track_estimated_bytes = args.fumarole_memory_soft_limit_bytes > 0;
+    let mut block_assembler = FumaroleBlockAssembler::new(track_estimated_bytes);
     let mut pressure_guard = FumarolePressureGuard::new(args.fumarole_memory_soft_limit_bytes);
     pressure_guard.observe(&block_assembler);
 
@@ -454,10 +455,10 @@ enum FumaroleAssembledUpdate {
     Block(Box<SubscribeUpdate>),
 }
 
-#[derive(Default)]
 struct FumaroleBlockAssembler {
     blocks: HashMap<u64, FumaroleBlockParts>,
     estimated_buffered_bytes: u64,
+    track_estimated_bytes: bool,
 }
 
 #[derive(Default)]
@@ -471,6 +472,14 @@ struct FumaroleBlockParts {
 }
 
 impl FumaroleBlockAssembler {
+    fn new(track_estimated_bytes: bool) -> Self {
+        Self {
+            blocks: HashMap::new(),
+            estimated_buffered_bytes: 0,
+            track_estimated_bytes,
+        }
+    }
+
     fn estimated_buffered_bytes(&self) -> u64 {
         self.estimated_buffered_bytes
     }
@@ -484,7 +493,7 @@ impl FumaroleBlockAssembler {
         stream_slot: u64,
         update: SubscribeUpdate,
     ) -> Result<FumaroleAssembledUpdate> {
-        let update_bytes = update.encoded_len() as u64;
+        let update_bytes = self.estimated_update_bytes(&update);
         match update.update_oneof {
             Some(UpdateOneof::Slot(slot)) => {
                 Ok(FumaroleAssembledUpdate::SlotStatus(slot.slot, slot.status))
@@ -561,6 +570,19 @@ impl FumaroleBlockAssembler {
                 Ok(FumaroleAssembledUpdate::None)
             }
             Some(_) => Ok(FumaroleAssembledUpdate::None),
+        }
+    }
+
+    fn estimated_update_bytes(&self, update: &SubscribeUpdate) -> u64 {
+        if !self.track_estimated_bytes {
+            return 0;
+        }
+
+        match update.update_oneof.as_ref() {
+            Some(UpdateOneof::BlockMeta(_))
+            | Some(UpdateOneof::Transaction(_))
+            | Some(UpdateOneof::Entry(_)) => update.encoded_len() as u64,
+            _ => 0,
         }
     }
 
@@ -788,7 +810,7 @@ mod tests {
 
     #[test]
     fn fumarole_block_assembler_builds_block_update_without_block_stream_adapter() {
-        let mut assembler = FumaroleBlockAssembler::default();
+        let mut assembler = FumaroleBlockAssembler::new(false);
         assembler
             .handle_update(
                 42,
@@ -834,7 +856,7 @@ mod tests {
 
     #[test]
     fn fumarole_block_assembler_rejects_payload_without_block_meta() {
-        let mut assembler = FumaroleBlockAssembler::default();
+        let mut assembler = FumaroleBlockAssembler::new(false);
         assembler
             .handle_update(
                 42,
@@ -861,7 +883,7 @@ mod tests {
 
     #[test]
     fn fumarole_block_assembler_tracks_pending_slots_and_estimated_bytes() {
-        let mut assembler = FumaroleBlockAssembler::default();
+        let mut assembler = FumaroleBlockAssembler::new(true);
 
         assembler
             .handle_update(
@@ -912,6 +934,52 @@ mod tests {
             err.to_string()
                 .contains("ended without block meta after receiving 1 transactions")
         );
+        assert_eq!(assembler.pending_slots(), 0);
+        assert_eq!(assembler.estimated_buffered_bytes(), 0);
+    }
+
+    #[test]
+    fn fumarole_block_assembler_skips_estimated_bytes_when_tracking_disabled() {
+        let mut assembler = FumaroleBlockAssembler::new(false);
+
+        assembler
+            .handle_update(
+                42,
+                SubscribeUpdate {
+                    update_oneof: Some(UpdateOneof::BlockMeta(SubscribeUpdateBlockMeta {
+                        slot: 42,
+                        blockhash: "hash".to_string(),
+                        executed_transaction_count: 1,
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                },
+            )
+            .expect("block meta");
+        assembler
+            .handle_update(
+                42,
+                SubscribeUpdate {
+                    update_oneof: Some(UpdateOneof::Transaction(SubscribeUpdateTransaction {
+                        slot: 42,
+                        transaction: Some(SubscribeUpdateTransactionInfo {
+                            index: 7,
+                            ..Default::default()
+                        }),
+                    })),
+                    ..Default::default()
+                },
+            )
+            .expect("transaction");
+
+        assert_eq!(assembler.pending_slots(), 1);
+        assert_eq!(assembler.estimated_buffered_bytes(), 0);
+
+        let update = assembler
+            .finish_slot(42)
+            .expect("finish slot")
+            .expect("block update");
+        assert_eq!(processed_fumarole_block_slot(&update), Some(42));
         assert_eq!(assembler.pending_slots(), 0);
         assert_eq!(assembler.estimated_buffered_bytes(), 0);
     }

--- a/crates/superbank/src/ingest/fumarole.rs
+++ b/crates/superbank/src/ingest/fumarole.rs
@@ -5,6 +5,7 @@
 
 use std::{
     collections::HashMap,
+    fs,
     num::{NonZeroU8, NonZeroUsize},
     time::Duration,
 };
@@ -12,6 +13,7 @@ use std::{
 use anyhow::{Context, Result, anyhow};
 use clickhouse::Client as ClickHouseClient;
 use futures::StreamExt;
+use prost::Message as _;
 use serde_yaml::{Mapping, Value};
 use tokio::time::{Instant, MissedTickBehavior, Sleep, interval, sleep_until};
 use tonic::Code;
@@ -20,7 +22,7 @@ use yellowstone_fumarole_client::{
     FumaroleClient, FumaroleSubscribeConfig,
     config::FumaroleConfig,
     proto::{CreateConsumerGroupRequest, InitialOffsetPolicy},
-    stream::{FumaroleEvent, SlotSequentialStream},
+    stream::{FumaroleEvent, FumaroleStream},
 };
 use yellowstone_grpc_proto::prelude::{
     SubscribeRequest, SubscribeRequestFilterBlocksMeta, SubscribeRequestFilterEntry,
@@ -56,11 +58,13 @@ pub(crate) async fn run_fumarole_ingest(args: &Args) -> Result<()> {
         fumarole_data_plane_tcp_connections = args.fumarole_data_plane_tcp_connections,
         fumarole_concurrent_download_limit_per_tcp = args.fumarole_concurrent_download_limit_per_tcp,
         fumarole_data_channel_capacity = args.fumarole_data_channel_capacity,
+        fumarole_memory_soft_limit_bytes = args.fumarole_memory_soft_limit_bytes,
         fumarole_commit_interval_secs = args.fumarole_commit_interval_secs,
         fumarole_no_commit = args.fumarole_no_commit,
         "starting superbank fumarole ingest"
     );
     metrics::set_fumarole_data_channel_capacity(args.fumarole_data_channel_capacity);
+    metrics::set_fumarole_memory_soft_limit_bytes(args.fumarole_memory_soft_limit_bytes);
 
     if args.fumarole_from_slot.is_some() && !args.fumarole_create_consumer_group {
         warn!(
@@ -82,8 +86,10 @@ pub(crate) async fn run_fumarole_ingest(args: &Args) -> Result<()> {
         .await
         .with_context(|| format!("subscribe to Fumarole consumer group {consumer_group}"))?;
     let (_sink, stream) = subscription.split();
-    let mut stream = stream.slot_sequential();
+    let mut stream = stream;
     let mut block_assembler = FumaroleBlockAssembler::default();
+    let mut pressure_guard = FumarolePressureGuard::new(args.fumarole_memory_soft_limit_bytes);
+    pressure_guard.observe(&block_assembler);
 
     let mut buffered_rows = BufferedRows::new(args);
     let insert_tables = InsertTables::from_args(args);
@@ -112,8 +118,10 @@ pub(crate) async fn run_fumarole_ingest(args: &Args) -> Result<()> {
                     &insert_tables,
                     &mut buffered_rows,
                     &mut stream,
+                    false,
                 )
                 .await?;
+                pressure_guard.observe(&block_assembler);
             }
             _ = &mut idle_timer => {
                 let reason = format!(
@@ -138,53 +146,65 @@ pub(crate) async fn run_fumarole_ingest(args: &Args) -> Result<()> {
             }
             event = stream.next() => {
                 match event {
-                    Some(Ok(FumaroleEvent::Data { slot, update })) => {
+                    Some(Ok(event)) => {
                         reset_idle_timer(idle_timer.as_mut(), idle_timeout);
-                        match block_assembler.handle_update(slot, update)? {
-                            FumaroleAssembledUpdate::None => {}
-                            FumaroleAssembledUpdate::SlotStatus(status_slot, status) => {
-                                observe_processed_slot(&mut last_processed_block_slot, status_slot);
-                                if status == commitment {
-                                    metrics::set_network_tip_slot(status_slot);
+                        match event {
+                            FumaroleEvent::Data { slot, update } => {
+                                match block_assembler.handle_update(slot, update)? {
+                                    FumaroleAssembledUpdate::None => {}
+                                    FumaroleAssembledUpdate::SlotStatus(status_slot, status) => {
+                                        observe_processed_slot(&mut last_processed_block_slot, status_slot);
+                                        if status == commitment {
+                                            metrics::set_network_tip_slot(status_slot);
+                                        }
+                                    }
+                                    FumaroleAssembledUpdate::Block(update) => {
+                                        let update = *update;
+                                        if let Some(slot) = processed_fumarole_block_slot(&update) {
+                                            observe_processed_slot(&mut last_processed_block_slot, slot);
+                                        }
+                                        if process_update(
+                                            update,
+                                            args,
+                                            &insert_tables,
+                                            &clickhouse,
+                                            &mut buffered_rows,
+                                        )
+                                        .await?
+                                        {
+                                            stream.commit();
+                                        }
+                                    }
                                 }
                             }
-                            FumaroleAssembledUpdate::Block(update) => {
-                                let update = *update;
-                                if let Some(slot) = processed_fumarole_block_slot(&update) {
-                                    observe_processed_slot(&mut last_processed_block_slot, slot);
-                                }
-                                if process_update(
-                                    update,
-                                    args,
-                                    &insert_tables,
-                                    &clickhouse,
-                                    &mut buffered_rows,
-                                )
-                                .await?
-                                {
+                            FumaroleEvent::SlotEnded(slot) => {
+                                observe_processed_slot(&mut last_processed_block_slot, slot);
+                                if let Some(update) = block_assembler.finish_slot(slot)? {
+                                    if process_update(
+                                        update,
+                                        args,
+                                        &insert_tables,
+                                        &clickhouse,
+                                        &mut buffered_rows,
+                                    )
+                                    .await?
+                                    {
+                                        stream.commit();
+                                    }
+                                } else if buffered_rows.is_empty() {
                                     stream.commit();
                                 }
                             }
                         }
-                    }
-                    Some(Ok(FumaroleEvent::SlotEnded(slot))) => {
-                        reset_idle_timer(idle_timer.as_mut(), idle_timeout);
-                        observe_processed_slot(&mut last_processed_block_slot, slot);
-                        if let Some(update) = block_assembler.finish_slot(slot)? {
-                            if process_update(
-                                update,
-                                args,
-                                &insert_tables,
-                                &clickhouse,
-                                &mut buffered_rows,
-                            )
-                            .await?
-                            {
-                                stream.commit();
-                            }
-                        } else if buffered_rows.is_empty() {
-                            stream.commit();
-                        }
+                        maybe_flush_for_pressure(
+                            &clickhouse,
+                            &insert_tables,
+                            &mut buffered_rows,
+                            &mut stream,
+                            &block_assembler,
+                            &mut pressure_guard,
+                        )
+                        .await?;
                     }
                     Some(Err(err)) => {
                         let reason = format!("Fumarole stream error: {err}");
@@ -233,6 +253,7 @@ pub(crate) async fn run_fumarole_ingest(args: &Args) -> Result<()> {
             &insert_tables,
             &mut buffered_rows,
             &mut stream,
+            false,
         ) => {
             result?;
         }
@@ -324,6 +345,109 @@ fn build_fumarole_subscribe_request(commitment: i32, include_entries: bool) -> S
     }
 }
 
+struct FumarolePressureGuard {
+    soft_limit_bytes: u64,
+    last_rss_bytes: Option<u64>,
+    last_rss_sample: Option<Instant>,
+    pressure_logged: bool,
+}
+
+struct FumarolePressureSnapshot {
+    soft_limit_bytes: u64,
+    buffered_bytes: u64,
+    pending_slots: usize,
+    rss_bytes: Option<u64>,
+    over_limit_reason: Option<&'static str>,
+}
+
+impl FumarolePressureGuard {
+    const RSS_SAMPLE_INTERVAL: Duration = Duration::from_secs(1);
+
+    const fn new(soft_limit_bytes: u64) -> Self {
+        Self {
+            soft_limit_bytes,
+            last_rss_bytes: None,
+            last_rss_sample: None,
+            pressure_logged: false,
+        }
+    }
+
+    fn observe(&mut self, block_assembler: &FumaroleBlockAssembler) -> FumarolePressureSnapshot {
+        let buffered_bytes = block_assembler.estimated_buffered_bytes();
+        let pending_slots = block_assembler.pending_slots();
+
+        if self.soft_limit_bytes > 0
+            && self
+                .last_rss_sample
+                .is_none_or(|sampled_at| sampled_at.elapsed() >= Self::RSS_SAMPLE_INTERVAL)
+        {
+            self.last_rss_bytes = current_rss_bytes();
+            self.last_rss_sample = Some(Instant::now());
+        }
+
+        metrics::set_fumarole_buffered_bytes(buffered_bytes);
+        metrics::set_fumarole_pending_slots(pending_slots);
+        if let Some(rss_bytes) = self.last_rss_bytes {
+            metrics::set_fumarole_rss_bytes(rss_bytes);
+        }
+
+        let over_limit_reason = if self.soft_limit_bytes == 0 {
+            None
+        } else if buffered_bytes >= self.soft_limit_bytes {
+            Some("buffered_bytes")
+        } else if self
+            .last_rss_bytes
+            .is_some_and(|rss_bytes| rss_bytes >= self.soft_limit_bytes)
+        {
+            Some("rss")
+        } else {
+            None
+        };
+
+        FumarolePressureSnapshot {
+            soft_limit_bytes: self.soft_limit_bytes,
+            buffered_bytes,
+            pending_slots,
+            rss_bytes: self.last_rss_bytes,
+            over_limit_reason,
+        }
+    }
+
+    fn warn_once(&mut self, warn: impl FnOnce()) {
+        if self.pressure_logged {
+            return;
+        }
+        warn();
+        self.pressure_logged = true;
+    }
+
+    fn clear_logged(&mut self) {
+        self.pressure_logged = false;
+    }
+}
+
+fn current_rss_bytes() -> Option<u64> {
+    let status = fs::read_to_string("/proc/self/status").ok()?;
+    parse_proc_status_rss_bytes(&status)
+}
+
+fn parse_proc_status_rss_bytes(status: &str) -> Option<u64> {
+    for line in status.lines() {
+        let Some(value) = line.strip_prefix("VmRSS:") else {
+            continue;
+        };
+        let mut fields = value.split_whitespace();
+        let amount = fields.next()?.parse::<u64>().ok()?;
+        let unit = fields.next().unwrap_or("kB");
+        return match unit {
+            "kB" | "KB" | "Kb" => amount.checked_mul(1024),
+            "B" => Some(amount),
+            _ => None,
+        };
+    }
+    None
+}
+
 enum FumaroleAssembledUpdate {
     None,
     SlotStatus(u64, i32),
@@ -333,22 +457,34 @@ enum FumaroleAssembledUpdate {
 #[derive(Default)]
 struct FumaroleBlockAssembler {
     blocks: HashMap<u64, FumaroleBlockParts>,
+    estimated_buffered_bytes: u64,
 }
 
 #[derive(Default)]
 struct FumaroleBlockParts {
     block_meta: Option<SubscribeUpdateBlockMeta>,
     block_meta_created_at: Option<prost_types::Timestamp>,
+    block_meta_bytes: u64,
     transactions: Vec<SubscribeUpdateTransactionInfo>,
     entries: Vec<SubscribeUpdateEntry>,
+    estimated_bytes: u64,
 }
 
 impl FumaroleBlockAssembler {
+    fn estimated_buffered_bytes(&self) -> u64 {
+        self.estimated_buffered_bytes
+    }
+
+    fn pending_slots(&self) -> usize {
+        self.blocks.len()
+    }
+
     fn handle_update(
         &mut self,
         stream_slot: u64,
         update: SubscribeUpdate,
     ) -> Result<FumaroleAssembledUpdate> {
+        let update_bytes = update.encoded_len() as u64;
         match update.update_oneof {
             Some(UpdateOneof::Slot(slot)) => {
                 Ok(FumaroleAssembledUpdate::SlotStatus(slot.slot, slot.status))
@@ -369,8 +505,19 @@ impl FumaroleBlockAssembler {
                     );
                 }
                 let block = self.blocks.entry(stream_slot).or_default();
+                if block.block_meta.is_some() {
+                    self.estimated_buffered_bytes = self
+                        .estimated_buffered_bytes
+                        .saturating_sub(block.block_meta_bytes);
+                    block.estimated_bytes =
+                        block.estimated_bytes.saturating_sub(block.block_meta_bytes);
+                }
                 block.block_meta_created_at = update.created_at;
                 block.block_meta = Some(meta);
+                block.block_meta_bytes = update_bytes;
+                block.estimated_bytes = block.estimated_bytes.saturating_add(update_bytes);
+                self.estimated_buffered_bytes =
+                    self.estimated_buffered_bytes.saturating_add(update_bytes);
                 Ok(FumaroleAssembledUpdate::None)
             }
             Some(UpdateOneof::Transaction(tx)) => {
@@ -382,11 +529,11 @@ impl FumaroleBlockAssembler {
                     );
                 }
                 if let Some(info) = tx.transaction {
-                    self.blocks
-                        .entry(stream_slot)
-                        .or_default()
-                        .transactions
-                        .push(info);
+                    let block = self.blocks.entry(stream_slot).or_default();
+                    block.transactions.push(info);
+                    block.estimated_bytes = block.estimated_bytes.saturating_add(update_bytes);
+                    self.estimated_buffered_bytes =
+                        self.estimated_buffered_bytes.saturating_add(update_bytes);
                 } else {
                     warn!(
                         slot = stream_slot,
@@ -403,11 +550,11 @@ impl FumaroleBlockAssembler {
                         "Fumarole entry slot mismatch"
                     );
                 }
-                self.blocks
-                    .entry(stream_slot)
-                    .or_default()
-                    .entries
-                    .push(entry);
+                let block = self.blocks.entry(stream_slot).or_default();
+                block.entries.push(entry);
+                block.estimated_bytes = block.estimated_bytes.saturating_add(update_bytes);
+                self.estimated_buffered_bytes =
+                    self.estimated_buffered_bytes.saturating_add(update_bytes);
                 Ok(FumaroleAssembledUpdate::None)
             }
             Some(UpdateOneof::Ping(_)) | Some(UpdateOneof::Pong(_)) | None => {
@@ -421,6 +568,9 @@ impl FumaroleBlockAssembler {
         let Some(parts) = self.blocks.remove(&slot) else {
             return Ok(None);
         };
+        self.estimated_buffered_bytes = self
+            .estimated_buffered_bytes
+            .saturating_sub(parts.estimated_bytes);
         parts.into_subscribe_update(slot)
     }
 }
@@ -430,8 +580,10 @@ impl FumaroleBlockParts {
         let Self {
             block_meta,
             block_meta_created_at,
+            block_meta_bytes: _,
             transactions,
             entries,
+            estimated_bytes: _,
         } = self;
 
         let Some(meta) = block_meta else {
@@ -552,10 +704,14 @@ async fn flush_and_commit(
     clickhouse: &ClickHouseClient,
     insert_tables: &InsertTables,
     buffered_rows: &mut BufferedRows,
-    stream: &mut SlotSequentialStream,
+    stream: &mut FumaroleStream,
+    commit_if_empty: bool,
 ) -> Result<()> {
+    let had_rows = !buffered_rows.is_empty();
     buffered_rows.flush(clickhouse, insert_tables).await?;
-    stream.commit();
+    if had_rows || commit_if_empty {
+        stream.commit();
+    }
     Ok(())
 }
 
@@ -563,12 +719,55 @@ async fn flush_after_fatal_condition(
     clickhouse: &ClickHouseClient,
     insert_tables: &InsertTables,
     buffered_rows: &mut BufferedRows,
-    stream: &mut SlotSequentialStream,
+    stream: &mut FumaroleStream,
     reason: &str,
 ) -> Result<()> {
-    flush_and_commit(clickhouse, insert_tables, buffered_rows, stream)
+    flush_and_commit(clickhouse, insert_tables, buffered_rows, stream, false)
         .await
         .with_context(|| format!("flush buffered rows after fatal Fumarole condition: {reason}"))
+}
+
+async fn maybe_flush_for_pressure(
+    clickhouse: &ClickHouseClient,
+    insert_tables: &InsertTables,
+    buffered_rows: &mut BufferedRows,
+    stream: &mut FumaroleStream,
+    block_assembler: &FumaroleBlockAssembler,
+    pressure_guard: &mut FumarolePressureGuard,
+) -> Result<()> {
+    let snapshot = pressure_guard.observe(block_assembler);
+    let Some(reason) = snapshot.over_limit_reason else {
+        pressure_guard.clear_logged();
+        return Ok(());
+    };
+
+    if buffered_rows.is_empty() {
+        pressure_guard.warn_once(|| {
+            warn!(
+                reason,
+                soft_limit_bytes = snapshot.soft_limit_bytes,
+                buffered_bytes = snapshot.buffered_bytes,
+                pending_slots = snapshot.pending_slots,
+                rss_bytes = snapshot.rss_bytes,
+                "Fumarole memory pressure detected but no complete rows are ready to flush; continuing to drain until a slot completes"
+            );
+        });
+        return Ok(());
+    }
+
+    warn!(
+        reason,
+        soft_limit_bytes = snapshot.soft_limit_bytes,
+        buffered_bytes = snapshot.buffered_bytes,
+        pending_slots = snapshot.pending_slots,
+        rss_bytes = snapshot.rss_bytes,
+        "Fumarole memory pressure detected; flushing buffered rows before polling more events"
+    );
+    metrics::observe_fumarole_pressure_flush();
+    flush_and_commit(clickhouse, insert_tables, buffered_rows, stream, false).await?;
+    pressure_guard.clear_logged();
+    pressure_guard.observe(block_assembler);
+    Ok(())
 }
 
 fn reset_idle_timer(idle_timer: std::pin::Pin<&mut Sleep>, idle_timeout: Duration) {
@@ -658,5 +857,79 @@ mod tests {
             err.to_string()
                 .contains("ended without block meta after receiving 1 transactions")
         );
+    }
+
+    #[test]
+    fn fumarole_block_assembler_tracks_pending_slots_and_estimated_bytes() {
+        let mut assembler = FumaroleBlockAssembler::default();
+
+        assembler
+            .handle_update(
+                42,
+                SubscribeUpdate {
+                    update_oneof: Some(UpdateOneof::BlockMeta(SubscribeUpdateBlockMeta {
+                        slot: 42,
+                        blockhash: "hash".to_string(),
+                        executed_transaction_count: 1,
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                },
+            )
+            .expect("block meta");
+        let after_meta_bytes = assembler.estimated_buffered_bytes();
+        assert_eq!(assembler.pending_slots(), 1);
+        assert!(after_meta_bytes > 0);
+
+        assembler
+            .handle_update(
+                43,
+                SubscribeUpdate {
+                    update_oneof: Some(UpdateOneof::Transaction(SubscribeUpdateTransaction {
+                        slot: 43,
+                        transaction: Some(SubscribeUpdateTransactionInfo {
+                            index: 7,
+                            ..Default::default()
+                        }),
+                    })),
+                    ..Default::default()
+                },
+            )
+            .expect("transaction");
+        assert_eq!(assembler.pending_slots(), 2);
+        assert!(assembler.estimated_buffered_bytes() > after_meta_bytes);
+
+        let update = assembler
+            .finish_slot(42)
+            .expect("finish slot")
+            .expect("block update");
+        assert_eq!(processed_fumarole_block_slot(&update), Some(42));
+        assert_eq!(assembler.pending_slots(), 1);
+        assert!(assembler.estimated_buffered_bytes() > 0);
+
+        let err = assembler.finish_slot(43).expect_err("missing block meta");
+        assert!(
+            err.to_string()
+                .contains("ended without block meta after receiving 1 transactions")
+        );
+        assert_eq!(assembler.pending_slots(), 0);
+        assert_eq!(assembler.estimated_buffered_bytes(), 0);
+    }
+
+    #[test]
+    fn parse_proc_status_rss_bytes_reads_kilobytes() {
+        let status = "\
+Name:\tsuperbank
+VmPeak:\t  123456 kB
+VmRSS:\t   12345 kB
+";
+
+        assert_eq!(parse_proc_status_rss_bytes(status), Some(12_641_280));
+    }
+
+    #[test]
+    fn parse_proc_status_rss_bytes_ignores_missing_or_unknown_units() {
+        assert_eq!(parse_proc_status_rss_bytes("Name:\tsuperbank\n"), None);
+        assert_eq!(parse_proc_status_rss_bytes("VmRSS:\t123 MB\n"), None);
     }
 }

--- a/crates/superbank/src/metrics.rs
+++ b/crates/superbank/src/metrics.rs
@@ -66,6 +66,11 @@ pub(crate) struct Metrics {
     inserted_slots_total: Counter,
     inserted_transactions_total: Counter,
     fumarole_data_channel_capacity: Gauge,
+    fumarole_memory_soft_limit_bytes: Gauge,
+    fumarole_buffered_bytes: Gauge,
+    fumarole_pending_slots: Gauge,
+    fumarole_rss_bytes: Gauge,
+    fumarole_pressure_flushes_total: Counter,
     last_successful_flush_timestamp_seconds: Gauge,
     flush_duration_seconds: Family<TableLabels, Histogram>,
     flush_rows_total: Family<TableLabels, Counter>,
@@ -84,6 +89,11 @@ impl Metrics {
         let inserted_slots_total = Counter::default();
         let inserted_transactions_total = Counter::default();
         let fumarole_data_channel_capacity = Gauge::default();
+        let fumarole_memory_soft_limit_bytes = Gauge::default();
+        let fumarole_buffered_bytes = Gauge::default();
+        let fumarole_pending_slots = Gauge::default();
+        let fumarole_rss_bytes = Gauge::default();
+        let fumarole_pressure_flushes_total = Counter::default();
         let last_successful_flush_timestamp_seconds = Gauge::default();
         let flush_duration_seconds =
             Family::new_with_constructor(latency_histogram as fn() -> Histogram);
@@ -141,6 +151,31 @@ impl Metrics {
             fumarole_data_channel_capacity.clone(),
         );
         registry_for_metrics.register(
+            "ingest_fumarole_memory_soft_limit_bytes",
+            "Configured Fumarole memory pressure soft limit in bytes; zero disables the guard",
+            fumarole_memory_soft_limit_bytes.clone(),
+        );
+        registry_for_metrics.register(
+            "ingest_fumarole_buffered_bytes",
+            "Estimated bytes buffered by the Superbank Fumarole block assembler",
+            fumarole_buffered_bytes.clone(),
+        );
+        registry_for_metrics.register(
+            "ingest_fumarole_pending_slots",
+            "Slots currently pending in the Superbank Fumarole block assembler",
+            fumarole_pending_slots.clone(),
+        );
+        registry_for_metrics.register(
+            "ingest_fumarole_rss_bytes",
+            "Latest sampled process resident set size in bytes used by the Fumarole pressure guard",
+            fumarole_rss_bytes.clone(),
+        );
+        registry_for_metrics.register(
+            "ingest_fumarole_pressure_flushes_total",
+            "Total ClickHouse flushes triggered by the Fumarole memory pressure guard",
+            fumarole_pressure_flushes_total.clone(),
+        );
+        registry_for_metrics.register(
             "ingest_last_successful_flush_timestamp_seconds",
             "Unix timestamp of the last successful ClickHouse flush",
             last_successful_flush_timestamp_seconds.clone(),
@@ -181,6 +216,11 @@ impl Metrics {
             inserted_slots_total,
             inserted_transactions_total,
             fumarole_data_channel_capacity,
+            fumarole_memory_soft_limit_bytes,
+            fumarole_buffered_bytes,
+            fumarole_pending_slots,
+            fumarole_rss_bytes,
+            fumarole_pressure_flushes_total,
             last_successful_flush_timestamp_seconds,
             flush_duration_seconds,
             flush_rows_total,
@@ -224,6 +264,26 @@ impl Metrics {
     fn set_fumarole_data_channel_capacity(&self, capacity: usize) {
         self.fumarole_data_channel_capacity
             .set(clamp_usize(capacity));
+    }
+
+    fn set_fumarole_memory_soft_limit_bytes(&self, bytes: u64) {
+        self.fumarole_memory_soft_limit_bytes.set(clamp_i64(bytes));
+    }
+
+    fn set_fumarole_buffered_bytes(&self, bytes: u64) {
+        self.fumarole_buffered_bytes.set(clamp_i64(bytes));
+    }
+
+    fn set_fumarole_pending_slots(&self, slots: usize) {
+        self.fumarole_pending_slots.set(clamp_usize(slots));
+    }
+
+    fn set_fumarole_rss_bytes(&self, bytes: u64) {
+        self.fumarole_rss_bytes.set(clamp_i64(bytes));
+    }
+
+    fn observe_fumarole_pressure_flush(&self) {
+        self.fumarole_pressure_flushes_total.inc();
     }
 
     fn observe_flush_duration(&self, table: &str, elapsed_seconds: f64) {
@@ -325,6 +385,26 @@ pub(crate) fn observe_transaction_insert(table: &str, rows: usize) {
 
 pub(crate) fn set_fumarole_data_channel_capacity(capacity: usize) {
     metrics().set_fumarole_data_channel_capacity(capacity);
+}
+
+pub(crate) fn set_fumarole_memory_soft_limit_bytes(bytes: u64) {
+    metrics().set_fumarole_memory_soft_limit_bytes(bytes);
+}
+
+pub(crate) fn set_fumarole_buffered_bytes(bytes: u64) {
+    metrics().set_fumarole_buffered_bytes(bytes);
+}
+
+pub(crate) fn set_fumarole_pending_slots(slots: usize) {
+    metrics().set_fumarole_pending_slots(slots);
+}
+
+pub(crate) fn set_fumarole_rss_bytes(bytes: u64) {
+    metrics().set_fumarole_rss_bytes(bytes);
+}
+
+pub(crate) fn observe_fumarole_pressure_flush() {
+    metrics().observe_fumarole_pressure_flush();
 }
 
 pub(crate) fn observe_flush_duration(table: &str, elapsed_seconds: f64) {

--- a/superbank.example.yaml
+++ b/superbank.example.yaml
@@ -24,6 +24,7 @@ grpc-slot-notifications: true
 # fumarole-data-plane-tcp-connections: 4
 # fumarole-concurrent-download-limit-per-tcp: 2
 # fumarole-data-channel-capacity: 4096
+# fumarole-memory-soft-limit-bytes: 25769803776 # 24 GiB; set 0 to disable
 # fumarole-commit-interval-secs: 10
 # fumarole-no-commit: false
 


### PR DESCRIPTION
This pull request introduces a configurable memory soft-limit backpressure guard to the Fumarole ingest pipeline in Superbank, along with related documentation, configuration, and test updates. The guard prevents unbounded memory growth during ingest by pausing event polling and flushing data to ClickHouse when memory usage exceeds the specified limit. By default, the limit is set to 24 GiB but can be adjusted (or disabled) via CLI, environment variable, or config file.

**Fumarole ingest memory backpressure guard:**

* Added a new `--fumarole-memory-soft-limit-bytes` CLI flag, `FUMAROLE_MEMORY_SOFT_LIMIT_BYTES` environment variable, and YAML config option to control the Fumarole memory soft-limit (default: 24 GiB, set to 0 to disable). [[1]](diffhunk://#diff-18763d9e024658654f7fbb6d9be59e1267331fc8137daec283fe496fbb0b5503R23-R24) [[2]](diffhunk://#diff-18763d9e024658654f7fbb6d9be59e1267331fc8137daec283fe496fbb0b5503R178-R185) [[3]](diffhunk://#diff-18763d9e024658654f7fbb6d9be59e1267331fc8137daec283fe496fbb0b5503R443) [[4]](diffhunk://#diff-18763d9e024658654f7fbb6d9be59e1267331fc8137daec283fe496fbb0b5503R517-R518) [[5]](diffhunk://#diff-18763d9e024658654f7fbb6d9be59e1267331fc8137daec283fe496fbb0b5503R679-R684) [[6]](diffhunk://#diff-4acd90365e006c34f4bc14a74f47dacf2703083087c754bee9fe0548bd9e1e05R141) [[7]](diffhunk://#diff-4acd90365e006c34f4bc14a74f47dacf2703083087c754bee9fe0548bd9e1e05R204-R207) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R172-R173)
* Implemented `FumarolePressureGuard` in `fumarole.rs` to monitor both buffered bytes and process RSS, pausing event polling and flushing rows to ClickHouse when the soft limit is exceeded. [[1]](diffhunk://#diff-a469ff08c10878a037a775a3ad6ba682a9b6109e1e837d3ac637bd6724cb379dR348-R450) [[2]](diffhunk://#diff-a469ff08c10878a037a775a3ad6ba682a9b6109e1e837d3ac637bd6724cb379dL85-R92) [[3]](diffhunk://#diff-a469ff08c10878a037a775a3ad6ba682a9b6109e1e837d3ac637bd6724cb379dR121-R124) [[4]](diffhunk://#diff-a469ff08c10878a037a775a3ad6ba682a9b6109e1e837d3ac637bd6724cb379dL141-R152) [[5]](diffhunk://#diff-a469ff08c10878a037a775a3ad6ba682a9b6109e1e837d3ac637bd6724cb379dR198-R208)
* Integrated the pressure guard into the Fumarole ingest event loop; it observes memory usage on each event and after flushes. [[1]](diffhunk://#diff-a469ff08c10878a037a775a3ad6ba682a9b6109e1e837d3ac637bd6724cb379dR61-R67) [[2]](diffhunk://#diff-a469ff08c10878a037a775a3ad6ba682a9b6109e1e837d3ac637bd6724cb379dL85-R92) [[3]](diffhunk://#diff-a469ff08c10878a037a775a3ad6ba682a9b6109e1e837d3ac637bd6724cb379dR121-R124) [[4]](diffhunk://#diff-a469ff08c10878a037a775a3ad6ba682a9b6109e1e837d3ac637bd6724cb379dL141-R152) [[5]](diffhunk://#diff-a469ff08c10878a037a775a3ad6ba682a9b6109e1e837d3ac637bd6724cb379dR198-R208)

**Documentation and configuration updates:**

* Updated `README.md` and `crates/superbank/README.md` to document the new memory soft-limit option and its effect on ingest behavior. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R172-R173) [[2]](diffhunk://#diff-4acd90365e006c34f4bc14a74f47dacf2703083087c754bee9fe0548bd9e1e05R141) [[3]](diffhunk://#diff-4acd90365e006c34f4bc14a74f47dacf2703083087c754bee9fe0548bd9e1e05R204-R207)
* Updated config parsing and merging logic to support the new option, and ensured it is included in default/test argument sets. [[1]](diffhunk://#diff-18763d9e024658654f7fbb6d9be59e1267331fc8137daec283fe496fbb0b5503R679-R684) [[2]](diffhunk://#diff-18763d9e024658654f7fbb6d9be59e1267331fc8137daec283fe496fbb0b5503R1684) [[3]](diffhunk://#diff-c37523bbbe3f900eab5e27718dd99b94e2625bb092ade315a5036c499770bab3R469)

**Testing:**

* Added and updated tests to verify CLI/config parsing, default values, and that zero disables the guard. [[1]](diffhunk://#diff-18763d9e024658654f7fbb6d9be59e1267331fc8137daec283fe496fbb0b5503R1378-R1379) [[2]](diffhunk://#diff-18763d9e024658654f7fbb6d9be59e1267331fc8137daec283fe496fbb0b5503R1399) [[3]](diffhunk://#diff-18763d9e024658654f7fbb6d9be59e1267331fc8137daec283fe496fbb0b5503R1415) [[4]](diffhunk://#diff-18763d9e024658654f7fbb6d9be59e1267331fc8137daec283fe496fbb0b5503R1436-R1465)

**Dependency update:**

* Added `prost` as a dependency in `crates/superbank/Cargo.toml` (required for protobuf message handling).