### PR TITLE
fix: update rustsec advisory dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2763,9 +2763,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -3415,7 +3415,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap 0.10.1",
@@ -3642,9 +3642,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## Summary

Updates Cargo.lock to resolve the RustSec dependency audit failure seen on PR #18.

- updates quinn-proto from 0.11.14 to 0.11.15 for RUSTSEC-2026-0185
- updates memmap2 from 0.9.10 to 0.9.11 for RUSTSEC-2026-0186
- keeps this as a lockfile-only dependency patch update

## Root Cause

The Dependency Audit workflow started failing after new RustSec advisories were published for versions already present on main. The failure is unrelated to PR #18's JSON-RPC response field ownership changes.

## Validation

- cargo audit --ignore RUSTSEC-2024-0375 --ignore RUSTSEC-2025-0012 --ignore RUSTSEC-2025-0141 --ignore RUSTSEC-2024-0388 --ignore RUSTSEC-2024-0384 --ignore RUSTSEC-2024-0436 --ignore RUSTSEC-2025-0134 --ignore RUSTSEC-2021-0145 --ignore RUSTSEC-2026-0098 --ignore RUSTSEC-2026-0099 --ignore RUSTSEC-2026-0104 --ignore RUSTSEC-2026-0097 --file ./Cargo.lock
- cargo check -p superbank-rpc --features pyroscope --locked
