### PR TITLE
fix: return `[]` not `null` for empty transaction `meta.rewards`

### DIFF
--- a/crates/superbank-rpc/src/hydration/meta.rs
+++ b/crates/superbank-rpc/src/hydration/meta.rs
@@ -135,7 +135,7 @@ pub(crate) fn build_transaction_status_meta(
                 "rewards populated without meta_rewards_present".to_string(),
             ));
         }
-        None
+        Some(Vec::new())
     };
 
     let loaded_addresses = solana_sdk::message::v0::LoadedAddresses {

--- a/crates/superbank-rpc/src/tests/mod.rs
+++ b/crates/superbank-rpc/src/tests/mod.rs
@@ -5685,7 +5685,7 @@ fn build_transaction_status_meta_emits_null_lists_when_absent_before_boundary() 
 
     assert!(meta.pre_token_balances.is_none());
     assert!(meta.post_token_balances.is_none());
-    assert!(meta.rewards.is_none());
+    assert!(meta.rewards.as_ref().expect("rewards").is_empty());
 }
 
 #[test]
@@ -5701,7 +5701,7 @@ fn build_transaction_status_meta_emits_null_lists_when_absent_after_boundary() {
 
     assert!(meta.pre_token_balances.is_none());
     assert!(meta.post_token_balances.is_none());
-    assert!(meta.rewards.is_none());
+    assert!(meta.rewards.as_ref().expect("rewards").is_empty());
 }
 
 #[test]


### PR DESCRIPTION
`getTransaction` returned `meta.rewards: null` for transactions with no transaction-level rewards, where agave returns `[]`. A client that treats `rewards` as an array (iterates it, reads `.length`) breaks on the `null`.

The internal meta builder set `rewards` to `None` in the empty branch. getTransaction encodes with `show_rewards = true`, so that `None` went straight to the wire as `null`. Changed it to an empty `Vec`.

## Verified on a live instance

Seeded a local ClickHouse from mainnet and ran the old vs fixed binary against the same data:

```
getTransaction  .result.meta.rewards
  before        -> null
  after         -> []
  mainnet-beta  -> []        (same signature, api.mainnet-beta)

getBlock (transactionDetails=full, rewards=true), unique meta.rewards across all txs in the block
  before        -> [null]
  after         -> [[]]
```

The change is in the shared meta builder, so getBlock (full) rides along on it. getBlock's `transactionDetails=accounts` goes through a separate builder; I left it alone since I haven't confirmed what agave returns for rewards in that mode.

## Tests

The two `build_transaction_status_meta_emits_null_lists_when_absent_*` tests asserted the old `null`; flipped them to assert `[]`. The present-rewards path (`build_transaction_status_meta_emits_empty_lists_when_present`) already asserted `[]`, so both the empty and present cases are covered.

`cargo test -p superbank-rpc` (default and `--all-features`), `cargo fmt --all -- --check`, and `cargo clippy -p superbank-rpc --all-targets --all-features -- -D warnings` all pass.


Closes #42.