### PR TITLE
fix: remove redundant borrows in format! args flagged by clippy

### DIFF
--- a/crates/superbank-rpc/src/clickhouse/queries.rs
+++ b/crates/superbank-rpc/src/clickhouse/queries.rs
@@ -644,10 +644,7 @@ pub(crate) fn build_transactions_for_address_query(
     query: &TransactionsForAddressQuery,
     settings_clause: &str,
 ) -> ProcessingResult<String> {
-    let address_literal = format!(
-        "CAST(base58Decode('{}') AS FixedString(32))",
-        &query.address
-    );
+    let address_literal = format!("CAST(base58Decode('{}') AS FixedString(32))", query.address);
     let gsfa_addr_bucket = format!(
         "cityHash64({}) % {}",
         address_literal, tables.gsfa_bucket_modulus
@@ -786,10 +783,7 @@ pub(crate) fn build_transactions_for_address_hot_query(
         ));
     }
 
-    let address_literal = format!(
-        "CAST(base58Decode('{}') AS FixedString(32))",
-        &query.address
-    );
+    let address_literal = format!("CAST(base58Decode('{}') AS FixedString(32))", query.address);
     let gsfa_addr_bucket = format!("cityHash64({}) % {}", address_literal, gsfa_bucket_modulus);
 
     let mut conditions = Vec::new();


### PR DESCRIPTION
Main's Lint job went red on clippy 1.97's `useless_borrows_in_formatting`: two `&query.address` args in `format!` calls in `clickhouse/queries.rs` (649, 791). `format!` borrows its args, so the `&` is redundant.

These lines predate recent PRs (there since 2026-06-03). The toolchain is `channel = "stable"`, so CI's clippy rolled forward to 1.97, which enforces the lint, and the next push to main surfaced it.

Removes both `&`. Verified green with clippy 1.97 (`cargo clippy --workspace --all-targets -- -D warnings`).