### PR TITLE
fix: reject unknown keys in ingestor YAML config

### DIFF
--- a/crates/superbank/src/cli.rs
+++ b/crates/superbank/src/cli.rs
@@ -519,7 +519,7 @@ pub(crate) struct Args {
 }
 
 #[derive(Debug, Default, Deserialize)]
-#[serde(default, rename_all = "kebab-case")]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 struct FileConfig {
     source: Option<IngestSource>,
     endpoint: Option<String>,
@@ -1374,6 +1374,14 @@ mod tests {
             serde_yaml::from_str("clickhouse-async-insert: true\n").expect("parse config");
 
         assert_eq!(config.clickhouse_async_insert, Some(true));
+    }
+
+    #[test]
+    fn file_config_rejects_unknown_keys() {
+        let err = serde_yaml::from_str::<FileConfig>("fumarole-creat-consumer-group: true\n")
+            .expect_err("typo'd key should not silently parse");
+
+        assert!(err.to_string().contains("fumarole-creat-consumer-group"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`FileConfig` (`crates/superbank/src/cli.rs`) has no `#[serde(deny_unknown_fields)]`. Serde's default behavior is to silently ignore unrecognized keys, so a typo like `fumarole-creat-consumer-group` parses fine, the field stays `None`, and the CLI/default value silently wins instead — no error, no log line. The same applies to any other mistyped key in the config file.

## Fix

Add `deny_unknown_fields` to the `FileConfig` derive attribute so an unknown key fails config parsing loudly at startup instead of being dropped. This matches the existing convention already used for other config structs in this repo (`superbank-rpc/src/clickhouse/sharding.rs`, `superbank-rpc/src/handlers/types.rs`).

Also added a regression test (`file_config_rejects_unknown_keys`) asserting a typo'd key now returns a parse error naming the bad key.

## Compatibility

Checked every key in `superbank.example.yaml` against `FileConfig`'s fields (including the existing snake_case `alias`es), all map cleanly, so this does not break the documented example config or any existing `serde_yaml::from_str::<FileConfig>` test in this file.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p superbank --all-targets --locked -- -D warnings`
- [x] `cargo test -p superbank --locked` (56 passed, including new test)


Closes: #45 