### PR TITLE
fix(rpc): optimize getInflationReward ClickHouse queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6385,6 +6385,7 @@ dependencies = [
  "solana-account-decoder-client-types",
  "solana-clock",
  "solana-commitment-config",
+ "solana-epoch-rewards-hasher",
  "solana-rpc-client-api",
  "solana-rpc-client-types",
  "solana-sdk",

--- a/crates/superbank-rpc/Cargo.toml
+++ b/crates/superbank-rpc/Cargo.toml
@@ -44,6 +44,7 @@ solana-rpc-client-api = "4.0.0-rc.0"
 solana-rpc-client-types = "4.0.0-rc.0"
 solana-account-decoder-client-types = "4.0.0-rc.0"
 solana-clock = "3.0.0"
+solana-epoch-rewards-hasher = "3.1.0"
 solana-sdk = "3.0"
 solana-transaction-context = "4.0.0-rc.0"
 solana-transaction-status = { version = "4.0.0-rc.0", features = ["agave-unstable-api"] }

--- a/crates/superbank-rpc/README.md
+++ b/crates/superbank-rpc/README.md
@@ -30,6 +30,9 @@ Notes:
 - Requests without an `id` are normalized to `id: null` and still return
   JSON-RPC response bodies (compatibility behavior; not strict notification semantics).
 - `processed` commitment is rejected by default; use `confirmed` or `finalized`.
+- `getInflationReward` reads the payout epoch boundary and only the reward partitions selected by
+  the requested addresses. It never expands reward arrays across a complete epoch; dedicated
+  address, concurrency, timeout, thread, memory, and read-byte limits are enabled by default.
 - `processed` commitment is supported for a subset of methods when compiled with
   `--features grpc-head-cache` and enabled at runtime with `HEAD_CACHE_ENABLED=true`
   (see "Optional gRPC head cache" below).
@@ -336,6 +339,12 @@ CLI flags and environment variables (see `crates/superbank-rpc/src/config.rs`):
 | `--rpc-concurrency-limit` | `RPC_CONCURRENCY_LIMIT` | `512` | Maximum number of in-flight HTTP JSON-RPC envelopes. |
 | `--rpc-max-batch-size` | `RPC_MAX_BATCH_SIZE` | `64` | Maximum number of JSON-RPC calls in a single batch envelope. |
 | `--rpc-batch-concurrency-limit` | `RPC_BATCH_CONCURRENCY_LIMIT` | `8` | Max concurrent item execution within one batch envelope. |
+| `--get-inflation-reward-max-addresses` | `GET_INFLATION_REWARD_MAX_ADDRESSES` | `100` | Maximum addresses accepted by one `getInflationReward` call. `0` disables this admission check; values above 100 are rejected at startup. |
+| `--get-inflation-reward-max-concurrency` | `GET_INFLATION_REWARD_MAX_CONCURRENCY` | `20` | Maximum active `getInflationReward` ClickHouse workflows per RPC instance. Excess calls fail fast with node-unhealthy (`-32005`); `0` disables this method-level admission check. |
+| `--get-inflation-reward-query-timeout-ms` | `GET_INFLATION_REWARD_QUERY_TIMEOUT_MS` | `5000` | End-to-end ClickHouse budget for the targeted boundary and partition lookup. Must be below `RPC_REQUEST_TIMEOUT_MS`. |
+| `--get-inflation-reward-max-threads` | `GET_INFLATION_REWARD_MAX_THREADS` | `2` | ClickHouse `max_threads` applied to every reward lookup query. |
+| `--get-inflation-reward-max-memory-bytes` | `GET_INFLATION_REWARD_MAX_MEMORY_BYTES` | `536870912` | ClickHouse `max_memory_usage` applied to every reward lookup query. |
+| `--get-inflation-reward-max-bytes-to-read` | `GET_INFLATION_REWARD_MAX_BYTES_TO_READ` | `536870912` | ClickHouse `max_bytes_to_read` applied to every reward lookup query. |
 | `--emit-http-errors` | `SUPERBANK_RPC_EMIT_HTTP_ERRORS` | `false` | Return HTTP `503 Service Unavailable` for selected server-side JSON-RPC failures; response bodies are unchanged. |
 | `--host` | `RPC_HOST` | `0.0.0.0` | — |
 | `--port` | `RPC_PORT` | `8899` | — |
@@ -435,7 +444,7 @@ Additional env flags:
 | `CLICKHOUSE_QUERY_ID_PREFIX` | `superbank` | `auto` or `off`/`0`/`false` disables. |
 | `CLICKHOUSE_GSFA_STRICT_PAGINATION` | `true` | — |
 | `CLICKHOUSE_GSFA_FALLBACK_TRANSACTIONS` | disabled | `empty`/`true` for empty-only fallback; `force`/`always` for incomplete fallback. |
-| `CLICKHOUSE_DISABLE_QUERY_SETTINGS` | `false` | Disables per-query ClickHouse `SETTINGS` overrides (including shard optimization, query-cache, and query-condition-cache settings) when truthy. |
+| `CLICKHOUSE_DISABLE_QUERY_SETTINGS` | `false` | Disables per-query ClickHouse `SETTINGS` overrides (including `getInflationReward` thread, memory, read-byte, and execution-time caps) when truthy. The targeted query shape and RPC admission limits remain active. |
 
 ### ClickHouse query cache (read queries)
 

--- a/crates/superbank-rpc/src/clickhouse/blocks.rs
+++ b/crates/superbank-rpc/src/clickhouse/blocks.rs
@@ -3,12 +3,14 @@
  * Copyright 2025-2026 Triton One Limited. All rights reserved.
  */
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::time::Instant;
 
 use serde::Deserialize;
 use serde_big_array::Array;
 use solana_clock::DEFAULT_SLOTS_PER_EPOCH;
+use solana_epoch_rewards_hasher::EpochRewardsHasher;
+use solana_sdk::{hash::Hash, pubkey::Pubkey};
 
 use crate::processing::{ProcessingError, ProcessingResult};
 
@@ -42,6 +44,164 @@ fn inflation_epoch_slot_bounds(epoch: u64) -> Option<(u64, u64)> {
     let start_slot = next_epoch.checked_mul(DEFAULT_SLOTS_PER_EPOCH)?;
     let end_slot_exclusive = following_epoch.checked_mul(DEFAULT_SLOTS_PER_EPOCH)?;
     Some((start_slot, end_slot_exclusive))
+}
+
+const MAX_INFLATION_REWARD_PARTITIONS: usize = 4_096;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum InflationRewardSelection {
+    VoteOnly,
+    VoteAndStake,
+    StakeOnly,
+}
+
+impl InflationRewardSelection {
+    fn sql_predicate(self) -> &'static str {
+        match self {
+            Self::VoteOnly => "lowerUTF8(ifNull(reward.4, '')) = 'voting'",
+            Self::VoteAndStake => "lowerUTF8(ifNull(reward.4, '')) IN ('staking', 'voting')",
+            Self::StakeOnly => "lowerUTF8(ifNull(reward.4, '')) = 'staking'",
+        }
+    }
+}
+
+#[derive(Deserialize, clickhouse::Row)]
+struct InflationBoundaryRow {
+    slot: u64,
+    parent_slot: u64,
+    parent_blockhash: Array<u8, 32>,
+    block_height: Option<u64>,
+    rewards_num_partitions: Option<u64>,
+}
+
+#[derive(Deserialize, clickhouse::Row)]
+struct InflationSlotRow {
+    slot: u64,
+}
+
+#[derive(Deserialize, clickhouse::Row)]
+struct InflationRewardRow {
+    pubkey: Array<u8, 32>,
+    effective_slot: u64,
+    lamports: i64,
+    post_balance: u64,
+    commission: Option<u8>,
+}
+
+fn build_inflation_boundary_query(
+    table: &str,
+    start_slot: u64,
+    end_slot_exclusive: u64,
+    settings_clause: &str,
+) -> String {
+    let payout_epoch = start_slot / SLOT_SHARD_DIVISOR;
+    format!(
+        "SELECT
+            slot,
+            parent_slot,
+            parent_blockhash,
+            block_height,
+            rewards_num_partitions
+         FROM {table}
+         PREWHERE
+            intDiv(slot, {slot_shard_divisor}) = {payout_epoch}
+            AND slot >= {start_slot}
+            AND slot < {end_slot_exclusive}
+         ORDER BY slot ASC
+         LIMIT 1
+         {settings_clause}",
+        slot_shard_divisor = SLOT_SHARD_DIVISOR,
+    )
+}
+
+fn build_inflation_partition_slots_query(
+    table: &str,
+    boundary_slot: u64,
+    end_slot_exclusive: u64,
+    num_partitions: usize,
+    settings_clause: &str,
+) -> String {
+    let payout_epoch = boundary_slot / SLOT_SHARD_DIVISOR;
+    format!(
+        "SELECT slot
+         FROM {table}
+         PREWHERE
+            intDiv(slot, {slot_shard_divisor}) = {payout_epoch}
+            AND slot > {boundary_slot}
+            AND slot < {end_slot_exclusive}
+         ORDER BY slot ASC
+         LIMIT 1 BY slot
+         LIMIT {num_partitions}
+         {settings_clause}",
+        slot_shard_divisor = SLOT_SHARD_DIVISOR,
+    )
+}
+
+fn build_inflation_rewards_query(
+    table: &str,
+    addresses: &[[u8; 32]],
+    slots: &[u64],
+    selection: InflationRewardSelection,
+    settings_clause: &str,
+) -> String {
+    let address_literals = addresses
+        .iter()
+        .map(|address| {
+            format!(
+                "toFixedString(unhex('{}'), 32)",
+                hex::encode(address).to_uppercase()
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+    let slot_literals = slots
+        .iter()
+        .map(u64::to_string)
+        .collect::<Vec<_>>()
+        .join(", ");
+    let reward_type_predicate = selection.sql_predicate();
+
+    format!(
+        "WITH [{address_literals}] AS target_pubkeys
+         SELECT
+            pubkey,
+            tupleElement(latest, 1) AS effective_slot,
+            tupleElement(latest, 2) AS lamports,
+            tupleElement(latest, 3) AS post_balance,
+            tupleElement(latest, 4) AS commission
+         FROM (
+            SELECT
+                reward.1 AS pubkey,
+                argMax(tuple(slot, reward.2, reward.3, reward.5), slot) AS latest
+            FROM (
+                SELECT
+                    slot,
+                    rewards_pubkey,
+                    rewards_lamports,
+                    rewards_post_balance,
+                    rewards_type,
+                    rewards_commission
+                FROM {table}
+                PREWHERE slot IN ({slot_literals})
+                WHERE rewards_present = 1 AND hasAny(rewards_pubkey, target_pubkeys)
+            ) AS selected_blocks
+            ARRAY JOIN arrayZip(
+                rewards_pubkey,
+                rewards_lamports,
+                rewards_post_balance,
+                rewards_type,
+                rewards_commission
+            ) AS reward
+            WHERE has(target_pubkeys, reward.1) AND {reward_type_predicate}
+            GROUP BY pubkey
+         )
+         {settings_clause}"
+    )
+}
+
+fn inflation_reward_partition(address: &[u8; 32], num_partitions: usize, seed: &[u8; 32]) -> usize {
+    EpochRewardsHasher::new(num_partitions, &Hash::new_from_array(*seed))
+        .hash_address_to_partition(&Pubkey::new_from_array(*address))
 }
 
 #[derive(Deserialize, clickhouse::Row)]
@@ -847,129 +1007,389 @@ impl ClickHouseClient {
             }
         }
 
-        let address_literals = deduped_addresses
-            .iter()
-            .map(|address| {
-                format!(
-                    "toFixedString(unhex('{}'), 32)",
-                    hex::encode(address).to_uppercase()
-                )
-            })
-            .collect::<Vec<_>>();
-        let target_pubkeys_literal = format!("[{}]", address_literals.join(", "));
+        let settings_clause = self.inflation_reward_settings_clause(OPERATION);
+        let (query_client, blocks_metadata_table, cleanup_cluster, query_scope) = if self
+            .scope_shard_direct()
+            && let (Some(topology), Some(local_table)) =
+                (&self.shard_topology, &self.blocks_metadata_local_table)
+        {
+            let shard = topology.shard_for_hash(start_slot / SLOT_SHARD_DIVISOR);
+            (
+                shard.http_client.clone(),
+                local_table.clone(),
+                None,
+                "shard_local",
+            )
+        } else {
+            (
+                self.client.clone(),
+                self.blocks_metadata_table.clone(),
+                self.shard_routing
+                    .as_ref()
+                    .map(|config| config.cluster.clone()),
+                "distributed",
+            )
+        };
+        let query_timeout = self.inflation_reward_limits.query_timeout;
+        let workflow_started = Instant::now();
 
-        #[derive(Deserialize, clickhouse::Row)]
-        struct InflationRewardRow {
-            pubkey: Array<u8, 32>,
-            effective_slot: u64,
-            lamports: i64,
-            post_balance: u64,
-            commission: Option<u8>,
-        }
-
-        let settings_clause =
-            self.select_settings_clause(OPERATION, QueryFreshnessClass::Historical);
-        let blocks_metadata_table = &self.blocks_metadata_table;
-        let query = format!(
-            "WITH {target_pubkeys_literal} AS target_pubkeys
-             SELECT
-                pubkey,
-                tupleElement(latest, 1) AS effective_slot,
-                tupleElement(latest, 2) AS lamports,
-                tupleElement(latest, 3) AS post_balance,
-                tupleElement(latest, 4) AS commission
-             FROM (
-                SELECT
-                    reward.1 AS pubkey,
-                    argMax(tuple(slot, reward.2, reward.3, reward.5), slot) AS latest
-                FROM (
-                    SELECT
-                        slot,
-                        rewards_pubkey,
-                        rewards_lamports,
-                        rewards_post_balance,
-                        rewards_type,
-                        rewards_commission
-                    FROM {blocks_metadata_table}
-                    PREWHERE slot >= {start_slot} AND slot < {end_slot_exclusive}
-                    WHERE rewards_present = 1 AND hasAny(rewards_pubkey, target_pubkeys)
-                ) AS epoch_rows
-                ARRAY JOIN arrayZip(
-                    rewards_pubkey,
-                    rewards_lamports,
-                    rewards_post_balance,
-                    rewards_type,
-                    rewards_commission
-                ) AS reward
-                WHERE
-                    has(target_pubkeys, reward.1)
-                    AND lowerUTF8(ifNull(reward.4, '')) IN ('staking', 'voting')
-                GROUP BY pubkey
-             )
-             {settings_clause}",
-            target_pubkeys_literal = target_pubkeys_literal,
-            blocks_metadata_table = blocks_metadata_table,
-            start_slot = start_slot,
-            end_slot_exclusive = end_slot_exclusive,
-            settings_clause = settings_clause
-        );
-        let (query, query_id) = annotate_required_query(query, OPERATION);
-        let mut cleanup = self.http_query_cleanup(OPERATION, query_id.clone());
-
+        // Keep one global HTTP permit for the complete multi-query workflow. This prevents each
+        // step from releasing and reacquiring capacity while an admitted reward request is active.
+        let _http_permit = self.http_query_sem.acquire().await.ok();
         let execute = async {
-            let start = Instant::now();
-            let mut cursor = http_query_with_id(&self.client, &query, Some(query_id))
-                .fetch::<InflationRewardRow>()
-                .map_err(|e| ProcessingError::database(e.to_string(), e))?;
+            let mut timings = QueryTimings::zero();
 
-            let mut rewards = Vec::new();
-            while let Some(row) = cursor
-                .next()
-                .await
-                .map_err(|e| ProcessingError::database(e.to_string(), e))?
-            {
-                rewards.push(InflationRewardRecord {
-                    pubkey: row.pubkey.0,
-                    effective_slot: row.effective_slot,
-                    lamports: row.lamports,
-                    post_balance: row.post_balance,
-                    commission: row.commission,
-                });
-            }
-
-            let timings = QueryTimings {
-                elapsed_ms: start.elapsed().as_millis() as u64,
-                received_bytes: cursor.received_bytes(),
-                decoded_bytes: cursor.decoded_bytes(),
+            let boundary_query = build_inflation_boundary_query(
+                &blocks_metadata_table,
+                start_slot,
+                end_slot_exclusive,
+                &settings_clause,
+            );
+            let (boundary_query, boundary_query_id) =
+                annotate_required_query(boundary_query, "get_inflation_reward_boundary");
+            let mut boundary_cleanup = self.http_query_cleanup_for_client(
+                query_client.clone(),
+                cleanup_cluster.clone(),
+                OPERATION,
+                boundary_query_id.clone(),
+            );
+            let boundary_started = Instant::now();
+            let mut boundary_cursor =
+                http_query_with_id(&query_client, &boundary_query, Some(boundary_query_id))
+                    .fetch::<InflationBoundaryRow>()
+                    .map_err(|e| ProcessingError::database(e.to_string(), e))?;
+            let boundary = match boundary_cursor.next().await {
+                Ok(row) => row,
+                Err(err) => {
+                    boundary_cleanup.spawn_cleanup("error");
+                    return Err(ProcessingError::database(err.to_string(), err));
+                }
+            };
+            timings.add(QueryTimings {
+                elapsed_ms: boundary_started.elapsed().as_millis() as u64,
+                received_bytes: boundary_cursor.received_bytes(),
+                decoded_bytes: boundary_cursor.decoded_bytes(),
                 rows_read: Some(0),
                 rows_read_unknown: true,
-                rows_returned: rewards.len() as u64,
-            };
+                rows_returned: u64::from(boundary.is_some()),
+            });
+            boundary_cleanup.disarm();
 
-            Ok((rewards, timings))
+            let Some(boundary) = boundary else {
+                crate::metrics::inflation_reward_lookup("unknown", "boundary_missing");
+                return Err(ProcessingError::database_msg(format!(
+                    "no confirmed block is available in payout epoch for inflation epoch {epoch}"
+                )));
+            };
+            if boundary.parent_slot >= start_slot {
+                crate::metrics::inflation_reward_lookup("unknown", "invalid_boundary");
+                return Err(ProcessingError::database_msg(format!(
+                    "slot {} is not a valid epoch boundary for inflation epoch {epoch}",
+                    boundary.slot
+                )));
+            }
+
+            let partitioned = boundary.rewards_num_partitions.is_some();
+            let boundary_selection = if partitioned {
+                InflationRewardSelection::VoteOnly
+            } else {
+                InflationRewardSelection::VoteAndStake
+            };
+            let boundary_rewards_query = build_inflation_rewards_query(
+                &blocks_metadata_table,
+                &deduped_addresses,
+                &[boundary.slot],
+                boundary_selection,
+                &settings_clause,
+            );
+            let (boundary_rewards_query, boundary_rewards_query_id) = annotate_required_query(
+                boundary_rewards_query,
+                "get_inflation_reward_boundary_rewards",
+            );
+            let mut boundary_rewards_cleanup = self.http_query_cleanup_for_client(
+                query_client.clone(),
+                cleanup_cluster.clone(),
+                OPERATION,
+                boundary_rewards_query_id.clone(),
+            );
+            let boundary_rewards_started = Instant::now();
+            let mut boundary_rewards_cursor = http_query_with_id(
+                &query_client,
+                &boundary_rewards_query,
+                Some(boundary_rewards_query_id),
+            )
+            .fetch::<InflationRewardRow>()
+            .map_err(|e| ProcessingError::database(e.to_string(), e))?;
+            let mut rewards_by_pubkey = HashMap::with_capacity(deduped_addresses.len());
+            loop {
+                let next = match boundary_rewards_cursor.next().await {
+                    Ok(next) => next,
+                    Err(err) => {
+                        boundary_rewards_cleanup.spawn_cleanup("error");
+                        return Err(ProcessingError::database(err.to_string(), err));
+                    }
+                };
+                let Some(row) = next else {
+                    break;
+                };
+                rewards_by_pubkey.insert(
+                    row.pubkey.0,
+                    InflationRewardRecord {
+                        pubkey: row.pubkey.0,
+                        effective_slot: row.effective_slot,
+                        lamports: row.lamports,
+                        post_balance: row.post_balance,
+                        commission: row.commission,
+                    },
+                );
+            }
+            timings.add(QueryTimings {
+                elapsed_ms: boundary_rewards_started.elapsed().as_millis() as u64,
+                received_bytes: boundary_rewards_cursor.received_bytes(),
+                decoded_bytes: boundary_rewards_cursor.decoded_bytes(),
+                rows_read: Some(0),
+                rows_read_unknown: true,
+                rows_returned: rewards_by_pubkey.len() as u64,
+            });
+            boundary_rewards_cleanup.disarm();
+
+            if !partitioned {
+                crate::metrics::inflation_reward_selected_blocks(1);
+                crate::metrics::inflation_reward_lookup("non_partitioned", "success");
+                tracing::info!(
+                    epoch,
+                    input_addresses = addresses.len(),
+                    unique_addresses = deduped_addresses.len(),
+                    declared_partitions = 0,
+                    selected_blocks = 1,
+                    elapsed_ms = workflow_started.elapsed().as_millis() as u64,
+                    received_bytes = timings.received_bytes,
+                    query_scope,
+                    "Completed targeted getInflationReward lookup"
+                );
+                return Ok((rewards_by_pubkey.into_values().collect(), timings));
+            }
+
+            let num_partitions_u64 = boundary
+                .rewards_num_partitions
+                .expect("partitioned boundary has a partition count");
+            let num_partitions = usize::try_from(num_partitions_u64).map_err(|_| {
+                ProcessingError::database_msg(format!(
+                    "inflation epoch {epoch} declares too many reward partitions"
+                ))
+            })?;
+            if num_partitions == 0 || num_partitions > MAX_INFLATION_REWARD_PARTITIONS {
+                crate::metrics::inflation_reward_lookup("partitioned", "invalid_partitions");
+                return Err(ProcessingError::database_msg(format!(
+                    "inflation epoch {epoch} declares unsupported reward partition count {num_partitions}"
+                )));
+            }
+
+            let unresolved_addresses = deduped_addresses
+                .iter()
+                .copied()
+                .filter(|address| !rewards_by_pubkey.contains_key(address))
+                .collect::<Vec<_>>();
+            if unresolved_addresses.is_empty() {
+                crate::metrics::inflation_reward_selected_blocks(1);
+                crate::metrics::inflation_reward_lookup("partitioned", "success");
+                tracing::info!(
+                    epoch,
+                    input_addresses = addresses.len(),
+                    unique_addresses = deduped_addresses.len(),
+                    declared_partitions = num_partitions,
+                    selected_blocks = 1,
+                    boundary_block_height = boundary.block_height,
+                    elapsed_ms = workflow_started.elapsed().as_millis() as u64,
+                    received_bytes = timings.received_bytes,
+                    query_scope,
+                    "Completed targeted getInflationReward lookup"
+                );
+                return Ok((rewards_by_pubkey.into_values().collect(), timings));
+            }
+
+            let partition_slots_query = build_inflation_partition_slots_query(
+                &blocks_metadata_table,
+                boundary.slot,
+                end_slot_exclusive,
+                num_partitions,
+                &settings_clause,
+            );
+            let (partition_slots_query, partition_slots_query_id) = annotate_required_query(
+                partition_slots_query,
+                "get_inflation_reward_partition_slots",
+            );
+            let mut partition_slots_cleanup = self.http_query_cleanup_for_client(
+                query_client.clone(),
+                cleanup_cluster.clone(),
+                OPERATION,
+                partition_slots_query_id.clone(),
+            );
+            let partition_slots_started = Instant::now();
+            let mut partition_slots_cursor = http_query_with_id(
+                &query_client,
+                &partition_slots_query,
+                Some(partition_slots_query_id),
+            )
+            .fetch::<InflationSlotRow>()
+            .map_err(|e| ProcessingError::database(e.to_string(), e))?;
+            let mut partition_slots = Vec::with_capacity(num_partitions);
+            loop {
+                let next = match partition_slots_cursor.next().await {
+                    Ok(next) => next,
+                    Err(err) => {
+                        partition_slots_cleanup.spawn_cleanup("error");
+                        return Err(ProcessingError::database(err.to_string(), err));
+                    }
+                };
+                let Some(row) = next else {
+                    break;
+                };
+                partition_slots.push(row.slot);
+            }
+            timings.add(QueryTimings {
+                elapsed_ms: partition_slots_started.elapsed().as_millis() as u64,
+                received_bytes: partition_slots_cursor.received_bytes(),
+                decoded_bytes: partition_slots_cursor.decoded_bytes(),
+                rows_read: Some(0),
+                rows_read_unknown: true,
+                rows_returned: partition_slots.len() as u64,
+            });
+            partition_slots_cleanup.disarm();
+            if partition_slots.len() < num_partitions {
+                crate::metrics::inflation_reward_lookup("partitioned", "incomplete");
+                return Err(ProcessingError::database_msg(format!(
+                    "inflation rewards period for epoch {epoch} is incomplete: expected {num_partitions} partition blocks, found {}",
+                    partition_slots.len()
+                )));
+            }
+
+            let mut expected_slot_by_pubkey = HashMap::with_capacity(unresolved_addresses.len());
+            let mut selected_slots = Vec::with_capacity(unresolved_addresses.len());
+            let mut selected_slot_set = HashSet::with_capacity(unresolved_addresses.len());
+            for address in &unresolved_addresses {
+                let partition_index = inflation_reward_partition(
+                    address,
+                    num_partitions,
+                    &boundary.parent_blockhash.0,
+                );
+                let expected_slot = partition_slots[partition_index];
+                expected_slot_by_pubkey.insert(*address, expected_slot);
+                if selected_slot_set.insert(expected_slot) {
+                    selected_slots.push(expected_slot);
+                }
+            }
+            selected_slots.sort_unstable();
+
+            let partition_rewards_query = build_inflation_rewards_query(
+                &blocks_metadata_table,
+                &unresolved_addresses,
+                &selected_slots,
+                InflationRewardSelection::StakeOnly,
+                &settings_clause,
+            );
+            let (partition_rewards_query, partition_rewards_query_id) = annotate_required_query(
+                partition_rewards_query,
+                "get_inflation_reward_partition_rewards",
+            );
+            let mut partition_rewards_cleanup = self.http_query_cleanup_for_client(
+                query_client.clone(),
+                cleanup_cluster.clone(),
+                OPERATION,
+                partition_rewards_query_id.clone(),
+            );
+            let partition_rewards_started = Instant::now();
+            let mut partition_rewards_cursor = http_query_with_id(
+                &query_client,
+                &partition_rewards_query,
+                Some(partition_rewards_query_id),
+            )
+            .fetch::<InflationRewardRow>()
+            .map_err(|e| ProcessingError::database(e.to_string(), e))?;
+            let mut partition_reward_count = 0u64;
+            loop {
+                let next = match partition_rewards_cursor.next().await {
+                    Ok(next) => next,
+                    Err(err) => {
+                        partition_rewards_cleanup.spawn_cleanup("error");
+                        return Err(ProcessingError::database(err.to_string(), err));
+                    }
+                };
+                let Some(row) = next else {
+                    break;
+                };
+                let pubkey = row.pubkey.0;
+                let Some(expected_slot) = expected_slot_by_pubkey.get(&pubkey) else {
+                    return Err(ProcessingError::database_msg(
+                        "partition reward query returned an unrequested address".to_string(),
+                    ));
+                };
+                if row.effective_slot != *expected_slot {
+                    return Err(ProcessingError::database_msg(format!(
+                        "partition reward for requested address came from slot {}, expected {}",
+                        row.effective_slot, expected_slot
+                    )));
+                }
+                rewards_by_pubkey.insert(
+                    pubkey,
+                    InflationRewardRecord {
+                        pubkey,
+                        effective_slot: row.effective_slot,
+                        lamports: row.lamports,
+                        post_balance: row.post_balance,
+                        commission: row.commission,
+                    },
+                );
+                partition_reward_count = partition_reward_count.saturating_add(1);
+            }
+            timings.add(QueryTimings {
+                elapsed_ms: partition_rewards_started.elapsed().as_millis() as u64,
+                received_bytes: partition_rewards_cursor.received_bytes(),
+                decoded_bytes: partition_rewards_cursor.decoded_bytes(),
+                rows_read: Some(0),
+                rows_read_unknown: true,
+                rows_returned: partition_reward_count,
+            });
+            partition_rewards_cleanup.disarm();
+
+            let selected_block_count = selected_slots.len().saturating_add(1);
+            crate::metrics::inflation_reward_selected_blocks(selected_block_count);
+            crate::metrics::inflation_reward_lookup("partitioned", "success");
+            tracing::info!(
+                epoch,
+                input_addresses = addresses.len(),
+                unique_addresses = deduped_addresses.len(),
+                declared_partitions = num_partitions,
+                selected_blocks = selected_block_count,
+                boundary_block_height = boundary.block_height,
+                elapsed_ms = workflow_started.elapsed().as_millis() as u64,
+                received_bytes = timings.received_bytes,
+                query_scope,
+                "Completed targeted getInflationReward lookup"
+            );
+
+            Ok((rewards_by_pubkey.into_values().collect(), timings))
         };
 
-        // Gate on the global HTTP-query permit like `with_timeout` does (this path uses a manual
-        // timeout for KILL-on-timeout cleanup, so it cannot reuse `with_timeout` directly).
-        // Acquire up front and box `execute` rather than wrapping it in another async block, to
-        // keep this future small (see the note in `with_timeout` about stack overflow).
-        let _http_permit = self.http_query_sem.acquire().await.ok();
         let execute = Box::pin(execute);
-        match tokio::time::timeout(self.query_timeout, execute).await {
-            Ok(Ok(result)) => {
-                cleanup.disarm();
-                Ok(result)
-            }
-            Ok(Err(err)) => {
-                cleanup.spawn_cleanup("error");
-                Err(err)
+        match tokio::time::timeout(query_timeout, execute).await {
+            Ok(result) => {
+                if let Err(err) = &result {
+                    let message = err.to_string();
+                    if message.contains("MEMORY_LIMIT_EXCEEDED")
+                        || message.contains("TOO_MANY_ROWS_OR_BYTES")
+                        || message.contains("max_bytes_to_read")
+                    {
+                        crate::metrics::inflation_reward_lookup("unknown", "resource_limit");
+                    }
+                }
+                result
             }
             Err(_) => {
                 crate::metrics::clickhouse_timeout(OPERATION);
-                cleanup.spawn_cleanup("timeout");
+                crate::metrics::inflation_reward_lookup("unknown", "timeout");
                 Err(ProcessingError::timeout_msg(format!(
-                    "ClickHouse operation '{OPERATION}' timed out after {:?}",
-                    self.query_timeout
+                    "ClickHouse operation '{OPERATION}' timed out after {query_timeout:?}"
                 )))
             }
         }
@@ -1750,8 +2170,10 @@ impl ClickHouseClient {
 #[cfg(test)]
 mod tests {
     use super::{
-        BlockTransactionProjection, SLOT_SHARD_DIVISOR, build_block_metadata_query,
-        build_block_transactions_query, build_blockhash_valid_query, build_transaction_count_query,
+        BlockTransactionProjection, InflationRewardSelection, SLOT_SHARD_DIVISOR,
+        build_block_metadata_query, build_block_transactions_query, build_blockhash_valid_query,
+        build_inflation_boundary_query, build_inflation_partition_slots_query,
+        build_inflation_rewards_query, build_transaction_count_query, inflation_reward_partition,
         normalize_slots, shard_indices_for_slot_range,
     };
     #[cfg(any(feature = "disk-cache", feature = "grpc-streaming"))]
@@ -1834,6 +2256,73 @@ mod tests {
     fn normalize_slots_sorts_and_deduplicates() {
         let slots = normalize_slots(vec![5, 2, 5, 3, 2, 9, 9, 1]);
         assert_eq!(slots, vec![1, 2, 3, 5, 9]);
+    }
+
+    #[test]
+    fn inflation_boundary_query_reads_only_lightweight_metadata() {
+        let query = build_inflation_boundary_query(
+            "default.blocks_metadata",
+            121_392_000,
+            121_824_000,
+            "SETTINGS max_threads=2",
+        );
+
+        assert!(query.contains("intDiv(slot, 432000) = 281"));
+        assert!(query.contains("slot >= 121392000"));
+        assert!(query.contains("slot < 121824000"));
+        assert!(query.contains("rewards_num_partitions"));
+        assert!(!query.contains("rewards_pubkey"));
+        assert!(query.contains("ORDER BY slot ASC"));
+        assert!(query.contains("LIMIT 1"));
+        assert!(query.contains("SETTINGS max_threads=2"));
+    }
+
+    #[test]
+    fn inflation_partition_slots_query_is_ordered_and_bounded() {
+        let query = build_inflation_partition_slots_query(
+            "default.blocks_metadata",
+            121_392_000,
+            121_824_000,
+            293,
+            "",
+        );
+
+        assert!(query.contains("slot > 121392000"));
+        assert!(query.contains("slot < 121824000"));
+        assert!(query.contains("LIMIT 1 BY slot"));
+        assert!(query.contains("LIMIT 293"));
+    }
+
+    #[test]
+    fn inflation_rewards_query_expands_only_exact_slots() {
+        let addresses = [[1u8; 32], [2u8; 32]];
+        let query = build_inflation_rewards_query(
+            "default.blocks_metadata",
+            &addresses,
+            &[121_392_000, 121_392_017],
+            InflationRewardSelection::StakeOnly,
+            "SETTINGS max_threads=2, max_memory_usage=536870912",
+        );
+
+        assert!(query.contains("PREWHERE slot IN (121392000, 121392017)"));
+        assert!(!query.contains("PREWHERE slot >="));
+        assert!(query.contains("ARRAY JOIN arrayZip"));
+        assert!(query.contains("= 'staking'"));
+        assert!(query.contains("max_threads=2"));
+        assert!(query.contains("max_memory_usage=536870912"));
+    }
+
+    #[test]
+    fn inflation_reward_partition_is_deterministic_and_bounded() {
+        let seed = [9u8; 32];
+        let first = inflation_reward_partition(&[1u8; 32], 293, &seed);
+        let repeated = inflation_reward_partition(&[1u8; 32], 293, &seed);
+        let second = inflation_reward_partition(&[2u8; 32], 293, &seed);
+
+        assert_eq!(first, repeated);
+        assert!(first < 293);
+        assert!(second < 293);
+        assert_ne!(first, second);
     }
 
     #[test]

--- a/crates/superbank-rpc/src/clickhouse/client.rs
+++ b/crates/superbank-rpc/src/clickhouse/client.rs
@@ -430,6 +430,7 @@ pub struct ClickHouseClient {
     pub(crate) routing_policy: RoutingPolicy,
 
     pub(crate) query_timeout: Duration,
+    pub(crate) inflation_reward_limits: InflationRewardQueryLimits,
     pub(crate) tcp_access_check_timeout: Duration,
     pub(crate) http_connect_timeout: Duration,
     pub(crate) fanout_sem: Arc<Semaphore>,
@@ -461,6 +462,26 @@ pub struct ClickHouseClientOptions {
     pub tcp_pool_max: usize,
     pub in_clause_chunk: usize,
     pub startup_table_check: ClickHouseStartupTableCheck,
+    pub inflation_reward_limits: InflationRewardQueryLimits,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct InflationRewardQueryLimits {
+    pub query_timeout: Duration,
+    pub max_threads: usize,
+    pub max_memory_bytes: u64,
+    pub max_bytes_to_read: u64,
+}
+
+impl Default for InflationRewardQueryLimits {
+    fn default() -> Self {
+        Self {
+            query_timeout: Duration::from_millis(5_000),
+            max_threads: 2,
+            max_memory_bytes: 536_870_912,
+            max_bytes_to_read: 536_870_912,
+        }
+    }
 }
 
 #[derive(Deserialize, clickhouse::Row)]
@@ -540,6 +561,7 @@ impl ClickHouseClientOptions {
             tcp_pool_max: 20,
             in_clause_chunk: 512,
             startup_table_check: ClickHouseStartupTableCheck::Exists,
+            inflation_reward_limits: InflationRewardQueryLimits::default(),
         }
     }
 
@@ -588,6 +610,11 @@ impl ClickHouseClientOptions {
         self.startup_table_check = mode;
         self
     }
+
+    pub fn with_inflation_reward_limits(mut self, limits: InflationRewardQueryLimits) -> Self {
+        self.inflation_reward_limits = limits;
+        self
+    }
 }
 
 impl ClickHouseClient {
@@ -614,7 +641,7 @@ impl ClickHouseClient {
             tcp_pool_max,
             in_clause_chunk,
             startup_table_check,
-            ..
+            inflation_reward_limits,
         } = options;
         let client =
             build_clickhouse_http_client(url, database, username, password, http_connect_timeout);
@@ -704,6 +731,7 @@ impl ClickHouseClient {
             routing_policy,
 
             query_timeout,
+            inflation_reward_limits,
             tcp_access_check_timeout,
             http_connect_timeout,
             fanout_sem: Arc::new(Semaphore::new(fanout_concurrency.max(1))),
@@ -763,6 +791,22 @@ impl ClickHouseClient {
                 .map(|config| config.cluster.clone()),
             operation,
             self.query_timeout,
+            query_id,
+        )
+    }
+
+    pub(crate) fn http_query_cleanup_for_client(
+        &self,
+        client: HttpClient,
+        cluster: Option<String>,
+        operation: &'static str,
+        query_id: String,
+    ) -> HttpQueryCleanup {
+        HttpQueryCleanup::new(
+            client,
+            cluster,
+            operation,
+            self.inflation_reward_limits.query_timeout,
             query_id,
         )
     }
@@ -853,6 +897,30 @@ impl ClickHouseClient {
             ),
             self.query_timeout,
         )
+    }
+
+    pub(crate) fn inflation_reward_settings_clause(&self, operation: &'static str) -> String {
+        let limits = self.inflation_reward_limits;
+        let base = self.select_settings_clause_with_timeout(
+            operation,
+            QueryFreshnessClass::Historical,
+            limits.query_timeout,
+        );
+        if base.is_empty() {
+            return base;
+        }
+
+        format!(
+            "{base}, max_threads={max_threads}, max_memory_usage={max_memory_bytes}, \
+             max_bytes_to_read={max_bytes_to_read}, read_overflow_mode='throw'",
+            max_threads = limits.max_threads,
+            max_memory_bytes = limits.max_memory_bytes,
+            max_bytes_to_read = limits.max_bytes_to_read,
+        )
+    }
+
+    pub(crate) fn query_settings_enabled(&self) -> bool {
+        self.allow_query_settings
     }
 
     pub(crate) async fn with_timeout<T>(
@@ -1962,8 +2030,8 @@ mod tests {
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     use super::{
-        ClickHouseClient, ClickHouseClientOptions, kill_query_sql, shard_tcp_query_timeout_for,
-        split_table_reference, validate_gsfa_shard_layout_query,
+        ClickHouseClient, ClickHouseClientOptions, InflationRewardQueryLimits, kill_query_sql,
+        shard_tcp_query_timeout_for, split_table_reference, validate_gsfa_shard_layout_query,
     };
     use crate::clickhouse::{
         QueryCacheConfig, QueryFreshnessClass, RoutingPolicy, RoutingScope, RoutingTransport,
@@ -2106,6 +2174,28 @@ mod tests {
         assert!(!clause.contains("query_cache_min_query_runs"));
         assert!(clause.contains("max_execution_time=30"));
         assert!(!clause.contains("max_execution_time=8"));
+    }
+
+    #[test]
+    fn inflation_reward_settings_clause_applies_method_limits() {
+        let client = test_client_with_query_cache();
+        let client = ClickHouseClient {
+            inflation_reward_limits: InflationRewardQueryLimits {
+                query_timeout: Duration::from_millis(4_500),
+                max_threads: 3,
+                max_memory_bytes: 123_456,
+                max_bytes_to_read: 654_321,
+            },
+            ..client
+        };
+
+        let clause = client.inflation_reward_settings_clause("get_inflation_reward_test");
+
+        assert!(clause.contains("max_execution_time=5"));
+        assert!(clause.contains("max_threads=3"));
+        assert!(clause.contains("max_memory_usage=123456"));
+        assert!(clause.contains("max_bytes_to_read=654321"));
+        assert!(clause.contains("read_overflow_mode='throw'"));
     }
 
     #[tokio::test]

--- a/crates/superbank-rpc/src/clickhouse/mod.rs
+++ b/crates/superbank-rpc/src/clickhouse/mod.rs
@@ -16,7 +16,7 @@ mod transactions;
 mod types;
 mod util;
 
-pub use client::{ClickHouseClient, ClickHouseClientOptions};
+pub use client::{ClickHouseClient, ClickHouseClientOptions, InflationRewardQueryLimits};
 #[allow(unused_imports)]
 pub use types::TransactionsForAddressRecord;
 pub use types::{

--- a/crates/superbank-rpc/src/config.rs
+++ b/crates/superbank-rpc/src/config.rs
@@ -74,6 +74,50 @@ pub struct RpcConfig {
     #[arg(long, env = "RPC_BATCH_CONCURRENCY_LIMIT", default_value_t = 8)]
     pub(crate) rpc_batch_concurrency_limit: usize,
 
+    /// Maximum number of addresses accepted by getInflationReward; zero disables the limit.
+    #[arg(
+        long,
+        env = "GET_INFLATION_REWARD_MAX_ADDRESSES",
+        default_value_t = 100
+    )]
+    pub(crate) get_inflation_reward_max_addresses: usize,
+
+    /// Maximum concurrent getInflationReward workflows; zero disables method admission control.
+    #[arg(
+        long,
+        env = "GET_INFLATION_REWARD_MAX_CONCURRENCY",
+        default_value_t = 20
+    )]
+    pub(crate) get_inflation_reward_max_concurrency: usize,
+
+    /// End-to-end ClickHouse budget for one getInflationReward lookup (milliseconds).
+    #[arg(
+        long,
+        env = "GET_INFLATION_REWARD_QUERY_TIMEOUT_MS",
+        default_value_t = 5_000
+    )]
+    pub(crate) get_inflation_reward_query_timeout_ms: u64,
+
+    /// Per-query ClickHouse thread cap for getInflationReward.
+    #[arg(long, env = "GET_INFLATION_REWARD_MAX_THREADS", default_value_t = 2)]
+    pub(crate) get_inflation_reward_max_threads: usize,
+
+    /// Per-query ClickHouse memory cap for getInflationReward (bytes).
+    #[arg(
+        long,
+        env = "GET_INFLATION_REWARD_MAX_MEMORY_BYTES",
+        default_value_t = 536_870_912
+    )]
+    pub(crate) get_inflation_reward_max_memory_bytes: u64,
+
+    /// Per-query ClickHouse read cap for getInflationReward (bytes).
+    #[arg(
+        long,
+        env = "GET_INFLATION_REWARD_MAX_BYTES_TO_READ",
+        default_value_t = 536_870_912
+    )]
+    pub(crate) get_inflation_reward_max_bytes_to_read: u64,
+
     /// Emit HTTP 503 for JSON-RPC server-side failures while keeping response bodies unchanged.
     #[arg(long, env = "SUPERBANK_RPC_EMIT_HTTP_ERRORS", default_value_t = false)]
     pub(crate) emit_http_errors: bool,
@@ -690,6 +734,52 @@ mod config_tests {
         assert!(!cfg.metrics_capture_x_rpc_node());
         assert!(!cfg.metrics_capture_x_subscription_id());
         assert!(!cfg.metrics_capture_x_account_id());
+        assert_eq!(cfg.get_inflation_reward_max_addresses, 100);
+        assert_eq!(cfg.get_inflation_reward_max_concurrency, 20);
+        assert_eq!(cfg.get_inflation_reward_query_timeout_ms, 5_000);
+        assert_eq!(cfg.get_inflation_reward_max_threads, 2);
+        assert_eq!(cfg.get_inflation_reward_max_memory_bytes, 536_870_912);
+        assert_eq!(cfg.get_inflation_reward_max_bytes_to_read, 536_870_912);
+    }
+
+    #[test]
+    fn inflation_reward_limits_parse() {
+        let cfg = RpcConfig::parse_from([
+            "superbank-rpc",
+            "--get-inflation-reward-max-addresses",
+            "50",
+            "--get-inflation-reward-max-concurrency",
+            "3",
+            "--get-inflation-reward-query-timeout-ms",
+            "4000",
+            "--get-inflation-reward-max-threads",
+            "4",
+            "--get-inflation-reward-max-memory-bytes",
+            "268435456",
+            "--get-inflation-reward-max-bytes-to-read",
+            "1073741824",
+        ]);
+
+        assert_eq!(cfg.get_inflation_reward_max_addresses, 50);
+        assert_eq!(cfg.get_inflation_reward_max_concurrency, 3);
+        assert_eq!(cfg.get_inflation_reward_query_timeout_ms, 4_000);
+        assert_eq!(cfg.get_inflation_reward_max_threads, 4);
+        assert_eq!(cfg.get_inflation_reward_max_memory_bytes, 268_435_456);
+        assert_eq!(cfg.get_inflation_reward_max_bytes_to_read, 1_073_741_824);
+    }
+
+    #[test]
+    fn inflation_reward_admission_limits_accept_zero_as_disabled() {
+        let cfg = RpcConfig::parse_from([
+            "superbank-rpc",
+            "--get-inflation-reward-max-addresses",
+            "0",
+            "--get-inflation-reward-max-concurrency",
+            "0",
+        ]);
+
+        assert_eq!(cfg.get_inflation_reward_max_addresses, 0);
+        assert_eq!(cfg.get_inflation_reward_max_concurrency, 0);
     }
 
     #[test]

--- a/crates/superbank-rpc/src/handlers/blocks.rs
+++ b/crates/superbank-rpc/src/handlers/blocks.rs
@@ -2063,6 +2063,13 @@ pub(crate) async fn handle_get_blocks_with_limit(
     .await
 }
 
+fn inflation_reward_address_limit_exceeded(
+    max_addresses: Option<usize>,
+    address_count: usize,
+) -> bool {
+    max_addresses.is_some_and(|max_addresses| address_count > max_addresses)
+}
+
 pub(crate) async fn handle_get_inflation_reward(
     state: Arc<AppState>,
     id: Value,
@@ -2100,6 +2107,26 @@ pub(crate) async fn handle_get_inflation_reward(
             None,
         ));
     };
+
+    if inflation_reward_address_limit_exceeded(
+        state.get_inflation_reward_max_addresses,
+        addresses.len(),
+    ) {
+        let max_addresses = state
+            .get_inflation_reward_max_addresses
+            .expect("exceeded address limit must be enabled");
+        metrics::inflation_reward_rejection("address_limit");
+        route.invalid_params();
+        return Ok(json_rpc_error_response(
+            id,
+            -32602,
+            format!(
+                "Invalid params: too many addresses; maximum is {}",
+                max_addresses
+            ),
+            None,
+        ));
+    }
 
     let mut requested_pubkeys = Vec::with_capacity(addresses.len());
     for value in addresses {
@@ -2191,6 +2218,19 @@ pub(crate) async fn handle_get_inflation_reward(
                 context_slot_opt.expect("context slot must be resolved when epoch is omitted");
             (context_slot / DEFAULT_SLOTS_PER_EPOCH).saturating_sub(1)
         }
+    };
+
+    let _inflation_reward_permit = if let Some(semaphore) = &state.get_inflation_reward_sem {
+        match semaphore.clone().try_acquire_owned() {
+            Ok(permit) => Some(permit),
+            Err(_) => {
+                metrics::inflation_reward_rejection("concurrency");
+                route.rpc_error();
+                return Ok(json_rpc_node_unhealthy_response(id));
+            }
+        }
+    } else {
+        None
     };
 
     route.source_clickhouse();
@@ -2388,7 +2428,9 @@ pub(crate) async fn handle_minimum_ledger_slot(
 
 #[cfg(test)]
 mod tests {
-    use super::{classify_get_block_miss, merge_sorted_block_slots};
+    use super::{
+        classify_get_block_miss, inflation_reward_address_limit_exceeded, merge_sorted_block_slots,
+    };
     use solana_rpc_client_api::custom_error::JSON_RPC_SERVER_ERROR_BLOCK_NOT_AVAILABLE;
     use solana_rpc_client_api::custom_error::JSON_RPC_SERVER_ERROR_LONG_TERM_STORAGE_SLOT_SKIPPED;
 
@@ -2412,6 +2454,13 @@ mod tests {
     fn merge_sorted_block_slots_deduplicates_overlap() {
         let merged = merge_sorted_block_slots(vec![1, 2, 2, 3, 6], vec![2, 3, 4, 6, 7]);
         assert_eq!(merged, vec![1, 2, 3, 4, 6, 7]);
+    }
+
+    #[test]
+    fn inflation_reward_address_limit_can_be_disabled() {
+        assert!(!inflation_reward_address_limit_exceeded(None, usize::MAX));
+        assert!(!inflation_reward_address_limit_exceeded(Some(100), 100));
+        assert!(inflation_reward_address_limit_exceeded(Some(100), 101));
     }
 
     #[test]

--- a/crates/superbank-rpc/src/metrics.rs
+++ b/crates/superbank-rpc/src/metrics.rs
@@ -509,6 +509,9 @@ pub struct Metrics {
     rpc_blocks_slots_returned: Family<MethodLabels, Histogram>,
 
     backend_errors: Family<OperationLabels, Counter>,
+    inflation_reward_rejections: Family<BatchRejectLabels, Counter>,
+    inflation_reward_lookups: Family<OperationOutcomeLabels, Counter>,
+    inflation_reward_selected_blocks: Histogram,
 
     route_total: Family<RouteLabels, Counter>,
     slot_source: Family<SlotSourceLabels, Counter>,
@@ -606,6 +609,9 @@ impl Metrics {
             Family::new_with_constructor(block_slot_count_histogram as fn() -> Histogram);
 
         let backend_errors = Family::default();
+        let inflation_reward_rejections = Family::default();
+        let inflation_reward_lookups = Family::default();
+        let inflation_reward_selected_blocks = block_slot_count_histogram();
 
         let route_total = Family::default();
         let slot_source = Family::default();
@@ -740,6 +746,21 @@ impl Metrics {
             "rpc_backend_errors",
             "Backend (ClickHouse) errors encountered while serving RPC",
             backend_errors.clone(),
+        );
+        registry.register(
+            "rpc_inflation_reward_rejections_total",
+            "getInflationReward requests rejected by reason",
+            inflation_reward_rejections.clone(),
+        );
+        registry.register(
+            "rpc_inflation_reward_lookups_total",
+            "getInflationReward lookup outcomes by lookup path",
+            inflation_reward_lookups.clone(),
+        );
+        registry.register(
+            "rpc_inflation_reward_selected_blocks",
+            "Distribution of exact reward blocks selected by getInflationReward",
+            inflation_reward_selected_blocks.clone(),
         );
         registry.register(
             "rpc_route_total",
@@ -974,6 +995,9 @@ impl Metrics {
             rpc_response_overhead_seconds,
             rpc_blocks_slots_returned,
             backend_errors,
+            inflation_reward_rejections,
+            inflation_reward_lookups,
+            inflation_reward_selected_blocks,
             route_total,
             slot_source,
             clickhouse_latency_seconds,
@@ -1269,6 +1293,22 @@ impl Metrics {
         self.backend_errors.get_or_create(&labels).inc();
     }
 
+    pub fn inflation_reward_rejection(&self, reason: &str) {
+        let labels = Self::current_batch_reject_labels(reason);
+        self.inflation_reward_rejections
+            .get_or_create(&labels)
+            .inc();
+    }
+
+    pub fn inflation_reward_lookup(&self, path: &'static str, outcome: &'static str) {
+        let labels = Self::current_operation_outcome_labels(path, outcome);
+        self.inflation_reward_lookups.get_or_create(&labels).inc();
+    }
+
+    pub fn inflation_reward_selected_blocks(&self, blocks: usize) {
+        self.inflation_reward_selected_blocks.observe(blocks as f64);
+    }
+
     pub fn rpc_timeout(&self, method: &str) {
         let labels = Self::current_method_labels(method);
         self.rpc_timeouts.get_or_create(&labels).inc();
@@ -1491,6 +1531,24 @@ pub(crate) fn track_request(method: &str) -> Option<RequestTracker<'static>> {
 pub(crate) fn backend_error(operation: &str) {
     if let Some(metrics) = metrics() {
         metrics.backend_error(operation);
+    }
+}
+
+pub(crate) fn inflation_reward_rejection(reason: &str) {
+    if let Some(metrics) = metrics() {
+        metrics.inflation_reward_rejection(reason);
+    }
+}
+
+pub(crate) fn inflation_reward_lookup(path: &'static str, outcome: &'static str) {
+    if let Some(metrics) = metrics() {
+        metrics.inflation_reward_lookup(path, outcome);
+    }
+}
+
+pub(crate) fn inflation_reward_selected_blocks(blocks: usize) {
+    if let Some(metrics) = metrics() {
+        metrics.inflation_reward_selected_blocks(blocks);
     }
 }
 

--- a/crates/superbank-rpc/src/server.rs
+++ b/crates/superbank-rpc/src/server.rs
@@ -17,8 +17,8 @@ use tower_http::cors::CorsLayer;
 use tracing::{info, warn};
 
 use crate::clickhouse::{
-    ClickHouseClient, ClickHouseClientOptions, QueryCacheConfig, RoutingPolicy, RoutingScope,
-    RoutingTransport, ShardRoutingConfig,
+    ClickHouseClient, ClickHouseClientOptions, InflationRewardQueryLimits, QueryCacheConfig,
+    RoutingPolicy, RoutingScope, RoutingTransport, ShardRoutingConfig,
 };
 use crate::config::{
     ClickHouseScope, ClickHouseTransport, RpcConfig, has_usable_gsfa_hot_addresses,
@@ -130,6 +130,34 @@ pub async fn run_server(args: RpcConfig) -> RpcResult<()> {
             "CLICKHOUSE_QUERY_TIMEOUT_MS should remain below RPC_REQUEST_TIMEOUT_MS so the ClickHouse-side query cap fires before the outer RPC timeout"
         );
     }
+    if args.get_inflation_reward_max_addresses > 100 {
+        return Err(RpcError::Config(
+            "GET_INFLATION_REWARD_MAX_ADDRESSES must be 0 (disabled) or between 1 and 100"
+                .to_string(),
+        ));
+    }
+    if args.get_inflation_reward_max_threads == 0
+        || args.get_inflation_reward_max_memory_bytes == 0
+        || args.get_inflation_reward_max_bytes_to_read == 0
+        || args.get_inflation_reward_query_timeout_ms == 0
+    {
+        return Err(RpcError::Config(
+            "getInflationReward ClickHouse resource limits must all be greater than zero"
+                .to_string(),
+        ));
+    }
+    if args.get_inflation_reward_max_addresses == 0 {
+        warn!("getInflationReward address admission limit is disabled");
+    }
+    if args.get_inflation_reward_max_concurrency == 0 {
+        warn!("getInflationReward concurrency admission limit is disabled");
+    }
+    if args.get_inflation_reward_query_timeout_ms >= args.rpc_request_timeout_ms {
+        return Err(RpcError::Config(
+            "GET_INFLATION_REWARD_QUERY_TIMEOUT_MS must be below RPC_REQUEST_TIMEOUT_MS"
+                .to_string(),
+        ));
+    }
 
     // Initialize ClickHouse client
     let shard_routing = build_shard_routing_config(&args);
@@ -170,11 +198,22 @@ pub async fn run_server(args: RpcConfig) -> RpcResult<()> {
         ))
         .with_tcp_pool_sizing(args.clickhouse_tcp_pool_min, args.clickhouse_tcp_pool_max)
         .with_in_clause_chunk(args.clickhouse_in_clause_chunk)
-        .with_startup_table_check(args.clickhouse_startup_table_check),
+        .with_startup_table_check(args.clickhouse_startup_table_check)
+        .with_inflation_reward_limits(InflationRewardQueryLimits {
+            query_timeout: Duration::from_millis(args.get_inflation_reward_query_timeout_ms),
+            max_threads: args.get_inflation_reward_max_threads,
+            max_memory_bytes: args.get_inflation_reward_max_memory_bytes,
+            max_bytes_to_read: args.get_inflation_reward_max_bytes_to_read,
+        }),
     );
 
     // Verify ClickHouse connection
     clickhouse.create_tables().await?;
+    if !clickhouse.query_settings_enabled() {
+        warn!(
+            "ClickHouse query SETTINGS are disabled; getInflationReward query shape and RPC admission limits remain active, but ClickHouse-side thread, memory, read-byte, and execution-time caps cannot be applied"
+        );
+    }
 
     if let Err(err) = metrics::force_init() {
         warn!("Metrics initialization failed; metrics disabled: {err}");
@@ -283,6 +322,13 @@ pub async fn run_server(args: RpcConfig) -> RpcResult<()> {
         max_signatures_limit: args.max_signatures_limit,
         rpc_max_batch_size: args.rpc_max_batch_size.max(1),
         rpc_batch_concurrency_limit: args.rpc_batch_concurrency_limit.max(1),
+        get_inflation_reward_max_addresses: (args.get_inflation_reward_max_addresses > 0)
+            .then_some(args.get_inflation_reward_max_addresses),
+        get_inflation_reward_sem: (args.get_inflation_reward_max_concurrency > 0).then(|| {
+            Arc::new(tokio::sync::Semaphore::new(
+                args.get_inflation_reward_max_concurrency,
+            ))
+        }),
         latest_slot_cache: LatestSlotCache::new(Duration::from_millis(1000)),
         latest_block_height_cache: LatestBlockHeightCache::new(Duration::from_millis(1000)),
         rpc_request_timeout: Duration::from_millis(args.rpc_request_timeout_ms),

--- a/crates/superbank-rpc/src/state.rs
+++ b/crates/superbank-rpc/src/state.rs
@@ -34,6 +34,8 @@ pub(crate) struct AppState {
     pub(crate) max_signatures_limit: u64,
     pub(crate) rpc_max_batch_size: usize,
     pub(crate) rpc_batch_concurrency_limit: usize,
+    pub(crate) get_inflation_reward_max_addresses: Option<usize>,
+    pub(crate) get_inflation_reward_sem: Option<Arc<Semaphore>>,
     pub(crate) latest_slot_cache: LatestSlotCache,
     pub(crate) latest_block_height_cache: LatestBlockHeightCache,
     pub(crate) rpc_request_timeout: Duration,

--- a/crates/superbank-rpc/src/tests/mod.rs
+++ b/crates/superbank-rpc/src/tests/mod.rs
@@ -157,6 +157,8 @@ fn test_state_with_token_owner_activity_available(available: bool) -> Arc<AppSta
         max_signatures_limit: TEST_MAX_LIMIT,
         rpc_max_batch_size: 64,
         rpc_batch_concurrency_limit: 8,
+        get_inflation_reward_max_addresses: Some(100),
+        get_inflation_reward_sem: Some(Arc::new(Semaphore::new(1))),
         latest_slot_cache: cache,
         latest_block_height_cache: height_cache,
         rpc_request_timeout: Duration::from_millis(10_000),
@@ -236,6 +238,8 @@ fn test_state_with_clickhouse_url(clickhouse_url: &str) -> Arc<AppState> {
         max_signatures_limit: TEST_MAX_LIMIT,
         rpc_max_batch_size: 64,
         rpc_batch_concurrency_limit: 8,
+        get_inflation_reward_max_addresses: Some(100),
+        get_inflation_reward_sem: Some(Arc::new(Semaphore::new(1))),
         latest_slot_cache: cache,
         latest_block_height_cache: height_cache,
         rpc_request_timeout: Duration::from_millis(10_000),
@@ -291,6 +295,8 @@ async fn test_state_with_clickhouse_cached_signature_slot(
         max_signatures_limit: TEST_MAX_LIMIT,
         rpc_max_batch_size: 64,
         rpc_batch_concurrency_limit: 8,
+        get_inflation_reward_max_addresses: Some(100),
+        get_inflation_reward_sem: Some(Arc::new(Semaphore::new(1))),
         latest_slot_cache: cache,
         latest_block_height_cache: height_cache,
         rpc_request_timeout: Duration::from_millis(10_000),
@@ -338,6 +344,8 @@ fn test_state_with_head_cache(head_cache: Arc<HeadCache>) -> Arc<AppState> {
         max_signatures_limit: TEST_MAX_LIMIT,
         rpc_max_batch_size: 64,
         rpc_batch_concurrency_limit: 8,
+        get_inflation_reward_max_addresses: Some(100),
+        get_inflation_reward_sem: Some(Arc::new(Semaphore::new(1))),
         latest_slot_cache,
         latest_block_height_cache,
         rpc_request_timeout: Duration::from_millis(10_000),
@@ -387,6 +395,8 @@ fn test_state_with_head_cache_and_clickhouse_url(
         max_signatures_limit: TEST_MAX_LIMIT,
         rpc_max_batch_size: 64,
         rpc_batch_concurrency_limit: 8,
+        get_inflation_reward_max_addresses: Some(100),
+        get_inflation_reward_sem: Some(Arc::new(Semaphore::new(1))),
         latest_slot_cache,
         latest_block_height_cache,
         rpc_request_timeout: Duration::from_millis(10_000),
@@ -443,6 +453,8 @@ async fn test_state_with_head_cache_and_cached_signature_slot(
         max_signatures_limit: TEST_MAX_LIMIT,
         rpc_max_batch_size: 64,
         rpc_batch_concurrency_limit: 8,
+        get_inflation_reward_max_addresses: Some(100),
+        get_inflation_reward_sem: Some(Arc::new(Semaphore::new(1))),
         latest_slot_cache,
         latest_block_height_cache,
         rpc_request_timeout: Duration::from_millis(10_000),
@@ -2519,6 +2531,75 @@ async fn get_inflation_reward_rejects_invalid_address() {
     let err = parsed.error.expect("error present");
     assert_eq!(err.code, -32602);
     assert_eq!(err.message, "Invalid param: Invalid");
+}
+
+#[tokio::test]
+async fn get_inflation_reward_rejects_more_than_configured_address_limit() {
+    let state = test_state();
+    let address = Hash::new_unique().to_string();
+    let addresses = vec![address; 101];
+
+    let response = handle_get_inflation_reward(
+        state,
+        json!(1),
+        Some(vec![json!(addresses), json!({ "epoch": 0u64 })]),
+    )
+    .await
+    .expect("response");
+
+    let parsed = parse_json_rpc_response(response).await;
+    let err = parsed.error.expect("error present");
+    assert_eq!(err.code, -32602);
+    assert_eq!(
+        err.message,
+        "Invalid params: too many addresses; maximum is 100"
+    );
+}
+
+#[tokio::test]
+async fn get_inflation_reward_sheds_when_method_concurrency_is_exhausted() {
+    let state = test_state();
+    let _permit = state
+        .get_inflation_reward_sem
+        .as_ref()
+        .expect("concurrency admission enabled")
+        .clone()
+        .try_acquire_owned()
+        .expect("test permit");
+    let address = Hash::new_unique().to_string();
+
+    let response = handle_get_inflation_reward(
+        state,
+        json!(1),
+        Some(vec![json!([address]), json!({ "epoch": 0u64 })]),
+    )
+    .await
+    .expect("response");
+
+    let parsed = parse_json_rpc_response(response).await;
+    let err = parsed.error.expect("error present");
+    assert_eq!(err.code, -32005);
+    assert_eq!(err.message, "Node is unhealthy");
+}
+
+#[tokio::test]
+async fn get_inflation_reward_skips_method_admission_when_disabled() {
+    let mut state = test_state();
+    Arc::get_mut(&mut state)
+        .expect("test state should not be shared")
+        .get_inflation_reward_sem = None;
+
+    let response = handle_get_inflation_reward(
+        state,
+        json!(1),
+        Some(vec![json!([]), json!({ "epoch": 0u64 })]),
+    )
+    .await
+    .expect("response");
+
+    let parsed = parse_json_rpc_response(response).await;
+    assert!(parsed.error.is_none());
+    assert_eq!(parsed.result, Some(json!([])));
 }
 
 #[tokio::test]

--- a/scripts/dev/run-local-rpc.sh
+++ b/scripts/dev/run-local-rpc.sh
@@ -63,6 +63,12 @@ fi
 : "${RPC_MAX_BODY_BYTES:=1048576}"
 : "${RPC_REQUEST_TIMEOUT_MS:=10000}"
 : "${RPC_CONCURRENCY_LIMIT:=512}"
+: "${GET_INFLATION_REWARD_MAX_ADDRESSES:=100}"
+: "${GET_INFLATION_REWARD_MAX_CONCURRENCY:=20}"
+: "${GET_INFLATION_REWARD_QUERY_TIMEOUT_MS:=5000}"
+: "${GET_INFLATION_REWARD_MAX_THREADS:=2}"
+: "${GET_INFLATION_REWARD_MAX_MEMORY_BYTES:=536870912}"
+: "${GET_INFLATION_REWARD_MAX_BYTES_TO_READ:=536870912}"
 : "${HYDRATION_CPU_CONCURRENCY:=8}"
 
 : "${CLICKHOUSE_URL:=http://localhost:8123}"
@@ -224,6 +230,12 @@ export CLICKHOUSE_GSFA_STRICT_PAGINATION=1
   --rpc-max-body-bytes "${RPC_MAX_BODY_BYTES}" \
   --rpc-request-timeout-ms "${RPC_REQUEST_TIMEOUT_MS}" \
   --rpc-concurrency-limit "${RPC_CONCURRENCY_LIMIT}" \
+  --get-inflation-reward-max-addresses "${GET_INFLATION_REWARD_MAX_ADDRESSES}" \
+  --get-inflation-reward-max-concurrency "${GET_INFLATION_REWARD_MAX_CONCURRENCY}" \
+  --get-inflation-reward-query-timeout-ms "${GET_INFLATION_REWARD_QUERY_TIMEOUT_MS}" \
+  --get-inflation-reward-max-threads "${GET_INFLATION_REWARD_MAX_THREADS}" \
+  --get-inflation-reward-max-memory-bytes "${GET_INFLATION_REWARD_MAX_MEMORY_BYTES}" \
+  --get-inflation-reward-max-bytes-to-read "${GET_INFLATION_REWARD_MAX_BYTES_TO_READ}" \
   --host "${RPC_HOST}" \
   --port "${RPC_PORT}" \
   --metrics-host "${METRICS_HOST}" \

--- a/tests/k6/README.md
+++ b/tests/k6/README.md
@@ -349,6 +349,13 @@ k6 run tests/k6/scenarios/stress/stress-test-get-blocks.js \
 k6 run tests/k6/scenarios/stress/stress-test-get-first-available-block.js \
   -e RPC_URL=http://localhost:8899
 
+# getInflationReward (successful admitted calls plus expected -32005 shedding)
+k6 run tests/k6/scenarios/stress/stress-test-get-inflation-reward.js \
+  -e RPC_URL=http://localhost:8899 \
+  -e ADDRESS_FILE=./tests/k6/data/pools/addresses.txt \
+  -e INFLATION_REWARD_EPOCH=280 \
+  -e INFLATION_REWARD_ADDRESS_COUNT=18
+
 # getLatestBlockhash
 k6 run tests/k6/scenarios/stress/stress-test-get-latest-blockhash.js \
   -e RPC_URL=http://localhost:8899
@@ -794,6 +801,7 @@ tests/k6/
 │   │   └── superbank-rpc-validate-get-transactions-for-address.js # TFA endpoint comparison
 │   ├── stress/
 │   │   ├── stress-test.js          # Stress test (find breaking point)
+│   │   ├── stress-test-get-inflation-reward.js
 │   │   ├── stress-test-get-block.js
 │   │   ├── stress-test-get-block-height.js
 │   │   ├── stress-test-get-block-time.js

--- a/tests/k6/scenarios/stress/stress-test-get-inflation-reward.js
+++ b/tests/k6/scenarios/stress/stress-test-get-inflation-reward.js
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+/*
+ * Copyright 2025-2026 Triton One Limited. All rights reserved.
+ */
+
+// Stress test for the getInflationReward admission and ClickHouse resource guards.
+// An explicit historical epoch is required so this scenario does not add getSlot load.
+//
+// Usage:
+//   k6 run tests/k6/scenarios/stress/stress-test-get-inflation-reward.js \
+//     -e RPC_URL=http://localhost:8899 \
+//     -e ADDRESS_FILE=./tests/k6/data/pools/addresses.txt \
+//     -e INFLATION_REWARD_EPOCH=280 \
+//     -e INFLATION_REWARD_ADDRESS_COUNT=18
+
+import { check } from 'k6';
+import { Trend } from 'k6/metrics';
+import { config, scenarios } from '../../lib/config.js';
+import { initAddressPool } from '../../lib/addresses.js';
+import { executeRequest, makeGetInflationRewardRequest } from '../../lib/rpc.js';
+import {
+  addDownstreamMetrics,
+  collectJsonrpcErrorCodeCounts,
+} from '../../lib/summary.js';
+
+if (config.inflationRewardEpoch === null) {
+  throw new Error('INFLATION_REWARD_EPOCH is required for this stress scenario.');
+}
+
+const addressPool = initAddressPool();
+if (addressPool.length === 0) {
+  throw new Error('The configured address pool is empty.');
+}
+
+const addressCount = Math.min(
+  config.inflationRewardAddressCount,
+  addressPool.length
+);
+const inflationRewardLatency = new Trend(
+  'rpc_getInflationReward_latency',
+  true
+);
+
+export const options = {
+  scenarios: {
+    stress: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: scenarios.stress.stages,
+      gracefulRampDown: '30s',
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate==0.0'],
+    checks: ['rate==1.0'],
+    rpc_getInflationReward_latency: ['p(95)<5000'],
+  },
+};
+
+function addressesForVu() {
+  const start = (__VU * addressCount) % addressPool.length;
+  const addresses = [];
+  for (let offset = 0; offset < addressCount; offset += 1) {
+    addresses.push(addressPool[(start + offset) % addressPool.length]);
+  }
+  return addresses;
+}
+
+export default function () {
+  const payload = makeGetInflationRewardRequest(
+    addressesForVu(),
+    {
+      epoch: config.inflationRewardEpoch,
+      commitment: config.inflationRewardCommitment,
+    }
+  );
+  const result = executeRequest(payload, {
+    rpcUrl: config.rpcUrl,
+    latencyMetric: inflationRewardLatency,
+  });
+  const errorCode = result.body?.error?.code;
+
+  check(result, {
+    'status is 200': ({ response }) => response.status === 200,
+    'request succeeds or is explicitly shed': () =>
+      errorCode === undefined || errorCode === -32005,
+  });
+}
+
+export function handleSummary(data) {
+  const jsonrpcCodes = collectJsonrpcErrorCodeCounts(data);
+  const summary = {
+    testType: 'stress-get-inflation-reward',
+    timestamp: new Date().toISOString(),
+    config: {
+      rpcUrl: config.rpcUrl,
+      epoch: config.inflationRewardEpoch,
+      addressCount,
+      commitment: config.inflationRewardCommitment,
+    },
+    metrics: {
+      requests: {
+        total: data.metrics.rpc_requests_total?.values?.count || 0,
+        successful: data.metrics.rpc_requests_success?.values?.count || 0,
+      },
+      latency: {
+        p95:
+          data.metrics.rpc_getInflationReward_latency?.values['p(95)'] || 0,
+        p99:
+          data.metrics.rpc_getInflationReward_latency?.values['p(99)'] || 0,
+        max: data.metrics.rpc_getInflationReward_latency?.values?.max || 0,
+      },
+      errors: {
+        jsonrpcTotal: jsonrpcCodes.total,
+        jsonrpcByCode: jsonrpcCodes.byCode,
+      },
+    },
+  };
+
+  addDownstreamMetrics(data, summary.metrics);
+  return { stdout: JSON.stringify(summary, null, 2) + '\n' };
+}


### PR DESCRIPTION
A recent issue at Triton surfaced a less-than-ideal query semantic for the getInflationReward method.

It scanned the entire payout epoch—roughly 432,000 slots—and read/expanded the large reward arrays before filtering for the requested addresses. For partitioned reward epochs, this caused excessive I/O, CPU, and memory pressure and could overwhelm or restart ClickHouse instances.

This new implementation follows Solana’s deterministic reward-partition algorithm:

  - Find the payout epoch boundary block.
  - Read vote rewards from that boundary block.
  - Use the boundary blockhash to calculate the exact reward partition for each requested address.
  - Query only the required partition slots instead of scanning the complete epoch.
  - Preserve the original request ordering, duplicates, and null results.

  I also added safety controls:

  - Maximum addresses: default 100; 0 disables the check.
  - Maximum concurrent workflows: default 20; 0 disables admission control.
  - Five-second query timeout.
  - Per-query limits of two threads, 512 MB memory, and 512 MB read volume.
  - Best-effort cleanup for cancelled or timed-out ClickHouse queries.
  - Metrics, structured logging, validation tests, and a dedicated k6 stress scenario.

In production-linked testing, the original 18-address epoch-280 request completed in about 1.08 seconds and read approximately 29.7 MB compared to 15.5 seconds and 32.8GB of data read in the previous implementation.

A partitioned epoch selected only 18 required blocks, read approximately 46.2 MB, and matched Solana’s results exactly.