### PR TITLE
fix: allow HTTP status codes to be emitted

### DIFF
--- a/crates/superbank-rpc/README.md
+++ b/crates/superbank-rpc/README.md
@@ -88,6 +88,20 @@ CLICKHOUSE_URL=http://localhost:8123 CLICKHOUSE_DATABASE=default \
 cargo run -p superbank-rpc --
 ```
 
+## HTTP status behavior
+
+By default, JSON-RPC responses use HTTP `200 OK`, including JSON-RPC error bodies. To make
+infrastructure/server-side failures visible to HTTP-aware load balancers and clients, enable:
+
+| Option | Environment | Default | Notes |
+| --- | --- | --- | --- |
+| `--emit-http-errors` | `SUPERBANK_RPC_EMIT_HTTP_ERRORS` | `false` | Returns HTTP `503 Service Unavailable` when the JSON-RPC response contains a server-side failure; JSON-RPC response bodies are unchanged. |
+
+Only internal error (`-32603`), server-generated request timeout (`-32000`), node unhealthy
+(`-32005`), and long-term storage unreachable (`-32019`) are promoted to HTTP `503`.
+Client, malformed-request, and data-condition errors remain HTTP `200 OK`. For batches, any
+eligible item promotes the whole HTTP response to `503`.
+
 ## Optional gRPC head cache (`grpc-head-cache`)
 
 When compiled with `--features grpc-head-cache` and enabled at runtime, superbank-rpc subscribes to

--- a/crates/superbank-rpc/src/config.rs
+++ b/crates/superbank-rpc/src/config.rs
@@ -74,6 +74,10 @@ pub struct RpcConfig {
     #[arg(long, env = "RPC_BATCH_CONCURRENCY_LIMIT", default_value_t = 8)]
     pub(crate) rpc_batch_concurrency_limit: usize,
 
+    /// Emit HTTP 503 for JSON-RPC server-side failures while keeping response bodies unchanged.
+    #[arg(long, env = "SUPERBANK_RPC_EMIT_HTTP_ERRORS", default_value_t = false)]
+    pub(crate) emit_http_errors: bool,
+
     #[arg(long, env = "RPC_HOST", default_value = "0.0.0.0")]
     pub(crate) host: String,
 
@@ -609,12 +613,14 @@ mod config_tests {
 
     #[test]
     fn clickhouse_query_cache_defaults() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
         let cfg = RpcConfig::parse_from(["superbank-rpc"]);
 
         assert!(!cfg.clickhouse_query_cache_enabled);
         assert_eq!(cfg.clickhouse_query_cache_ttl_seconds, 1);
         assert!(!cfg.clickhouse_query_cache_share_between_users);
         assert!(!cfg.clickhouse_query_condition_cache_enabled);
+        assert!(!cfg.emit_http_errors);
         assert!(!cfg.metrics_capture_x_endpoint());
         assert!(!cfg.metrics_capture_x_rpc_node());
         assert!(!cfg.metrics_capture_x_subscription_id());
@@ -636,6 +642,23 @@ mod config_tests {
         assert_eq!(cfg.clickhouse_query_cache_ttl_seconds, 5);
         assert!(cfg.clickhouse_query_cache_share_between_users);
         assert!(cfg.clickhouse_query_condition_cache_enabled);
+    }
+
+    #[test]
+    fn emit_http_errors_flag_parses() {
+        let cfg = RpcConfig::parse_from(["superbank-rpc", "--emit-http-errors"]);
+
+        assert!(cfg.emit_http_errors);
+    }
+
+    #[test]
+    fn emit_http_errors_env_parses() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let _env = EnvVarGuard::set("SUPERBANK_RPC_EMIT_HTTP_ERRORS", "true");
+
+        let cfg = RpcConfig::parse_from(["superbank-rpc"]);
+
+        assert!(cfg.emit_http_errors);
     }
 
     #[test]

--- a/crates/superbank-rpc/src/handlers/mod.rs
+++ b/crates/superbank-rpc/src/handlers/mod.rs
@@ -10,12 +10,15 @@ pub(crate) mod types;
 
 use axum::{
     Json,
-    body::{Bytes, to_bytes},
+    body::{Body, Bytes, to_bytes},
     extract::State,
     http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
 };
 use serde_json::Value;
+use solana_rpc_client_api::custom_error::{
+    JSON_RPC_SERVER_ERROR_LONG_TERM_STORAGE_UNREACHABLE, JSON_RPC_SERVER_ERROR_NODE_UNHEALTHY,
+};
 use std::future::Future;
 use std::io::{self, Write};
 use std::sync::{
@@ -50,6 +53,9 @@ pub(crate) const ROUTE_OUTCOME_RPC_ERROR: &str = "rpc_error";
 pub(crate) const ROUTE_OUTCOME_BACKEND_ERROR: &str = "backend_error";
 pub(crate) const ROUTE_OUTCOME_TIMEOUT: &str = "timeout";
 const ROUTE_HEADER_LABEL_MISSING: &str = "missing";
+const JSON_RPC_INTERNAL_ERROR_CODE: i64 = -32603;
+const JSON_RPC_REQUEST_TIMEOUT_CODE: i64 = -32000;
+const JSON_RPC_REQUEST_TIMEOUT_MESSAGE: &str = "Request timeout";
 const HEADER_X_ENDPOINT: &str = "X-Endpoint";
 const HEADER_X_RPC_NODE: &str = "X-RPC-Node";
 const HEADER_X_SUBSCRIPTION_ID: &str = "X-Subscription-ID";
@@ -631,6 +637,67 @@ fn json_rpc_error_value(
     Value::Object(response)
 }
 
+fn is_http_503_eligible_json_rpc_error(code: i64, message: Option<&str>) -> bool {
+    if code == JSON_RPC_INTERNAL_ERROR_CODE {
+        return true;
+    }
+    if code == JSON_RPC_REQUEST_TIMEOUT_CODE {
+        return message == Some(JSON_RPC_REQUEST_TIMEOUT_MESSAGE);
+    }
+    if code == JSON_RPC_SERVER_ERROR_NODE_UNHEALTHY {
+        return true;
+    }
+    if code == JSON_RPC_SERVER_ERROR_LONG_TERM_STORAGE_UNREACHABLE {
+        return true;
+    }
+    false
+}
+
+fn json_rpc_response_value_has_http_503_error(value: &Value) -> bool {
+    match value {
+        Value::Array(items) => items.iter().any(json_rpc_response_item_has_http_503_error),
+        _ => json_rpc_response_item_has_http_503_error(value),
+    }
+}
+
+fn json_rpc_response_item_has_http_503_error(value: &Value) -> bool {
+    let Some(error) = value.get("error").and_then(Value::as_object) else {
+        return false;
+    };
+    let Some(code) = error.get("code").and_then(Value::as_i64) else {
+        return false;
+    };
+    let message = error.get("message").and_then(Value::as_str);
+    is_http_503_eligible_json_rpc_error(code, message)
+}
+
+async fn promote_http_status_for_json_rpc_errors(response: Response, enabled: bool) -> Response {
+    if !enabled {
+        return response;
+    }
+
+    let (mut parts, body) = response.into_parts();
+    let bytes = match to_bytes(body, usize::MAX).await {
+        Ok(bytes) => bytes,
+        Err(err) => {
+            error!("Failed to read JSON-RPC response body for HTTP status promotion: {err}");
+            return Response::from_parts(parts, Body::empty());
+        }
+    };
+
+    match serde_json::from_slice::<Value>(&bytes) {
+        Ok(value) if json_rpc_response_value_has_http_503_error(&value) => {
+            parts.status = StatusCode::SERVICE_UNAVAILABLE;
+        }
+        Ok(_) => {}
+        Err(err) => {
+            error!("Failed to deserialize JSON-RPC response body for HTTP status promotion: {err}");
+        }
+    }
+
+    Response::from_parts(parts, Body::from(bytes))
+}
+
 fn validate_json_rpc_response_value(value: &Value) -> Result<(), &'static str> {
     let response = value
         .as_object()
@@ -833,8 +900,8 @@ async fn dispatch_json_rpc_request(
                 metrics::rpc_timeout(method_label);
                 Ok(json_rpc_error_response(
                     id,
-                    -32000,
-                    "Request timeout",
+                    JSON_RPC_REQUEST_TIMEOUT_CODE as i32,
+                    JSON_RPC_REQUEST_TIMEOUT_MESSAGE,
                     Some(serde_json::json!({
                         "timeoutMs": timeout.as_millis().min(u128::from(u64::MAX)) as u64,
                     })),
@@ -1130,8 +1197,8 @@ async fn handle_batch_request(
                 metrics::batch_rejected("timeout");
                 Ok(json_rpc_error_response(
                     Value::Null,
-                    -32000,
-                    "Request timeout",
+                    JSON_RPC_REQUEST_TIMEOUT_CODE as i32,
+                    JSON_RPC_REQUEST_TIMEOUT_MESSAGE,
                     Some(serde_json::json!({
                         "timeoutMs": timeout.as_millis().min(u128::from(u64::MAX)) as u64,
                     })),
@@ -1147,6 +1214,7 @@ pub(crate) async fn handle_json_rpc_with_headers(
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<Response, StatusCode> {
+    let emit_http_errors = state.emit_http_errors;
     let response_header_metrics_context = Arc::new(ResponseHeaderMetricsContext::default());
     let mut response =
         with_response_header_metrics_context(response_header_metrics_context.clone(), async move {
@@ -1181,6 +1249,7 @@ pub(crate) async fn handle_json_rpc_with_headers(
         })
         .await?;
 
+    response = promote_http_status_for_json_rpc_errors(response, emit_http_errors).await;
     add_response_metrics_headers(&mut response, response_header_metrics_context.snapshot());
     Ok(response)
 }
@@ -1188,7 +1257,10 @@ pub(crate) async fn handle_json_rpc_with_headers(
 #[cfg(test)]
 mod tests {
     use super::{
-        request_header_metric_labels, response_to_json_value, validate_json_rpc_response_value,
+        JSON_RPC_INTERNAL_ERROR_CODE, JSON_RPC_REQUEST_TIMEOUT_CODE,
+        JSON_RPC_REQUEST_TIMEOUT_MESSAGE, is_http_503_eligible_json_rpc_error,
+        json_rpc_response_value_has_http_503_error, request_header_metric_labels,
+        response_to_json_value, validate_json_rpc_response_value,
     };
     use axum::{
         Json,
@@ -1196,8 +1268,97 @@ mod tests {
         response::IntoResponse,
     };
     use serde_json::json;
+    use solana_rpc_client_api::custom_error::{
+        JSON_RPC_SERVER_ERROR_BLOCK_NOT_AVAILABLE,
+        JSON_RPC_SERVER_ERROR_FILTER_TRANSACTION_NOT_FOUND,
+        JSON_RPC_SERVER_ERROR_LONG_TERM_STORAGE_SLOT_SKIPPED,
+        JSON_RPC_SERVER_ERROR_LONG_TERM_STORAGE_UNREACHABLE,
+        JSON_RPC_SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED, JSON_RPC_SERVER_ERROR_NODE_UNHEALTHY,
+        JSON_RPC_SERVER_ERROR_UNSUPPORTED_TRANSACTION_VERSION,
+    };
 
     use crate::state::MetricsHeaderCaptureConfig;
+
+    #[test]
+    fn http_503_classifier_includes_server_side_codes() {
+        assert!(is_http_503_eligible_json_rpc_error(
+            JSON_RPC_INTERNAL_ERROR_CODE,
+            Some("Internal error"),
+        ));
+        assert!(is_http_503_eligible_json_rpc_error(
+            JSON_RPC_REQUEST_TIMEOUT_CODE,
+            Some(JSON_RPC_REQUEST_TIMEOUT_MESSAGE),
+        ));
+        assert!(is_http_503_eligible_json_rpc_error(
+            JSON_RPC_SERVER_ERROR_NODE_UNHEALTHY,
+            Some("Node is unhealthy"),
+        ));
+        assert!(is_http_503_eligible_json_rpc_error(
+            JSON_RPC_SERVER_ERROR_LONG_TERM_STORAGE_UNREACHABLE,
+            Some("Failed to query long-term storage; please try again"),
+        ));
+    }
+
+    #[test]
+    fn http_503_classifier_excludes_client_and_data_condition_codes() {
+        for code in [
+            -32700,
+            -32600,
+            -32601,
+            -32602,
+            JSON_RPC_SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED,
+            JSON_RPC_SERVER_ERROR_UNSUPPORTED_TRANSACTION_VERSION,
+            JSON_RPC_SERVER_ERROR_BLOCK_NOT_AVAILABLE,
+            JSON_RPC_SERVER_ERROR_LONG_TERM_STORAGE_SLOT_SKIPPED,
+            JSON_RPC_SERVER_ERROR_FILTER_TRANSACTION_NOT_FOUND,
+        ] {
+            assert!(
+                !is_http_503_eligible_json_rpc_error(code, Some("not server infrastructure")),
+                "code {code} should not be HTTP-503 eligible"
+            );
+        }
+
+        assert!(!is_http_503_eligible_json_rpc_error(
+            JSON_RPC_REQUEST_TIMEOUT_CODE,
+            Some("Upstream returned -32000"),
+        ));
+    }
+
+    #[test]
+    fn http_503_classifier_checks_batch_items() {
+        let value = json!([
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "error": { "code": -32602, "message": "Invalid params" }
+            },
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "error": { "code": -32603, "message": "Internal error" }
+            }
+        ]);
+
+        assert!(json_rpc_response_value_has_http_503_error(&value));
+    }
+
+    #[test]
+    fn http_503_classifier_ignores_batch_without_server_side_errors() {
+        let value = json!([
+            {
+                "jsonrpc": "2.0",
+                "id": null,
+                "error": { "code": -32600, "message": "Invalid Request" }
+            },
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "error": { "code": -32601, "message": "Method not found" }
+            }
+        ]);
+
+        assert!(!json_rpc_response_value_has_http_503_error(&value));
+    }
 
     #[test]
     fn request_metric_labels_disabled_when_capture_off() {

--- a/crates/superbank-rpc/src/server.rs
+++ b/crates/superbank-rpc/src/server.rs
@@ -280,6 +280,7 @@ pub async fn run_server(args: RpcConfig) -> RpcResult<()> {
         latest_slot_cache: LatestSlotCache::new(Duration::from_millis(1000)),
         latest_block_height_cache: LatestBlockHeightCache::new(Duration::from_millis(1000)),
         rpc_request_timeout: Duration::from_millis(args.rpc_request_timeout_ms),
+        emit_http_errors: args.emit_http_errors,
         metrics_header_capture: MetricsHeaderCaptureConfig {
             capture_x_endpoint: args.metrics_capture_x_endpoint(),
             capture_x_rpc_node: args.metrics_capture_x_rpc_node(),

--- a/crates/superbank-rpc/src/state.rs
+++ b/crates/superbank-rpc/src/state.rs
@@ -37,6 +37,7 @@ pub(crate) struct AppState {
     pub(crate) latest_slot_cache: LatestSlotCache,
     pub(crate) latest_block_height_cache: LatestBlockHeightCache,
     pub(crate) rpc_request_timeout: Duration,
+    pub(crate) emit_http_errors: bool,
     pub(crate) metrics_header_capture: MetricsHeaderCaptureConfig,
     pub(crate) hydration_sem: Arc<Semaphore>,
     #[cfg(feature = "grpc-head-cache")]

--- a/crates/superbank-rpc/src/tests/mod.rs
+++ b/crates/superbank-rpc/src/tests/mod.rs
@@ -158,6 +158,7 @@ fn test_state_with_token_owner_activity_available(available: bool) -> Arc<AppSta
         latest_slot_cache: cache,
         latest_block_height_cache: height_cache,
         rpc_request_timeout: Duration::from_millis(10_000),
+        emit_http_errors: false,
         metrics_header_capture: Default::default(),
         hydration_sem: Arc::new(Semaphore::new(8)),
         #[cfg(feature = "grpc-head-cache")]
@@ -177,6 +178,15 @@ fn test_state_with_metrics_header_capture(capture: MetricsHeaderCaptureConfig) -
         Err(_) => panic!("test_state should have a single Arc owner"),
     };
     state.metrics_header_capture = capture;
+    Arc::new(state)
+}
+
+fn test_state_with_emit_http_errors(state: Arc<AppState>) -> Arc<AppState> {
+    let mut state = match Arc::try_unwrap(state) {
+        Ok(state) => state,
+        Err(_) => panic!("test_state should have a single Arc owner"),
+    };
+    state.emit_http_errors = true;
     Arc::new(state)
 }
 
@@ -227,6 +237,7 @@ fn test_state_with_clickhouse_url(clickhouse_url: &str) -> Arc<AppState> {
         latest_slot_cache: cache,
         latest_block_height_cache: height_cache,
         rpc_request_timeout: Duration::from_millis(10_000),
+        emit_http_errors: false,
         metrics_header_capture: Default::default(),
         hydration_sem: Arc::new(Semaphore::new(8)),
         #[cfg(feature = "grpc-head-cache")]
@@ -281,6 +292,7 @@ async fn test_state_with_clickhouse_cached_signature_slot(
         latest_slot_cache: cache,
         latest_block_height_cache: height_cache,
         rpc_request_timeout: Duration::from_millis(10_000),
+        emit_http_errors: false,
         metrics_header_capture: Default::default(),
         hydration_sem: Arc::new(Semaphore::new(8)),
         #[cfg(feature = "grpc-head-cache")]
@@ -327,6 +339,7 @@ fn test_state_with_head_cache(head_cache: Arc<HeadCache>) -> Arc<AppState> {
         latest_slot_cache,
         latest_block_height_cache,
         rpc_request_timeout: Duration::from_millis(10_000),
+        emit_http_errors: false,
         metrics_header_capture: Default::default(),
         hydration_sem: Arc::new(Semaphore::new(8)),
         head_cache: Some(head_cache),
@@ -375,6 +388,7 @@ fn test_state_with_head_cache_and_clickhouse_url(
         latest_slot_cache,
         latest_block_height_cache,
         rpc_request_timeout: Duration::from_millis(10_000),
+        emit_http_errors: false,
         metrics_header_capture: Default::default(),
         hydration_sem: Arc::new(Semaphore::new(8)),
         head_cache: Some(head_cache),
@@ -430,6 +444,7 @@ async fn test_state_with_head_cache_and_cached_signature_slot(
         latest_slot_cache,
         latest_block_height_cache,
         rpc_request_timeout: Duration::from_millis(10_000),
+        emit_http_errors: false,
         metrics_header_capture: Default::default(),
         hydration_sem: Arc::new(Semaphore::new(8)),
         head_cache: Some(head_cache),
@@ -3405,6 +3420,177 @@ async fn handle_json_rpc_invalid_json_returns_parse_error() {
     assert_eq!(err.code, -32700);
     assert_eq!(err.message, "Parse error");
     assert_eq!(parsed.id, Value::Null);
+}
+
+#[tokio::test]
+async fn emit_http_errors_promotes_clickhouse_unreachable_server_error_without_body_change() {
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "getHealth",
+        "params": []
+    });
+
+    let disabled_response = handle_json_rpc_value(
+        test_state_with_clickhouse_url("http://127.0.0.1:1"),
+        &request,
+    )
+    .await;
+    assert_eq!(disabled_response.status(), StatusCode::OK);
+    let disabled_body = parse_json_value_response(disabled_response).await;
+
+    let enabled_response = handle_json_rpc_value(
+        test_state_with_emit_http_errors(test_state_with_clickhouse_url("http://127.0.0.1:1")),
+        &request,
+    )
+    .await;
+    assert_eq!(enabled_response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let enabled_body = parse_json_value_response(enabled_response).await;
+
+    assert_eq!(enabled_body, disabled_body);
+    assert_eq!(
+        enabled_body
+            .get("error")
+            .and_then(|error| error.get("code"))
+            .and_then(Value::as_i64),
+        Some(-32005)
+    );
+}
+
+#[tokio::test]
+async fn emit_http_errors_keeps_malformed_and_client_errors_http_200() {
+    let state = test_state_with_emit_http_errors(test_state());
+
+    let response = handle_json_rpc_body_with_headers(
+        state.clone(),
+        HeaderMap::new(),
+        Bytes::from_static(br#"{"jsonrpc":"2.0""#),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let parsed = parse_json_rpc_response(response).await;
+    assert_eq!(parsed.error.expect("parse error").code, -32700);
+
+    let invalid_params = json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "getSignaturesForAddress",
+        "params": []
+    });
+    let response = handle_json_rpc_value(state.clone(), &invalid_params).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let parsed = parse_json_rpc_response(response).await;
+    assert_eq!(parsed.error.expect("invalid params").code, -32602);
+
+    let method_not_found = json!({
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "unknownMethod",
+        "params": []
+    });
+    let response = handle_json_rpc_value(state, &method_not_found).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let parsed = parse_json_rpc_response(response).await;
+    assert_eq!(parsed.error.expect("method not found").code, -32601);
+}
+
+#[tokio::test]
+async fn emit_http_errors_keeps_success_http_200() {
+    let state = test_state_with_emit_http_errors(test_state());
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "getSlot",
+        "params": []
+    });
+
+    let response = handle_json_rpc_value(state, &request).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let parsed = parse_json_rpc_response(response).await;
+    assert_eq!(parsed.result, Some(json!(1)));
+    assert!(parsed.error.is_none());
+}
+
+#[tokio::test]
+async fn emit_http_errors_promotes_mixed_batch_with_server_error() {
+    let state =
+        test_state_with_emit_http_errors(test_state_with_clickhouse_url("http://127.0.0.1:1"));
+    let request = json!([
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "getHealth",
+            "params": []
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "unknownMethod",
+            "params": []
+        }
+    ]);
+
+    let response = handle_json_rpc_value(state, &request).await;
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+    let parsed = parse_json_value_response(response).await;
+    let items = parsed.as_array().expect("batch response array");
+    assert_eq!(items.len(), 2);
+    assert_eq!(
+        items[0]
+            .get("error")
+            .and_then(|error| error.get("code"))
+            .and_then(Value::as_i64),
+        Some(-32005)
+    );
+    assert_eq!(
+        items[1]
+            .get("error")
+            .and_then(|error| error.get("code"))
+            .and_then(Value::as_i64),
+        Some(-32601)
+    );
+}
+
+#[tokio::test]
+async fn emit_http_errors_keeps_client_error_only_batch_http_200() {
+    let state = test_state_with_emit_http_errors(test_state());
+    let request = json!([
+        {
+            "jsonrpc": "2.0",
+            "id": 1
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "unknownMethod",
+            "params": []
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "getSignaturesForAddress",
+            "params": []
+        }
+    ]);
+
+    let response = handle_json_rpc_value(state, &request).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let parsed = parse_json_value_response(response).await;
+    let items = parsed.as_array().expect("batch response array");
+    assert_eq!(items.len(), 3);
+    let codes: Vec<i64> = items
+        .iter()
+        .map(|item| {
+            item.get("error")
+                .and_then(|error| error.get("code"))
+                .and_then(Value::as_i64)
+                .expect("error code")
+        })
+        .collect();
+    assert_eq!(codes, vec![-32600, -32601, -32602]);
 }
 
 #[tokio::test]


### PR DESCRIPTION
This pull request introduces a new feature to the `superbank-rpc` service that allows server-side JSON-RPC errors to be surfaced as HTTP 503 responses, making infrastructure failures more visible to HTTP-aware clients and load balancers. The change is controlled by a new configuration flag and includes comprehensive tests and documentation updates.

The most important changes are:

**Feature: HTTP 503 for server-side JSON-RPC errors**
* Added a new configuration flag (`--emit-http-errors` / `SUPERBANK_RPC_EMIT_HTTP_ERRORS`) to enable returning HTTP 503 status for specific server-side JSON-RPC error codes, while keeping the JSON-RPC response body unchanged. Only internal errors, server timeouts, node unhealthy, and long-term storage unreachable errors are promoted to HTTP 503. [[1]](diffhunk://#diff-38fc1c83818ca964bb749891f093c0b0e4f77c7aafa2567ecbbe8ac19b945703R77-R80) [[2]](diffhunk://#diff-d520a39c230a8012b22bb2c0279fd36de1c852c94bc29b5bd5f6281a451ad56eR91-R104) [[3]](diffhunk://#diff-761da600b84fd2b4661dee32ac513d15c928d388a05fb2502e0eacc437c55227R40) [[4]](diffhunk://#diff-0140e2d4093473e85443b3a4418e8c510c7a4ea80eac62f688687c86c3007df0R283)

**Implementation: Response handling and classification**
* Implemented logic in `handlers/mod.rs` to inspect JSON-RPC responses and promote the HTTP status to 503 if eligible errors are detected, including for batch responses. [[1]](diffhunk://#diff-843e39cd69388ca5881732ce458df8cc8e433608419631278b88d85350b50068R640-R700) [[2]](diffhunk://#diff-843e39cd69388ca5881732ce458df8cc8e433608419631278b88d85350b50068R1217) [[3]](diffhunk://#diff-843e39cd69388ca5881732ce458df8cc8e433608419631278b88d85350b50068R1252-R1362)
* Updated timeout error handling to use new constants for consistency and easier maintenance. [[1]](diffhunk://#diff-843e39cd69388ca5881732ce458df8cc8e433608419631278b88d85350b50068L836-R904) [[2]](diffhunk://#diff-843e39cd69388ca5881732ce458df8cc8e433608419631278b88d85350b50068L1133-R1201) [[3]](diffhunk://#diff-843e39cd69388ca5881732ce458df8cc8e433608419631278b88d85350b50068R56-R58)

**Testing: Configuration and error promotion**
* Added and improved tests to verify correct parsing of the new flag from both CLI and environment, and to ensure correct classification of errors for HTTP 503 promotion, including batch and edge cases. [[1]](diffhunk://#diff-38fc1c83818ca964bb749891f093c0b0e4f77c7aafa2567ecbbe8ac19b945703R616-R623) [[2]](diffhunk://#diff-38fc1c83818ca964bb749891f093c0b0e4f77c7aafa2567ecbbe8ac19b945703R647-R663) [[3]](diffhunk://#diff-843e39cd69388ca5881732ce458df8cc8e433608419631278b88d85350b50068R1252-R1362)

**Documentation**
* Updated the `README.md` to document the new flag, its behavior, and which error codes are affected.

**Test Utilities**
* Updated test state helpers to support the new `emit_http_errors` field, ensuring test coverage for configurations with and without the flag enabled. [[1]](diffhunk://#diff-06ff0b330b8e38bb605d92cebe067005586b454768b3aa5024986cfad730ffaeR161) [[2]](diffhunk://#diff-06ff0b330b8e38bb605d92cebe067005586b454768b3aa5024986cfad730ffaeR184-R192) [[3]](diffhunk://#diff-06ff0b330b8e38bb605d92cebe067005586b454768b3aa5024986cfad730ffaeR240) [[4]](diffhunk://#diff-06ff0b330b8e38bb605d92cebe067005586b454768b3aa5024986cfad730ffaeR295) [[5]](diffhunk://#diff-06ff0b330b8e38bb605d92cebe067005586b454768b3aa5024986cfad730ffaeR342) [[6]](diffhunk://#diff-06ff0b330b8e38bb605d92cebe067005586b454768b3aa5024986cfad730ffaeR391) [[7]](diffhunk://#diff-06ff0b330b8e38bb605d92cebe067005586b454768b3aa5024986cfad730ffaeR447)

These changes improve the observability and reliability of the service by making infrastructure failures more transparent to upstream systems.