### PR TITLE
fix: honor getSignatureStatuses history flag

### DIFF
--- a/crates/superbank-rpc/src/handlers/signatures.rs
+++ b/crates/superbank-rpc/src/handlers/signatures.rs
@@ -109,17 +109,23 @@ pub(crate) async fn handle_get_signature_statuses(
         ));
     }
 
-    if let Some(config_value) = params.get(1).filter(|value| !value.is_null())
-        && serde_json::from_value::<GetSignatureStatusesConfig>(config_value.clone()).is_err()
-    {
-        route.invalid_params();
-        return Ok(json_rpc_error_response(
-            id,
-            -32602,
-            "Invalid params: failed to parse config",
-            None,
-        ));
-    }
+    let search_transaction_history = match params.get(1).filter(|value| !value.is_null()) {
+        Some(config_value) => {
+            match serde_json::from_value::<GetSignatureStatusesConfig>(config_value.clone()) {
+                Ok(config) => config.search_transaction_history.unwrap_or(false),
+                Err(_) => {
+                    route.invalid_params();
+                    return Ok(json_rpc_error_response(
+                        id,
+                        -32602,
+                        "Invalid params: failed to parse config",
+                        None,
+                    ));
+                }
+            }
+        }
+        None => false,
+    };
 
     let mut inputs: Vec<Option<String>> = Vec::with_capacity(signatures.len());
     let mut unique_valid: Vec<String> = Vec::new();
@@ -191,10 +197,10 @@ pub(crate) async fn handle_get_signature_statuses(
     };
 
     // Disk tier: finalized statuses for signatures the head cache does not hold.
-    // A disk miss proves nothing (the signature may predate the window), so the
-    // remainder still goes to ClickHouse.
+    // Per getSignatureStatuses semantics, historical tiers are searched only
+    // when searchTransactionHistory is set.
     #[cfg(feature = "disk-cache")]
-    let disk_statuses: HashMap<String, (u64, Option<Value>)> =
+    let disk_statuses: HashMap<String, (u64, Option<Value>)> = if search_transaction_history {
         if let Some(disk) = state.disk_cache.as_ref() {
             let pending: Vec<(String, Signature)> = unique_valid
                 .iter()
@@ -226,7 +232,10 @@ pub(crate) async fn handle_get_signature_statuses(
             }
         } else {
             HashMap::new()
-        };
+        }
+    } else {
+        HashMap::new()
+    };
 
     #[cfg(feature = "disk-cache")]
     let in_disk = |sig: &String| disk_statuses.contains_key(sig);
@@ -234,42 +243,43 @@ pub(crate) async fn handle_get_signature_statuses(
     let in_disk = |_sig: &String| false;
 
     let mut timings: Option<crate::clickhouse::QueryTimings> = None;
-    let status_map: HashMap<String, SignatureStatusRecord> = if unique_valid.is_empty() {
-        HashMap::new()
-    } else {
-        #[cfg(feature = "grpc-head-cache")]
-        let to_query = unique_valid
-            .iter()
-            .filter(|sig| !head_statuses.contains_key(*sig) && !in_disk(sig))
-            .cloned()
-            .collect::<Vec<_>>();
-        #[cfg(not(feature = "grpc-head-cache"))]
-        let to_query: Vec<String> = unique_valid
-            .iter()
-            .filter(|sig| !in_disk(sig))
-            .cloned()
-            .collect();
-
-        if to_query.is_empty() {
+    let status_map: HashMap<String, SignatureStatusRecord> =
+        if unique_valid.is_empty() || !search_transaction_history {
             HashMap::new()
         } else {
-            route.source_clickhouse();
-            match state.clickhouse.get_signature_statuses(&to_query).await {
-                Ok((records, query_timings)) => {
-                    timings = Some(query_timings);
-                    records
-                        .into_iter()
-                        .map(|record| (record.signature.clone(), record))
-                        .collect()
-                }
-                Err(e) => {
-                    metrics::backend_error("get_signature_statuses");
-                    error!("Failed to query ClickHouse for signature statuses: {}", e);
-                    return Ok(json_rpc_internal_error_response(id));
+            #[cfg(feature = "grpc-head-cache")]
+            let to_query = unique_valid
+                .iter()
+                .filter(|sig| !head_statuses.contains_key(*sig) && !in_disk(sig))
+                .cloned()
+                .collect::<Vec<_>>();
+            #[cfg(not(feature = "grpc-head-cache"))]
+            let to_query: Vec<String> = unique_valid
+                .iter()
+                .filter(|sig| !in_disk(sig))
+                .cloned()
+                .collect();
+
+            if to_query.is_empty() {
+                HashMap::new()
+            } else {
+                route.source_clickhouse();
+                match state.clickhouse.get_signature_statuses(&to_query).await {
+                    Ok((records, query_timings)) => {
+                        timings = Some(query_timings);
+                        records
+                            .into_iter()
+                            .map(|record| (record.signature.clone(), record))
+                            .collect()
+                    }
+                    Err(e) => {
+                        metrics::backend_error("get_signature_statuses");
+                        error!("Failed to query ClickHouse for signature statuses: {}", e);
+                        return Ok(json_rpc_internal_error_response(id));
+                    }
                 }
             }
-        }
-    };
+        };
 
     let mut value = Vec::with_capacity(inputs.len());
     let mut has_clickhouse_match = false;

--- a/crates/superbank-rpc/src/handlers/types.rs
+++ b/crates/superbank-rpc/src/handlers/types.rs
@@ -154,7 +154,6 @@ pub(crate) const MAX_GET_BLOCKS_RANGE: u64 = 500_000;
 #[derive(Debug, Deserialize)]
 pub(crate) struct GetSignatureStatusesConfig {
     #[serde(rename = "searchTransactionHistory")]
-    #[allow(dead_code)]
     pub(crate) search_transaction_history: Option<bool>,
 }
 

--- a/crates/superbank-rpc/src/tests/mod.rs
+++ b/crates/superbank-rpc/src/tests/mod.rs
@@ -6146,7 +6146,10 @@ mod disk_cache_tier {
         let response = handle_get_signature_statuses(
             state,
             json!(1),
-            Some(vec![json!([signatures[0], signatures[1]])]),
+            Some(vec![
+                json!([signatures[0], signatures[1]]),
+                json!({ "searchTransactionHistory": true }),
+            ]),
         )
         .await
         .expect("response");
@@ -6164,6 +6167,40 @@ mod disk_cache_tier {
                 Some("finalized")
             );
             assert_eq!(status.get("slot").and_then(Value::as_u64), Some(100));
+        }
+    }
+
+    #[tokio::test]
+    async fn get_signature_statuses_skips_disk_without_search_history() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let disk = open_disk_cache(&dir);
+        let signatures = write_block(&disk, 100, 99, 2);
+        let state = state_with_disk_cache(disk);
+
+        for (case, config) in [
+            ("omitted", None),
+            ("false", Some(json!({ "searchTransactionHistory": false }))),
+        ] {
+            let mut params = vec![json!([signatures[0].clone(), signatures[1].clone()])];
+            if let Some(config) = config {
+                params.push(config);
+            }
+
+            let response = handle_get_signature_statuses(state.clone(), json!(1), Some(params))
+                .await
+                .expect("response");
+            let parsed = parse_json_rpc_response(response).await;
+            assert!(parsed.error.is_none(), "{case}: {:?}", parsed.error);
+            let value = parsed
+                .result
+                .and_then(|mut result| result.get_mut("value").map(Value::take))
+                .expect("statuses");
+            let statuses = value.as_array().expect("array");
+            assert_eq!(statuses.len(), 2);
+            assert!(
+                statuses.iter().all(Value::is_null),
+                "{case}: expected no historical lookup, got {statuses:?}"
+            );
         }
     }
 
@@ -6550,7 +6587,29 @@ mod disk_cache_tier {
     }
 
     #[tokio::test]
-    async fn get_signature_statuses_unknown_signature_consults_clickhouse() {
+    async fn get_signature_statuses_unknown_signature_with_search_history_consults_clickhouse() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let disk = open_disk_cache(&dir);
+        write_block(&disk, 100, 99, 1);
+        let state = state_with_disk_cache(disk);
+
+        let unknown = bs58::encode([7u8; 64]).into_string();
+        let response = handle_get_signature_statuses(
+            state,
+            json!(1),
+            Some(vec![
+                json!([unknown]),
+                json!({ "searchTransactionHistory": true }),
+            ]),
+        )
+        .await
+        .expect("response");
+        let parsed = parse_json_rpc_response(response).await;
+        assert!(parsed.error.is_some(), "fallthrough should hit ClickHouse");
+    }
+
+    #[tokio::test]
+    async fn get_signature_statuses_unknown_signature_without_search_history_returns_null() {
         let dir = tempfile::tempdir().expect("tempdir");
         let disk = open_disk_cache(&dir);
         write_block(&disk, 100, 99, 1);
@@ -6561,6 +6620,13 @@ mod disk_cache_tier {
             .await
             .expect("response");
         let parsed = parse_json_rpc_response(response).await;
-        assert!(parsed.error.is_some(), "fallthrough should hit ClickHouse");
+        assert!(parsed.error.is_none(), "{:?}", parsed.error);
+        let value = parsed
+            .result
+            .and_then(|mut result| result.get_mut("value").map(Value::take))
+            .expect("statuses");
+        let statuses = value.as_array().expect("array");
+        assert_eq!(statuses.len(), 1);
+        assert!(statuses[0].is_null());
     }
 }


### PR DESCRIPTION
Fixes #27.

## Summary
- parse getSignatureStatuses config into search_transaction_history
- skip disk-cache and ClickHouse history lookups unless searchTransactionHistory is true
- add regression coverage for omitted/false versus true behavior

## Tests
- cargo test -p superbank-rpc --features disk-cache get_signature_statuses
- cargo test -p superbank-rpc get_signature_statuses