### PR TITLE
docs: document getSignatureStatuses searchTransactionHistory requirement

### DIFF
--- a/crates/superbank-rpc/README.md
+++ b/crates/superbank-rpc/README.md
@@ -48,6 +48,11 @@ Notes:
 - Methods that need a latest finalized context return a backend/internal JSON-RPC error when
   ClickHouse has no finalized slot available. This includes `getSlot`, `getBlockHeight`,
   `getTransactionCount`, `getLatestBlockhash`, `getSignatureStatuses`, and min-context checks.
+- `getSignatureStatuses` only looks up historical (ClickHouse-backed) statuses when the second
+  param sets `searchTransactionHistory: true`. Without it, only the short-lived head-cache tier
+  (when compiled with `--features grpc-head-cache` and enabled) is checked, so a signature that is
+  known to exist and is already indexed can still return `null`. This matches standard Solana
+  JSON-RPC semantics, not a Superbank-specific limitation.
 - `getTransaction` accepts the standard Solana config fields plus an optional Superbank extension:
   - `slot`: optional `u64`; when supplied, ClickHouse is queried directly for that exact slot and
     the response is `null` if the signature is not present in that slot.


### PR DESCRIPTION
## Problem

Calling `getSignatureStatuses` with a real, indexed signature (confirmed
present in the `signatures` table) returns `null`:

```json
{"jsonrpc":"2.0","id":1,"result":{"context":{"slot":...},"value":[null]}}
```

Adding `{"searchTransactionHistory": true}` as the second param returns
the full status correctly.

This matches standard Solana JSON-RPC semantics exactly (mainline
`getSignatureStatuses` also requires this flag to look beyond a
short-lived recent-status cache — see
`crates/superbank-rpc/src/handlers/signatures.rs`, where the
ClickHouse-backed historical lookup is skipped entirely unless
`search_transaction_history` is `true`). Not a bug, but it wasn't
obvious from `crates/superbank-rpc/README.md`'s method list, so a new
integrator coming from a different RPC provider could reasonably
assume a signature known to exist would resolve without the flag.

## Fix

Add a line to the notes in `crates/superbank-rpc/README.md` calling out
the `searchTransactionHistory` requirement next to the existing
`getSignatureStatuses` references.

Fixes #57