### PR TITLE
feat: implement isBlockhashValid RPC method

### DIFF
--- a/crates/superbank-rpc/README.md
+++ b/crates/superbank-rpc/README.md
@@ -13,6 +13,7 @@ writer that matches the same schemas).
 - `getSlot`
 - `getTransactionCount`
 - `getLatestBlockhash`
+- `isBlockhashValid`
 - `getBlockTime`
 - `getBlocks`
 - `getBlocksWithLimit`
@@ -161,6 +162,7 @@ qualifying slot.
 - `getSlot`
 - `getTransactionCount`
 - `getLatestBlockhash`
+- `isBlockhashValid`
 - `getBlocks`
 - `getBlocksWithLimit`
 

--- a/crates/superbank-rpc/src/clickhouse/blocks.rs
+++ b/crates/superbank-rpc/src/clickhouse/blocks.rs
@@ -225,6 +225,42 @@ fn build_block_transactions_query(
     )
 }
 
+// Efficiency bound for the isBlockhashValid lookup so the query hits the slot primary
+// key, not the unindexed blockhash. It must still exceed MAX_PROCESSING_AGE (150), since
+// skipped slots make slots >= block heights, or valid rows fall outside the scan.
+const BLOCKHASH_VALID_SLOT_WINDOW: u64 = 512;
+
+fn build_blockhash_valid_query(
+    table: &str,
+    blockhash_literal: &str,
+    start_slot: u64,
+    end_slot: u64,
+    min_block_height: u64,
+    settings_clause: &str,
+) -> String {
+    let start_bucket = start_slot / SLOT_SHARD_DIVISOR;
+    let end_bucket = end_slot / SLOT_SHARD_DIVISOR;
+    format!(
+        "SELECT 1 AS present
+             FROM {blocks_metadata_table}
+             PREWHERE
+                intDiv(slot, {slot_shard_divisor}) BETWEEN {start_bucket} AND {end_bucket}
+                AND slot BETWEEN {start_slot} AND {end_slot}
+             WHERE blockhash = {blockhash_literal} AND block_height >= {min_block_height}
+             LIMIT 1
+             {settings_clause}",
+        blocks_metadata_table = table,
+        slot_shard_divisor = SLOT_SHARD_DIVISOR,
+        start_bucket = start_bucket,
+        end_bucket = end_bucket,
+        start_slot = start_slot,
+        end_slot = end_slot,
+        blockhash_literal = blockhash_literal,
+        min_block_height = min_block_height,
+        settings_clause = settings_clause,
+    )
+}
+
 /// Range variant for streaming/cache backfill: every block in `[start, end]`,
 /// rewards included, ascending. Always routed via the distributed table because
 /// slot ranges can straddle shard buckets.
@@ -514,6 +550,61 @@ impl ClickHouseClient {
                 .map_err(|e| ProcessingError::database(e.to_string(), e))?;
 
             Ok(row.max_slot)
+        })
+        .await
+    }
+
+    pub async fn is_blockhash_valid_in_window(
+        &self,
+        blockhash: &[u8; 32],
+        context_slot: u64,
+        min_block_height: u64,
+    ) -> ProcessingResult<(bool, QueryTimings)> {
+        self.with_timeout("is_blockhash_valid", async {
+            #[derive(Deserialize, clickhouse::Row)]
+            struct PresentRow {
+                present: u8,
+            }
+
+            let blocks_metadata_table = &self.blocks_metadata_table;
+            let settings_clause = self
+                .select_settings_clause("is_blockhash_valid", QueryFreshnessClass::TipSensitive);
+            let start_slot = context_slot.saturating_sub(BLOCKHASH_VALID_SLOT_WINDOW);
+            let blockhash_literal = format!(
+                "toFixedString(unhex('{}'), 32)",
+                hex::encode(blockhash).to_uppercase()
+            );
+            let query = build_blockhash_valid_query(
+                blocks_metadata_table,
+                &blockhash_literal,
+                start_slot,
+                context_slot,
+                min_block_height,
+                &settings_clause,
+            );
+            let start = Instant::now();
+            let mut cursor = self
+                .client
+                .query(&query)
+                .fetch::<PresentRow>()
+                .map_err(|e| ProcessingError::database(e.to_string(), e))?;
+
+            let row_opt = cursor
+                .next()
+                .await
+                .map_err(|e| ProcessingError::database(e.to_string(), e))?;
+            let exists = row_opt.is_some_and(|row| row.present == 1);
+
+            let timings = QueryTimings {
+                elapsed_ms: start.elapsed().as_millis() as u64,
+                received_bytes: cursor.received_bytes(),
+                decoded_bytes: cursor.decoded_bytes(),
+                rows_read: Some(0),
+                rows_read_unknown: true,
+                rows_returned: u64::from(exists),
+            };
+
+            Ok((exists, timings))
         })
         .await
     }
@@ -1660,8 +1751,8 @@ impl ClickHouseClient {
 mod tests {
     use super::{
         BlockTransactionProjection, SLOT_SHARD_DIVISOR, build_block_metadata_query,
-        build_block_transactions_query, build_transaction_count_query, normalize_slots,
-        shard_indices_for_slot_range,
+        build_block_transactions_query, build_blockhash_valid_query, build_transaction_count_query,
+        normalize_slots, shard_indices_for_slot_range,
     };
     #[cfg(any(feature = "disk-cache", feature = "grpc-streaming"))]
     use super::{
@@ -1766,6 +1857,24 @@ mod tests {
 
         assert!(query.contains("intDiv(slot, 432000) BETWEEN 1 AND 1"));
         assert!(query.contains("AND slot BETWEEN 432001 AND 432010"));
+    }
+
+    #[test]
+    fn blockhash_valid_query_uses_slot_bounds_and_inclusive_height() {
+        let query = build_blockhash_valid_query(
+            "default.blocks_metadata",
+            "toFixedString(unhex('AB'), 32)",
+            744,
+            1000,
+            850,
+            "",
+        );
+
+        assert!(query.contains("intDiv(slot, 432000) BETWEEN 0 AND 0"));
+        assert!(query.contains("AND slot BETWEEN 744 AND 1000"));
+        assert!(query.contains("blockhash = toFixedString(unhex('AB'), 32)"));
+        assert!(query.contains("block_height >= 850"));
+        assert!(query.contains("LIMIT 1"));
     }
 
     #[test]

--- a/crates/superbank-rpc/src/handlers/blocks.rs
+++ b/crates/superbank-rpc/src/handlers/blocks.rs
@@ -16,6 +16,7 @@ use solana_sdk::hash::Hash;
 use solana_sdk::pubkey::Pubkey;
 use solana_transaction_status::{EncodeError, TransactionDetails, UiTransactionEncoding};
 use std::collections::HashMap;
+use std::str::FromStr;
 use std::sync::Arc;
 use tracing::{error, warn};
 
@@ -25,7 +26,7 @@ use crate::handlers::{
     types::{
         GetBlockHeightConfig, GetBlocksConfig, GetInflationRewardConfig, GetLatestBlockhashConfig,
         GetLatestBlockhashResult, GetLatestBlockhashValue, GetSlotConfig, InflationRewardInfo,
-        MAX_GET_BLOCKS_RANGE, RpcContextSlot, reject_unknown_fields,
+        IsBlockhashValidResult, MAX_GET_BLOCKS_RANGE, RpcContextSlot, reject_unknown_fields,
     },
 };
 use crate::hydration::{BlockHydrationError, hydrate_block_payload};
@@ -1020,6 +1021,240 @@ pub(crate) async fn handle_get_latest_blockhash(
         add_downstream_header(&mut resp, &timings);
     }
     route.success();
+    Ok(resp)
+}
+
+pub(crate) async fn handle_is_blockhash_valid(
+    state: Arc<AppState>,
+    id: Value,
+    params: Option<Vec<Value>>,
+) -> Result<Response, StatusCode> {
+    let mut route = RouteMetric::for_state("isBlockhashValid", state.as_ref());
+
+    let Some(params) = params.filter(|v| !v.is_empty()) else {
+        route.invalid_params();
+        return Ok(json_rpc_error_response(
+            id,
+            -32602,
+            "Invalid params: expected a blockhash string",
+            None,
+        ));
+    };
+    let Some(blockhash_str) = params.first().and_then(Value::as_str) else {
+        route.invalid_params();
+        return Ok(json_rpc_error_response(
+            id,
+            -32602,
+            "Invalid params: blockhash must be a base-58 encoded string",
+            None,
+        ));
+    };
+    let Ok(blockhash) = Hash::from_str(blockhash_str) else {
+        route.invalid_params();
+        return Ok(json_rpc_error_response(
+            id,
+            -32602,
+            "Invalid params: invalid blockhash",
+            None,
+        ));
+    };
+    let blockhash_bytes = blockhash.to_bytes();
+
+    let config = match params.get(1) {
+        None => GetLatestBlockhashConfig::default(),
+        Some(v) if v.is_null() => GetLatestBlockhashConfig::default(),
+        Some(v) if v.is_object() => {
+            match serde_json::from_value::<GetLatestBlockhashConfig>(v.clone()) {
+                Ok(config) => config,
+                Err(e) => {
+                    warn!(error = %e, "Invalid isBlockhashValid config");
+                    route.invalid_params();
+                    return Ok(json_rpc_error_response(
+                        id,
+                        -32602,
+                        "Invalid params: failed to parse config".to_string(),
+                        None,
+                    ));
+                }
+            }
+        }
+        Some(_) => {
+            route.invalid_params();
+            return Ok(json_rpc_error_response(
+                id,
+                -32602,
+                "Invalid params: config must be an object",
+                None,
+            ));
+        }
+    };
+    let commitment = config.commitment.unwrap_or_default();
+
+    if commitment.is_processed() {
+        #[cfg(feature = "grpc-head-cache")]
+        {
+            if state.head_cache.is_none() {
+                route.invalid_params();
+                return Ok(json_rpc_error_response(
+                    id,
+                    -32602,
+                    "Only confirmed or finalized commitments are supported",
+                    Some(json!({ "requestedCommitment": commitment.commitment })),
+                ));
+            }
+        }
+        #[cfg(not(feature = "grpc-head-cache"))]
+        {
+            route.invalid_params();
+            return Ok(json_rpc_error_response(
+                id,
+                -32602,
+                "Only confirmed or finalized commitments are supported",
+                Some(json!({ "requestedCommitment": commitment.commitment })),
+            ));
+        }
+    }
+
+    let head_candidate = {
+        #[cfg(feature = "grpc-head-cache")]
+        {
+            if let Some(cache) = state.head_cache.as_ref() {
+                route.head_cache_read();
+                cache.latest_blockhash_info_at_least(commitment.commitment)
+            } else {
+                None
+            }
+        }
+        #[cfg(not(feature = "grpc-head-cache"))]
+        {
+            None
+        }
+    };
+    #[cfg(feature = "grpc-head-cache")]
+    let head_context_source = LatestSlotSource::HeadCache;
+    #[cfg(not(feature = "grpc-head-cache"))]
+    let head_context_source = LatestSlotSource::ClickHouse;
+
+    let (context_slot, use_head, context_source) = if let Some((head_slot, _, _)) = head_candidate {
+        (head_slot, true, head_context_source)
+    } else {
+        let (slot, source) = match state
+            .resolve_latest_slot_with_source("is_blockhash_valid", commitment.commitment)
+            .await
+        {
+            Ok(result) => result,
+            Err(e) => {
+                metrics::backend_error("get_latest_finalized_slot");
+                error!("Failed to fetch latest slot for isBlockhashValid: {}", e);
+                return Ok(json_rpc_internal_error_response(id));
+            }
+        };
+        (slot, false, source)
+    };
+    if use_head {
+        #[cfg(feature = "grpc-head-cache")]
+        route.source_head_cache();
+    } else {
+        match context_source {
+            LatestSlotSource::ClickHouse => route.source_clickhouse(),
+            #[cfg(feature = "grpc-head-cache")]
+            LatestSlotSource::HeadCache => route.source_head_cache(),
+        }
+    }
+
+    if let Some(min_context_slot) = config.min_context_slot
+        && context_slot < min_context_slot
+    {
+        route.rpc_error();
+        return Ok(json_rpc_error_response(
+            id,
+            JSON_RPC_SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED as i32,
+            "Minimum context slot has not been reached",
+            Some(json!({ "contextSlot": context_slot })),
+        ));
+    }
+
+    let current_block_height = if use_head {
+        let (_slot, _blockhash, block_height): (u64, [u8; 32], u64) =
+            head_candidate.expect("use_head implies head_candidate");
+        block_height
+    } else {
+        route.source_clickhouse();
+        let (row_opt, timings) = match state
+            .clickhouse
+            .get_blockhash_height_by_slot(context_slot)
+            .await
+        {
+            Ok(result) => result,
+            Err(e) => {
+                metrics::backend_error("get_blockhash_height_by_slot");
+                error!(
+                    "Failed to query ClickHouse for block height at slot {}: {}",
+                    context_slot, e
+                );
+                return Ok(json_rpc_internal_error_response(id));
+            }
+        };
+        let Some((_blockhash, height_opt)) = row_opt else {
+            error!(
+                slot = context_slot,
+                "Block height unavailable for isBlockhashValid"
+            );
+            let mut resp = json_rpc_internal_error_response(id);
+            add_downstream_header(&mut resp, &timings);
+            return Ok(resp);
+        };
+        let Some(height) = height_opt else {
+            error!(
+                slot = context_slot,
+                "Block height unavailable for isBlockhashValid"
+            );
+            let mut resp = json_rpc_internal_error_response(id);
+            add_downstream_header(&mut resp, &timings);
+            return Ok(resp);
+        };
+        height
+    };
+
+    let min_block_height = current_block_height.saturating_sub(MAX_PROCESSING_AGE as u64);
+
+    #[cfg(feature = "grpc-head-cache")]
+    if let Some(cache) = state.head_cache.as_ref() {
+        route.head_cache_read();
+        if let Some(valid) =
+            cache.blockhash_valid_at_least(blockhash_bytes, min_block_height, commitment.commitment)
+        {
+            route.source_head_cache();
+            route.success();
+            let result = IsBlockhashValidResult {
+                context: RpcContextSlot { slot: context_slot },
+                value: valid,
+            };
+            return Ok(json_rpc_success_response(id, json!(result)));
+        }
+    }
+
+    route.source_clickhouse();
+    let (value, timings) = match state
+        .clickhouse
+        .is_blockhash_valid_in_window(&blockhash_bytes, context_slot, min_block_height)
+        .await
+    {
+        Ok(result) => result,
+        Err(e) => {
+            metrics::backend_error("is_blockhash_valid");
+            error!("Failed to query ClickHouse for isBlockhashValid: {}", e);
+            return Ok(json_rpc_internal_error_response(id));
+        }
+    };
+
+    route.success();
+    let result = IsBlockhashValidResult {
+        context: RpcContextSlot { slot: context_slot },
+        value,
+    };
+    let mut resp = json_rpc_success_response(id, json!(result));
+    add_downstream_header(&mut resp, &timings);
     Ok(resp)
 }
 

--- a/crates/superbank-rpc/src/handlers/mod.rs
+++ b/crates/superbank-rpc/src/handlers/mod.rs
@@ -537,6 +537,7 @@ fn metrics_method_label(method: &str) -> &'static str {
         "getSlot" => "getSlot",
         "getTransactionCount" => "getTransactionCount",
         "getLatestBlockhash" => "getLatestBlockhash",
+        "isBlockhashValid" => "isBlockhashValid",
         "getBlockTime" => "getBlockTime",
         "getBlocks" => "getBlocks",
         "getBlocksWithLimit" => "getBlocksWithLimit",
@@ -866,6 +867,9 @@ async fn dispatch_json_rpc_request(
             }
             "getLatestBlockhash" => {
                 blocks::handle_get_latest_blockhash(state, id_for_dispatch, params).await
+            }
+            "isBlockhashValid" => {
+                blocks::handle_is_blockhash_valid(state, id_for_dispatch, params).await
             }
             "getBlockTime" => blocks::handle_get_block_time(state, id_for_dispatch, params).await,
             "getBlocks" => blocks::handle_get_blocks(state, id_for_dispatch, params).await,

--- a/crates/superbank-rpc/src/handlers/types.rs
+++ b/crates/superbank-rpc/src/handlers/types.rs
@@ -261,6 +261,11 @@ pub(crate) struct GetLatestBlockhashResult {
     pub(crate) context: RpcContextSlot,
     pub(crate) value: GetLatestBlockhashValue,
 }
+#[derive(Debug, Serialize)]
+pub(crate) struct IsBlockhashValidResult {
+    pub(crate) context: RpcContextSlot,
+    pub(crate) value: bool,
+}
 
 #[derive(Debug, Serialize)]
 pub(crate) struct SignatureStatusesResult {

--- a/crates/superbank-rpc/src/head_cache/mod.rs
+++ b/crates/superbank-rpc/src/head_cache/mod.rs
@@ -196,6 +196,36 @@ impl HeadCache {
         best
     }
 
+    pub(crate) fn blockhash_valid_at_least(
+        &self,
+        blockhash: [u8; 32],
+        min_block_height: u64,
+        min_commitment: CommitmentLevel,
+    ) -> Option<bool> {
+        let mut found_at_commitment = false;
+        for entry in self.slot_blockhash.iter() {
+            if *entry.value() != blockhash {
+                continue;
+            }
+            let slot = *entry.key();
+            if !commitment_meets(self.slot_commitment(slot), min_commitment) {
+                continue;
+            }
+            let Some(height) = self.slot_block_height.get(&slot).map(|h| *h.value()) else {
+                continue;
+            };
+            found_at_commitment = true;
+            if height >= min_block_height {
+                return Some(true);
+            }
+        }
+        if found_at_commitment {
+            Some(false)
+        } else {
+            None
+        }
+    }
+
     pub(crate) fn tx_entries(&self) -> usize {
         self.tx_by_signature.len()
     }

--- a/crates/superbank-rpc/src/tests/mod.rs
+++ b/crates/superbank-rpc/src/tests/mod.rs
@@ -38,7 +38,7 @@ use crate::handlers::blocks::{
     handle_get_block, handle_get_block_height, handle_get_block_time, handle_get_blocks,
     handle_get_blocks_with_limit, handle_get_first_available_block, handle_get_health,
     handle_get_inflation_reward, handle_get_latest_blockhash, handle_get_slot,
-    handle_get_transaction_count, handle_minimum_ledger_slot,
+    handle_get_transaction_count, handle_is_blockhash_valid, handle_minimum_ledger_slot,
 };
 use crate::handlers::handle_json_rpc_with_headers;
 use crate::handlers::signatures::{
@@ -2231,6 +2231,193 @@ async fn get_latest_blockhash_processed_from_head_cache() {
                 "lastValidBlockHeight": expected_last_valid,
             },
         }))
+    );
+}
+
+#[tokio::test]
+async fn is_blockhash_valid_rejects_missing_blockhash() {
+    let state = test_state();
+    let response = handle_is_blockhash_valid(state, json!(1), None)
+        .await
+        .expect("response");
+    let err = parse_json_rpc_response(response)
+        .await
+        .error
+        .expect("error present");
+    assert_eq!(err.code, -32602);
+    assert_eq!(err.message, "Invalid params: expected a blockhash string");
+}
+
+#[tokio::test]
+async fn is_blockhash_valid_rejects_non_string_blockhash() {
+    let state = test_state();
+    let response = handle_is_blockhash_valid(state, json!(1), Some(vec![json!(123)]))
+        .await
+        .expect("response");
+    let err = parse_json_rpc_response(response)
+        .await
+        .error
+        .expect("error present");
+    assert_eq!(err.code, -32602);
+    assert_eq!(
+        err.message,
+        "Invalid params: blockhash must be a base-58 encoded string"
+    );
+}
+
+#[tokio::test]
+async fn is_blockhash_valid_rejects_malformed_blockhash() {
+    let state = test_state();
+    let response = handle_is_blockhash_valid(state, json!(1), Some(vec![json!("not_base58")]))
+        .await
+        .expect("response");
+    let err = parse_json_rpc_response(response)
+        .await
+        .error
+        .expect("error present");
+    assert_eq!(err.code, -32602);
+    assert_eq!(err.message, "Invalid params: invalid blockhash");
+}
+
+#[tokio::test]
+async fn is_blockhash_valid_rejects_non_object_config() {
+    let state = test_state();
+    let blockhash = Hash::from([1u8; 32]).to_string();
+    let response =
+        handle_is_blockhash_valid(state, json!(1), Some(vec![json!(blockhash), json!(1)]))
+            .await
+            .expect("response");
+    let err = parse_json_rpc_response(response)
+        .await
+        .error
+        .expect("error present");
+    assert_eq!(err.code, -32602);
+    assert_eq!(err.message, "Invalid params: config must be an object");
+}
+
+#[tokio::test]
+async fn is_blockhash_valid_rejects_processed_commitment() {
+    let state = test_state();
+    let blockhash = Hash::from([1u8; 32]).to_string();
+    let response = handle_is_blockhash_valid(
+        state,
+        json!(1),
+        Some(vec![json!(blockhash), json!({ "commitment": "processed" })]),
+    )
+    .await
+    .expect("response");
+    let err = parse_json_rpc_response(response)
+        .await
+        .error
+        .expect("error present");
+    assert_eq!(err.code, -32602);
+    assert_eq!(
+        err.message,
+        "Only confirmed or finalized commitments are supported"
+    );
+}
+
+#[tokio::test]
+async fn is_blockhash_valid_rejects_min_context_slot_not_reached() {
+    let state = test_state();
+    let blockhash = Hash::from([1u8; 32]).to_string();
+    let response = handle_is_blockhash_valid(
+        state,
+        json!(1),
+        Some(vec![json!(blockhash), json!({ "minContextSlot": 2 })]),
+    )
+    .await
+    .expect("response");
+    let err = parse_json_rpc_response(response)
+        .await
+        .error
+        .expect("error present");
+    assert_eq!(
+        err.code,
+        JSON_RPC_SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED as i32
+    );
+    assert_eq!(err.message, "Minimum context slot has not been reached");
+    assert_eq!(
+        err.data.and_then(|d| d.get("contextSlot").cloned()),
+        Some(json!(1u64))
+    );
+}
+
+#[cfg(feature = "grpc-head-cache")]
+#[tokio::test]
+async fn is_blockhash_valid_true_from_head_cache() {
+    let cache = Arc::new(HeadCache::new(32, 1024));
+    cache.note_slot_commitment(10, CommitmentLevel::Finalized);
+    cache.note_block_height(10, 123);
+    cache.note_blockhash(10, [1u8; 32]);
+    let state = test_state_with_head_cache(cache);
+
+    let blockhash = Hash::from([1u8; 32]).to_string();
+    let response = handle_is_blockhash_valid(state, json!(1), Some(vec![json!(blockhash)]))
+        .await
+        .expect("response");
+
+    let parsed = parse_json_rpc_response(response).await;
+    assert!(parsed.error.is_none());
+    assert_eq!(
+        parsed.result,
+        Some(json!({ "context": { "slot": 10u64 }, "value": true }))
+    );
+}
+
+#[cfg(feature = "grpc-head-cache")]
+#[tokio::test]
+async fn is_blockhash_valid_true_at_window_boundary_from_head_cache() {
+    // A blockhash whose block_height is exactly the floor (current - MAX_PROCESSING_AGE)
+    // is still valid; guards the inclusive `>=` boundary.
+    let cache = Arc::new(HeadCache::new(256, 1024));
+    cache.note_slot_commitment(200, CommitmentLevel::Finalized);
+    cache.note_block_height(200, 200);
+    cache.note_blockhash(200, [1u8; 32]);
+    // min_block_height = 200 - 150 = 50; height 50 is exactly on the boundary.
+    cache.note_slot_commitment(60, CommitmentLevel::Finalized);
+    cache.note_block_height(60, 50);
+    cache.note_blockhash(60, [2u8; 32]);
+    let state = test_state_with_head_cache(cache);
+
+    let blockhash = Hash::from([2u8; 32]).to_string();
+    let response = handle_is_blockhash_valid(state, json!(1), Some(vec![json!(blockhash)]))
+        .await
+        .expect("response");
+
+    let parsed = parse_json_rpc_response(response).await;
+    assert!(parsed.error.is_none());
+    assert_eq!(
+        parsed.result,
+        Some(json!({ "context": { "slot": 200u64 }, "value": true }))
+    );
+}
+
+#[cfg(feature = "grpc-head-cache")]
+#[tokio::test]
+async fn is_blockhash_valid_false_for_aged_out_head_cache() {
+    // A blockhash present in the cache but below the height floor is invalid
+    // (the Some(false) branch), answered without touching ClickHouse.
+    let cache = Arc::new(HeadCache::new(256, 1024));
+    cache.note_slot_commitment(200, CommitmentLevel::Finalized);
+    cache.note_block_height(200, 200);
+    cache.note_blockhash(200, [1u8; 32]);
+    // min_block_height = 200 - 150 = 50; height 40 is below the floor.
+    cache.note_slot_commitment(45, CommitmentLevel::Finalized);
+    cache.note_block_height(45, 40);
+    cache.note_blockhash(45, [2u8; 32]);
+    let state = test_state_with_head_cache(cache);
+
+    let blockhash = Hash::from([2u8; 32]).to_string();
+    let response = handle_is_blockhash_valid(state, json!(1), Some(vec![json!(blockhash)]))
+        .await
+        .expect("response");
+
+    let parsed = parse_json_rpc_response(response).await;
+    assert!(parsed.error.is_none());
+    assert_eq!(
+        parsed.result,
+        Some(json!({ "context": { "slot": 200u64 }, "value": false }))
     );
 }
 


### PR DESCRIPTION
Adds the `isBlockhashValid` JSON-RPC method, so a client can check whether a blockhash is still usable before submitting or retrying a transaction.

## Behavior

`isBlockhashValid([blockhash, {commitment, minContextSlot}?])` returns `{context: {slot}, value}`. `value` is true while the blockhash's block is within the last `MAX_PROCESSING_AGE` (150) block heights of the current height, i.e. while a transaction using it would still be accepted. The check is inclusive at the boundary (`block_height >= current - 150`), matching Solana and the `last_valid_block_height` that `getLatestBlockhash` already returns.

Commitment handling and the context/height resolution mirror `getLatestBlockhash`: default finalized, `processed` only with the head cache, `minContextSlot` respected, and the config type (commitment + `minContextSlot`) is reused. The blockhash is an additional required first param. An unknown or expired blockhash returns `value: false`, not an error; malformed base58 returns `-32602`.

## How the lookup works

Two tiers, the same shape getSignatureStatuses / getTransaction / getBlock already use:

- **Head cache first** (when the `grpc-head-cache` feature is on): if the cache holds the blockhash in its retained window at the requested commitment, answer from it. This covers a blockhash a client just fetched from `getLatestBlockhash` that hasn't been flushed to ClickHouse yet.
- **ClickHouse fallback**: a slot-bounded range query. `block_height >= min` is the validity filter; the slot window (`BLOCKHASH_VALID_SLOT_WINDOW = 512`) is an efficiency bound so the query hits the slot primary key and partition pruning rather than scanning the unindexed blockhash column. It's kept wider than 150 because skipped slots make slots grow faster than block heights.

## Testing

- Unit tests for the param/error paths (missing, non-string, and malformed blockhash; non-object config; `processed` rejection; `minContextSlot`), the head-cache hit (`value: true`), the inclusive boundary (`value: true` at exactly the floor), the aged-out case (`value: false`), and a builder test asserting the generated SQL.
- The ClickHouse fallback query isn't exercised by the unit suite (same as `getLatestBlockhash`'s ClickHouse path, which would need a test seam). I validated it directly against a ClickHouse instance instead: present-and-valid and the exact boundary return true; aged-out, out-of-window, and absent return false.

`cargo fmt --all --check` is clean, and `superbank-rpc`'s `clippy --all-targets -D warnings` and tests pass in both the default and `--all-features` configurations.
