### PR TITLE
fix: return [] not null for empty accounts-mode meta.rewards

### DIFF
--- a/crates/superbank-rpc/src/hydration/meta.rs
+++ b/crates/superbank-rpc/src/hydration/meta.rs
@@ -288,7 +288,7 @@ pub(crate) fn build_transaction_status_meta_for_accounts(
                 "rewards populated without meta_rewards_present".to_string(),
             ));
         }
-        None
+        Some(Vec::new())
     };
 
     let loaded_addresses = solana_sdk::message::v0::LoadedAddresses {

--- a/crates/superbank-rpc/src/hydration/mod.rs
+++ b/crates/superbank-rpc/src/hydration/mod.rs
@@ -12,6 +12,8 @@ pub(crate) use block::hydrate_block_payload;
 pub(crate) use errors::{BlockHydrationError, TransactionHydrationError};
 #[cfg(any(test, feature = "grpc-streaming"))]
 pub(crate) use meta::build_transaction_status_meta;
+#[cfg(test)]
+pub(crate) use meta::build_transaction_status_meta_for_accounts;
 pub(crate) use meta::parse_transaction_error_display;
 #[cfg(any(test, feature = "grpc-streaming"))]
 pub(crate) use transaction::build_versioned_transaction;

--- a/crates/superbank-rpc/src/tests/mod.rs
+++ b/crates/superbank-rpc/src/tests/mod.rs
@@ -29,6 +29,7 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 use tokio::sync::Semaphore;
 
+use crate::clickhouse::StoredAccountsTransactionRecord;
 use crate::clickhouse::{
     BlockMetadataRecord, ClickHouseClient, ClickHouseClientOptions, RoutingPolicy, RoutingScope,
     RoutingTransport, SignatureSlot, StoredBlockPayload, StoredBlockRecord,
@@ -48,6 +49,7 @@ use crate::handlers::transactions::handle_get_transactions_for_address;
 use crate::handlers::types::MAX_GET_BLOCKS_RANGE;
 use crate::hydration::BlockHydrationError;
 use crate::hydration::build_transaction_status_meta;
+use crate::hydration::build_transaction_status_meta_for_accounts;
 use crate::hydration::{
     TransactionHydrationError, build_versioned_transaction, hydrate_block_payload,
     hydrate_block_record, hydrate_transaction_record, parse_instruction_error_display,
@@ -5920,6 +5922,20 @@ fn build_transaction_status_meta_emits_empty_lists_when_present() {
             .expect("post tokens")
             .is_empty()
     );
+    assert!(meta.rewards.as_ref().expect("rewards").is_empty());
+}
+
+#[test]
+fn build_transaction_status_meta_for_accounts_emits_empty_rewards_when_absent() {
+    let mut record = base_transaction_record();
+    record.meta_pre_balances = vec![1];
+    record.meta_post_balances = vec![1];
+    let record: StoredAccountsTransactionRecord = record.into();
+
+    let meta = build_transaction_status_meta_for_accounts(&record)
+        .expect("build meta")
+        .expect("meta present");
+
     assert!(meta.rewards.as_ref().expect("rewards").is_empty());
 }
 


### PR DESCRIPTION
Accounts-mode sibling of #43. `getBlock` with `transactionDetails=accounts` returns `meta.rewards: null` for transactions with no rewards, where agave returns `[]`. It's the default path too (`rewards` defaults to `true`). #43 fixed the shared full-meta builder; this applies the same `None` -> `Some(Vec::new())` to `build_transaction_status_meta_for_accounts`. Test added.