### PR TITLE
chore: relase tech debt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,31 @@ jobs:
       - name: Export Rust version
         run: echo "RUST_VERSION=$(rustc --version)" >> "${GITHUB_ENV}"
 
+      - name: Verify tag matches Cargo package versions
+        run: |
+          set -euo pipefail
+          tag_version="${GITHUB_REF_NAME#v}"
+          cargo metadata --format-version=1 --locked --no-deps > cargo-metadata.json
+          python3 - "$tag_version" <<'PY'
+          import json
+          import sys
+
+          expected = sys.argv[1]
+          packages = {"superbank-workspace", "superbank", "superbank-rpc"}
+          with open("cargo-metadata.json", encoding="utf-8") as f:
+              metadata = json.load(f)
+
+          mismatches = [
+              (package["name"], package["version"])
+              for package in metadata["packages"]
+              if package["name"] in packages and package["version"] != expected
+          ]
+          if mismatches:
+              for name, version in mismatches:
+                  print(f"{name} version {version} does not match release tag v{expected}", file=sys.stderr)
+              sys.exit(1)
+          PY
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6302,7 +6302,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "superbank"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -6351,7 +6351,7 @@ dependencies = [
 
 [[package]]
 name = "superbank-rpc"
-version = "0.3.0"
+version = "0.5.0"
 dependencies = [
  "async-stream",
  "axum 0.8.8",
@@ -6409,7 +6409,7 @@ dependencies = [
 
 [[package]]
 name = "superbank-workspace"
-version = "0.3.0"
+version = "0.5.0"
 
 [[package]]
 name = "symbolic-common"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ version = "0.5.0"
 edition = "2024"
 license = "AGPL-3.0-only"
 authors = [
+    ""Triton One Limited",
     "Miles 'wedtm' Smith <52319902+notwedtm@users.noreply.github.com>",
     "Daniel Camargo <67828229+dancamarg0@users.noreply.github.com>",
     "Augustin Cheron <1165445+augustin-cheron@users.noreply.github.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.5.0"
 edition = "2024"
 license = "AGPL-3.0-only"
 authors = [
-    ""Triton One Limited",
+    "Triton One Limited",
     "Miles 'wedtm' Smith <52319902+notwedtm@users.noreply.github.com>",
     "Daniel Camargo <67828229+dancamarg0@users.noreply.github.com>",
     "Augustin Cheron <1165445+augustin-cheron@users.noreply.github.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,24 @@
 [package]
 name = "superbank-workspace"
-version = "0.3.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+publish = false
+
+[workspace.package]
+version = "0.5.0"
 edition = "2024"
 license = "AGPL-3.0-only"
-authors = ["Triton One Limited", "Miles Smith <52319902+notwedtm@users.noreply.github.com>", "Daniel Camargo <67828229+dancamarg0@users.noreply.github.com>", "Augustin Cheron <1165445+augustin-cheron@users.noreply.github.com>"]
-publish = false
+authors = [
+    "Miles 'wedtm' Smith <52319902+notwedtm@users.noreply.github.com>",
+    "Daniel Camargo <67828229+dancamarg0@users.noreply.github.com>",
+    "Augustin Cheron <1165445+augustin-cheron@users.noreply.github.com>",
+    "Henry Adenuga <39364502+Mctursh@users.noreply.github.com>",
+    "Rishav <68805388+rishavmehra@users.noreply.github.com>",
+    "TechieGhost <116256043+gamandeepsingh@users.noreply.github.com>",
+    "aspnxdd <43625217+aspnxdd@users.noreply.github.com>",
+]
 
 [workspace]
 members = [

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Edit `superbank.yaml` to choose a source and set credentials/endpoints:
 
 - Fumarole: `source: fumarole`, `fumarole-endpoint`, `fumarole-consumer-group`, optional `fumarole-x-token`
 - gRPC (DragonsMouth): `source: grpc`, `endpoint`, optional `x-token`
-- RPC: `source: rpc`, `rpc-url`, `rpc-from-slot`, and either `to-slot` or `slot-count`
+- RPC: `source: rpc`, `rpc-url`, `rpc-from-slot`, and either `rpc-to-slot` or `rpc-slot-count`
 - Bigtable: `source: bigtable` plus range/slot file and GCP credentials
 - Prometheus metrics: `metrics-host` / `metrics-port` (default `0.0.0.0:9901`, exposed at `/metrics`)
 - Optional static metrics label: `metrics-cluster-label`

--- a/crates/superbank-rpc/Cargo.toml
+++ b/crates/superbank-rpc/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "superbank-rpc"
-version = "0.3.0"
-edition = "2024"
-license = "AGPL-3.0-only"
-authors = ["Triton One Limited", "Miles Smith <52319902+notwedtm@users.noreply.github.com>", "Daniel Camargo <67828229+dancamarg0@users.noreply.github.com>", "Augustin Cheron <1165445+augustin-cheron@users.noreply.github.com>"]
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
 
 [features]
 default = []

--- a/crates/superbank-rpc/README.md
+++ b/crates/superbank-rpc/README.md
@@ -54,7 +54,7 @@ Notes:
   - Missing `before` or `until` signatures return JSON-RPC error `-32020` (`Transaction <signature> not found`).
 - `getTransactionsForAddress` supports `transactionDetails=signatures|full`, `sortOrder=asc|desc`,
   `paginationToken`, and filters (`slot`, `blockTime`, `signature`, `status`, `tokenAccounts`).
-  With `transactionDetails=full`, each item carries the transaction's `version`when `maxSupportedTransactionVersion` is set.
+  With `transactionDetails=full`, each item carries the transaction's `version` when `maxSupportedTransactionVersion` is set.
   It also accepts `beforeSlot`/`untilSlot` as aliases for `filters.slot.lt`/`filters.slot.gt`;
   these aliases cannot be combined with same-side slot filters (`lt`/`lte` for `beforeSlot`,
   `gt`/`gte` for `untilSlot`).

--- a/crates/superbank-rpc/build.rs
+++ b/crates/superbank-rpc/build.rs
@@ -3,12 +3,35 @@
  * Copyright 2025-2026 Triton One Limited. All rights reserved.
  */
 
+fn emit_git_sha() {
+    println!("cargo:rerun-if-env-changed=SUPERBANK_GIT_SHA");
+    println!("cargo:rerun-if-env-changed=GITHUB_SHA");
+
+    let sha = std::env::var("SUPERBANK_GIT_SHA")
+        .ok()
+        .or_else(|| std::env::var("GITHUB_SHA").ok())
+        .unwrap_or_default();
+
+    let sha = sha.trim();
+    if sha.is_empty() {
+        return;
+    }
+
+    println!("cargo:rustc-env=SUPERBANK_GIT_SHA={sha}");
+}
+
 #[cfg(feature = "grpc-streaming")]
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn compile_protos() -> Result<(), Box<dyn std::error::Error>> {
     let protos = ["proto/superbank.proto", "proto/confirmed_block.proto"];
     tonic_prost_build::configure().compile_protos(&protos, &["proto"])?;
     Ok(())
 }
 
-#[cfg(not(feature = "grpc-streaming"))]
-fn main() {}
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    emit_git_sha();
+
+    #[cfg(feature = "grpc-streaming")]
+    compile_protos()?;
+
+    Ok(())
+}

--- a/crates/superbank/Cargo.toml
+++ b/crates/superbank/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "superbank"
-version = "0.3.0"
-edition = "2024"
-license = "AGPL-3.0-only"
-authors = ["Triton One Limited", "Miles Smith <52319902+notwedtm@users.noreply.github.com>", "Daniel Camargo <67828229+dancamarg0@users.noreply.github.com>", "Augustin Cheron <1165445+augustin-cheron@users.noreply.github.com>"]
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
 
 [dependencies]
 anyhow = "1.0"

--- a/crates/superbank/src/cli.rs
+++ b/crates/superbank/src/cli.rs
@@ -1125,7 +1125,7 @@ fn validate_args(args: &Args) -> Result<()> {
             if let Some(count) = args.rpc_slot_count
                 && count == 0
             {
-                return Err(anyhow!("rpc slot-count must be greater than 0"));
+                return Err(anyhow!("rpc-slot-count must be greater than 0"));
             }
             if args.rpc_max_inflight == 0 {
                 return Err(anyhow!("rpc max-inflight must be greater than 0"));

--- a/crates/superbank/src/ingest/rpc.rs
+++ b/crates/superbank/src/ingest/rpc.rs
@@ -707,7 +707,7 @@ async fn resolve_rpc_range(
         (Some(to_slot), None) => {
             if to_slot < start {
                 return Err(anyhow!(
-                    "to-slot {} must be greater than or equal to rpc-from-slot {}",
+                    "rpc-to-slot {} must be greater than or equal to rpc-from-slot {}",
                     to_slot,
                     start
                 ));
@@ -717,7 +717,7 @@ async fn resolve_rpc_range(
         (None, Some(count)) => {
             let count_minus_one = count
                 .checked_sub(1)
-                .ok_or_else(|| anyhow!("rpc slot-count must be greater than 0"))?;
+                .ok_or_else(|| anyhow!("rpc-slot-count must be greater than 0"))?;
             start
                 .checked_add(count_minus_one)
                 .ok_or_else(|| anyhow!("rpc slot range exceeds u64::MAX"))?


### PR DESCRIPTION
This pull request introduces several improvements to version management and configuration consistency across the workspace. It centralizes package metadata in the workspace root, enforces release tag and package version alignment in CI, and clarifies configuration and error messages for RPC sources. It also adds a build step to embed the current git SHA into the build environment.

**Workspace and package version management:**

* Centralized `version`, `edition`, `license`, and `authors` fields in the `[workspace.package]` section of the root `Cargo.toml`; individual crate `Cargo.toml` files now use `*.workspace = true` for these fields. This ensures consistency and simplifies version updates across all workspace crates. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R21) [[2]](diffhunk://#diff-6afdafc8f0db0d459b2c5955b357a501add95bb3c34cda284e0ece82722efc68L3-R6) [[3]](diffhunk://#diff-39049890566f5678cbe52d53c4bb5b5b41c86e27dad526f327d81c0f0aa100baL3-R6)

**Release and CI improvements:**

* Added a CI step in `.github/workflows/release.yml` to verify that the release tag matches the versions of all relevant Cargo packages, preventing version mismatches during releases.

**Build process enhancements:**

* Updated `crates/superbank-rpc/build.rs` to emit the current git SHA as a build environment variable, allowing the built binary to reference its source commit.

**Configuration and error message consistency:**

* Standardized configuration keys and error messages: changed all references from `slot-count` and `to-slot` to `rpc-slot-count` and `rpc-to-slot` for clarity and consistency in documentation, CLI validation, and runtime errors. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L127-R127) [[2]](diffhunk://#diff-18763d9e024658654f7fbb6d9be59e1267331fc8137daec283fe496fbb0b5503L1128-R1128) [[3]](diffhunk://#diff-b8d3c6e0f3e5568597dc847809a4f93ee86d7b9d966c3eaa4266fd74fd01c894L710-R710) [[4]](diffhunk://#diff-b8d3c6e0f3e5568597dc847809a4f93ee86d7b9d966c3eaa4266fd74fd01c894L720-R720)