### PR TITLE
fix: flush remaining rows when rpc backfill completes

### DIFF
--- a/crates/superbank/src/ingest/rpc.rs
+++ b/crates/superbank/src/ingest/rpc.rs
@@ -604,6 +604,22 @@ async fn run_rpc_inserter(args: RpcInserterArgs<'_>) -> Result<RpcInserterOutcom
         }
     }
 
+    if let Some(batch) = take_flush_batch(
+        cli_args,
+        &mut transaction_rows,
+        &mut block_rows,
+        last_progress.take(),
+    ) {
+        enqueue_flush(
+            &mut insert_tasks,
+            insert_concurrency,
+            clickhouse.clone(),
+            insert_tables.clone(),
+            batch,
+        )
+        .await?;
+    }
+
     if shutdown_requested {
         let shutdown_count = *shutdown_rx.borrow();
         tokio::select! {


### PR DESCRIPTION
 Closes #19

Flushes leftover buffered rows when a bounded RPC backfill ends cleanly. Without this, a small/fast backfill that finishes before crossing any flush trigger (`rpc-flush-every-slots`, row thresholds, or the timer) exits 0 with 0 rows written. Mirrors what the Bigtable inserter already does.

  ## Changes

  - Added a final `take_flush_batch` + `enqueue_flush` of remaining `transaction_rows` / `block_rows` after the inserter loop in `run_rpc_inserter`, before `drain_insert_tasks`
  - No new config or flags, reuses existing flush path

  Verified on devnet (default 5-slot range): before = 0 rows everywhere, after = 5 blocks / 159 tx / 163 signatures / 804 gsfa / 86 token_owner_activity.

  cc @notwedtm