### PR TITLE
feat: include transaction versions in getTransactionsForAddress response

### DIFF
--- a/crates/superbank-rpc/README.md
+++ b/crates/superbank-rpc/README.md
@@ -54,6 +54,7 @@ Notes:
   - Missing `before` or `until` signatures return JSON-RPC error `-32020` (`Transaction <signature> not found`).
 - `getTransactionsForAddress` supports `transactionDetails=signatures|full`, `sortOrder=asc|desc`,
   `paginationToken`, and filters (`slot`, `blockTime`, `signature`, `status`, `tokenAccounts`).
+  With `transactionDetails=full`, each item carries the transaction's `version`when `maxSupportedTransactionVersion` is set.
   It also accepts `beforeSlot`/`untilSlot` as aliases for `filters.slot.lt`/`filters.slot.gt`;
   these aliases cannot be combined with same-side slot filters (`lt`/`lte` for `beforeSlot`,
   `gt`/`gte` for `untilSlot`).

--- a/crates/superbank-rpc/src/handlers/transactions.rs
+++ b/crates/superbank-rpc/src/handlers/transactions.rs
@@ -1198,6 +1198,7 @@ pub(crate) async fn handle_get_transactions_for_address(
                             block_time: input.block_time,
                             transaction: encoded.transaction.transaction,
                             meta: encoded.transaction.meta,
+                            version: encoded.transaction.version,
                         });
 
                         pagination_token = Some(format!("{}:{}", input.slot, input.slot_idx));
@@ -1764,6 +1765,7 @@ pub(crate) async fn handle_get_transactions_for_address(
                 block_time: input.block_time,
                 transaction: encoded.transaction.transaction,
                 meta: encoded.transaction.meta,
+                version: encoded.transaction.version,
             });
 
             #[cfg(feature = "grpc-head-cache")]

--- a/crates/superbank-rpc/src/handlers/types.rs
+++ b/crates/superbank-rpc/src/handlers/types.rs
@@ -6,6 +6,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use solana_commitment_config::CommitmentConfig;
+use solana_sdk::transaction::TransactionVersion;
 use solana_transaction_status::{EncodedTransaction, UiTransactionStatusMeta};
 
 #[derive(Debug, Deserialize, Default)]
@@ -192,6 +193,8 @@ pub(crate) struct TransactionsForAddressFullInfo {
     pub(crate) block_time: Option<i64>,
     pub(crate) transaction: EncodedTransaction,
     pub(crate) meta: Option<UiTransactionStatusMeta>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) version: Option<TransactionVersion>,
 }
 
 #[derive(Debug, Serialize)]


### PR DESCRIPTION
This PR updates the `getTransactionsForAddress` RPC method to include `version: TransactionVersion` when a transaction version is present (ie when `maxSupportedTransactionVersion` was set).

The response is now shaped:

```ts
  "result": {
    "data": [
      {
        "transaction": {
          // snip
        },
        "version": "legacy", // new
        "slot": 400477452,
        "transactionIndex": 1107,
        "blockTime": 1771178084
      },
     // ...
```

This aligns with `getTransaction` (both in Superbank and Agave/the previous spec), and also with Helius' implementation.