### PR TITLE
Codex/program address filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ curl -sS http://localhost:8899 \
   Fumarole ingest includes a default memory soft-limit backpressure guard; set
   `fumarole-memory-soft-limit-bytes: 0` only if you want to disable it.
 - `superbank-rpc` is configured via CLI flags and environment variables.
-  It can also read RPC parameter filters from the shared YAML file when started
+  It can also read RPC method and parameter filters from the shared YAML file when started
   with `--config superbank.yaml` / `SUPERBANK_CONFIG=superbank.yaml`.
   See `crates/superbank-rpc/README.md`.
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ curl -sS http://localhost:8899 \
   Fumarole ingest includes a default memory soft-limit backpressure guard; set
   `fumarole-memory-soft-limit-bytes: 0` only if you want to disable it.
 - `superbank-rpc` is configured via CLI flags and environment variables.
+  It can also read RPC parameter filters from the shared YAML file when started
+  with `--config superbank.yaml` / `SUPERBANK_CONFIG=superbank.yaml`.
   See `crates/superbank-rpc/README.md`.
 
 ## Docker local development

--- a/crates/superbank-rpc/README.md
+++ b/crates/superbank-rpc/README.md
@@ -112,6 +112,8 @@ dispatch or use any cache or ClickHouse resources. Pass the shared YAML configur
 rpc-parameter-filters:
   - [getSignaturesForAddress, ComputeBudget111111111111111111111111111111]
   - [getTransactionsForAddress, ComputeBudget111111111111111111111111111111]
+  - [getSignaturesForAddress, Vote111111111111111111111111111111111111111, {before: any}]
+  - [getTransactionsForAddress, MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr, {paginationToken: any}]
   - [getTransactionsForAddress, So11111111111111111111111111111111111111112, {transactionDetails: signatures}]
 ```
 
@@ -123,7 +125,15 @@ method-only entry matches an explicitly empty `params: []` array; omitted `param
 There is one address-wide form: an entry containing only `getSignaturesForAddress` or
 `getTransactionsForAddress` and a string address matches that address as the first request
 parameter regardless of any trailing configuration object. Add one entry for each method to block
-both forms of address-history lookup. Full entries for these methods remain exact.
+both forms of address-history lookup. Entries with a config object use the exact or
+cursor-conditional behavior described below.
+
+There is also a cursor-conditional address form. A three-value `getSignaturesForAddress` entry
+whose config object contains `before` or `until` matches that address whenever either request
+cursor is present and non-null. A `getTransactionsForAddress` entry containing `paginationToken`
+does the same for a non-null pagination token. The values and all other fields in the filter's
+config object are markers only and are ignored, as are unrelated fields in the request config.
+Missing and JSON `null` cursors do not match. Full entries without these cursor keys remain exact.
 
 A matching call returns HTTP `405 Method Not Allowed` and preserves the request ID in a JSON-RPC
 error with code `-32601` and message `Method not allowed`. In a mixed batch, allowed calls still

--- a/crates/superbank-rpc/README.md
+++ b/crates/superbank-rpc/README.md
@@ -102,7 +102,7 @@ CLICKHOUSE_URL=http://localhost:8123 CLICKHOUSE_DATABASE=default \
 cargo run -p superbank-rpc --
 ```
 
-## Exact method and parameter filters
+## Method and parameter filters
 
 `superbank-rpc` can reject configured method and parameter combinations before they enter handler
 dispatch or use any cache or ClickHouse resources. Pass the shared YAML configuration with
@@ -110,14 +110,20 @@ dispatch or use any cache or ClickHouse resources. Pass the shared YAML configur
 
 ```yaml
 rpc-parameter-filters:
-  - [getTransactionsForAddress, So11111111111111111111111111111111111111112]
+  - [getSignaturesForAddress, ComputeBudget111111111111111111111111111111]
+  - [getTransactionsForAddress, ComputeBudget111111111111111111111111111111]
   - [getTransactionsForAddress, So11111111111111111111111111111111111111112, {transactionDetails: signatures}]
 ```
 
-Each entry contains the case-sensitive method followed by its complete parameter array. Matching
-is structural and exact: parameter count, array order, JSON types, and values must match; mapping
-key order does not matter. Extra parameters do not match. A method-only entry matches an explicitly
-empty `params: []` array; omitted `params` is distinct.
+Each entry contains the case-sensitive method followed by its complete parameter array. Except for
+the address-wide form below, matching is structural and exact: parameter count, array order, JSON
+types, and values must match; mapping key order does not matter. Extra parameters do not match. A
+method-only entry matches an explicitly empty `params: []` array; omitted `params` is distinct.
+
+There is one address-wide form: an entry containing only `getSignaturesForAddress` or
+`getTransactionsForAddress` and a string address matches that address as the first request
+parameter regardless of any trailing configuration object. Add one entry for each method to block
+both forms of address-history lookup. Full entries for these methods remain exact.
 
 A matching call returns HTTP `405 Method Not Allowed` and preserves the request ID in a JSON-RPC
 error with code `-32601` and message `Method not allowed`. In a mixed batch, allowed calls still

--- a/crates/superbank-rpc/README.md
+++ b/crates/superbank-rpc/README.md
@@ -102,6 +102,29 @@ CLICKHOUSE_URL=http://localhost:8123 CLICKHOUSE_DATABASE=default \
 cargo run -p superbank-rpc --
 ```
 
+## Exact method and parameter filters
+
+`superbank-rpc` can reject configured method and parameter combinations before they enter handler
+dispatch or use any cache or ClickHouse resources. Pass the shared YAML configuration with
+`--config superbank.yaml` or `SUPERBANK_CONFIG=superbank.yaml` and add:
+
+```yaml
+rpc-parameter-filters:
+  - [getTransactionsForAddress, So11111111111111111111111111111111111111112]
+  - [getTransactionsForAddress, So11111111111111111111111111111111111111112, {transactionDetails: signatures}]
+```
+
+Each entry contains the case-sensitive method followed by its complete parameter array. Matching
+is structural and exact: parameter count, array order, JSON types, and values must match; mapping
+key order does not matter. Extra parameters do not match. A method-only entry matches an explicitly
+empty `params: []` array; omitted `params` is distinct.
+
+A matching call returns HTTP `405 Method Not Allowed` and preserves the request ID in a JSON-RPC
+error with code `-32601` and message `Method not allowed`. In a mixed batch, allowed calls still
+execute and matched calls receive individual errors in their original positions; the batch HTTP
+status is 405 if any item matched. Filters are validated and indexed once at startup, so changing
+the file requires restarting `superbank-rpc`.
+
 ## Optional Superbank gRPC streaming (`grpc-streaming`)
 
 When compiled with `--features grpc-streaming` and enabled at runtime, superbank-rpc serves a

--- a/crates/superbank-rpc/README.md
+++ b/crates/superbank-rpc/README.md
@@ -109,6 +109,9 @@ dispatch or use any cache or ClickHouse resources. Pass the shared YAML configur
 `--config superbank.yaml` or `SUPERBANK_CONFIG=superbank.yaml` and add:
 
 ```yaml
+rpc-method-filters:
+  - getTransactionsForAddress
+
 rpc-parameter-filters:
   - [getSignaturesForAddress, ComputeBudget111111111111111111111111111111]
   - [getTransactionsForAddress, ComputeBudget111111111111111111111111111111]
@@ -117,10 +120,15 @@ rpc-parameter-filters:
   - [getTransactionsForAddress, So11111111111111111111111111111111111111112, {transactionDetails: signatures}]
 ```
 
-Each entry contains the case-sensitive method followed by its complete parameter array. Except for
-the address-wide form below, matching is structural and exact: parameter count, array order, JSON
-types, and values must match; mapping key order does not matter. Extra parameters do not match. A
-method-only entry matches an explicitly empty `params: []` array; omitted `params` is distinct.
+Each case-sensitive `rpc-method-filters` entry blocks every request for that method regardless of
+whether `params` is omitted, empty, or populated. Duplicate entries are removed and blank method
+names fail startup validation. This is the simplest way to disable a method temporarily.
+
+Each `rpc-parameter-filters` entry contains the case-sensitive method followed by its complete
+parameter array. Except for the address-wide form below, matching is structural and exact:
+parameter count, array order, JSON types, and values must match; mapping key order does not matter.
+Extra parameters do not match. A method-only parameter entry matches an explicitly empty
+`params: []` array; omitted `params` is distinct.
 
 There is one address-wide form: an entry containing only `getSignaturesForAddress` or
 `getTransactionsForAddress` and a string address matches that address as the first request
@@ -138,8 +146,8 @@ Missing and JSON `null` cursors do not match. Full entries without these cursor 
 A matching call returns HTTP `405 Method Not Allowed` and preserves the request ID in a JSON-RPC
 error with code `-32601` and message `Method not allowed`. In a mixed batch, allowed calls still
 execute and matched calls receive individual errors in their original positions; the batch HTTP
-status is 405 if any item matched. Filters are validated and indexed once at startup, so changing
-the file requires restarting `superbank-rpc`.
+status is 405 if any item matched. Method and parameter filters are validated and indexed once at
+startup, so changing the file requires restarting `superbank-rpc`.
 
 ## Optional Superbank gRPC streaming (`grpc-streaming`)
 

--- a/crates/superbank-rpc/src/config.rs
+++ b/crates/superbank-rpc/src/config.rs
@@ -3,7 +3,7 @@
  * Copyright 2025-2026 Triton One Limited. All rights reserved.
  */
 
-use std::str::FromStr;
+use std::{path::PathBuf, str::FromStr};
 
 use clap::{ArgAction, Parser};
 use solana_sdk::pubkey::Pubkey;
@@ -54,6 +54,10 @@ pub enum PyroscopeCompression {
     about = "Solana RPC server serving data from ClickHouse"
 )]
 pub struct RpcConfig {
+    /// Path to the shared YAML configuration file.
+    #[arg(long, env = "SUPERBANK_CONFIG", value_name = "PATH")]
+    pub(crate) config: Option<PathBuf>,
+
     /// Maximum accepted JSON-RPC request body size (bytes).
     #[arg(long, env = "RPC_MAX_BODY_BYTES", default_value_t = 1_048_576)]
     pub(crate) rpc_max_body_bytes: usize,
@@ -740,6 +744,17 @@ mod config_tests {
         assert_eq!(cfg.get_inflation_reward_max_threads, 2);
         assert_eq!(cfg.get_inflation_reward_max_memory_bytes, 536_870_912);
         assert_eq!(cfg.get_inflation_reward_max_bytes_to_read, 536_870_912);
+    }
+
+    #[test]
+    fn shared_config_path_flag_parses() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let cfg = RpcConfig::parse_from(["superbank-rpc", "--config", "superbank.yaml"]);
+
+        assert_eq!(
+            cfg.config.as_deref(),
+            Some(std::path::Path::new("superbank.yaml"))
+        );
     }
 
     #[test]

--- a/crates/superbank-rpc/src/handlers/mod.rs
+++ b/crates/superbank-rpc/src/handlers/mod.rs
@@ -56,6 +56,8 @@ const ROUTE_HEADER_LABEL_MISSING: &str = "missing";
 const JSON_RPC_INTERNAL_ERROR_CODE: i64 = -32603;
 const JSON_RPC_REQUEST_TIMEOUT_CODE: i64 = -32000;
 const JSON_RPC_REQUEST_TIMEOUT_MESSAGE: &str = "Request timeout";
+const JSON_RPC_METHOD_NOT_ALLOWED_CODE: i32 = -32601;
+const JSON_RPC_METHOD_NOT_ALLOWED_MESSAGE: &str = "Method not allowed";
 const HEADER_X_ENDPOINT: &str = "X-Endpoint";
 const HEADER_X_RPC_NODE: &str = "X-RPC-Node";
 const HEADER_X_SUBSCRIPTION_ID: &str = "X-Subscription-ID";
@@ -639,6 +641,32 @@ fn json_rpc_error_value(
     Value::Object(response)
 }
 
+fn observe_parameter_filter_match(method: &str) {
+    if let Some(tracker) = metrics::track_request(metrics_method_label(method)) {
+        tracker.observe(StatusCode::METHOD_NOT_ALLOWED);
+    }
+}
+
+fn parameter_filter_response(id: Value) -> Response {
+    let mut response = json_rpc_error_response(
+        id,
+        JSON_RPC_METHOD_NOT_ALLOWED_CODE,
+        JSON_RPC_METHOD_NOT_ALLOWED_MESSAGE,
+        None,
+    );
+    *response.status_mut() = StatusCode::METHOD_NOT_ALLOWED;
+    response
+}
+
+fn parameter_filter_response_value(id: Value) -> Value {
+    json_rpc_error_value(
+        id,
+        JSON_RPC_METHOD_NOT_ALLOWED_CODE,
+        JSON_RPC_METHOD_NOT_ALLOWED_MESSAGE,
+        None,
+    )
+}
+
 fn is_http_503_eligible_json_rpc_error(code: i64, message: Option<&str>) -> bool {
     if code == JSON_RPC_INTERNAL_ERROR_CODE {
         return true;
@@ -1059,6 +1087,19 @@ async fn handle_single_request(
         }
     };
 
+    if state
+        .rpc_parameter_filters
+        .matches(&request.method, request.params.as_deref())
+    {
+        let method = request.method;
+        let id = request.id.unwrap_or(Value::Null);
+        return metrics::with_request_metric_labels(request_metric_labels, async move {
+            observe_parameter_filter_match(&method);
+            Ok(parameter_filter_response(id))
+        })
+        .await;
+    }
+
     let timeout = state.rpc_request_timeout;
     let dispatch_request = request.into_dispatch_request();
     let response = metrics::with_request_metric_labels(
@@ -1084,10 +1125,23 @@ async fn execute_batch_requests(
 
     let mut responses: Vec<Option<BatchItemResponse>> = (0..batch_len).map(|_| None).collect();
     let mut join_set: JoinSet<BatchTaskOutput> = JoinSet::new();
+    let mut parameter_filter_matched = false;
 
     for (idx, request_value) in requests.into_iter().enumerate() {
         match parse_json_rpc_request(request_value) {
             Ok(request) => {
+                if state
+                    .rpc_parameter_filters
+                    .matches(&request.method, request.params.as_deref())
+                {
+                    observe_parameter_filter_match(&request.method);
+                    responses[idx] = Some(parameter_filter_response_value(
+                        request.id.unwrap_or(Value::Null),
+                    ));
+                    parameter_filter_matched = true;
+                    continue;
+                }
+
                 let response_id = request.id.clone().unwrap_or(Value::Null);
                 let dispatch_request = request.into_dispatch_request();
                 let state = state.clone();
@@ -1159,7 +1213,11 @@ async fn execute_batch_requests(
         response_values.push(value);
     }
 
-    Ok(Json(Value::Array(response_values)).into_response())
+    let mut response = Json(Value::Array(response_values)).into_response();
+    if parameter_filter_matched {
+        *response.status_mut() = StatusCode::METHOD_NOT_ALLOWED;
+    }
+    Ok(response)
 }
 
 async fn handle_batch_request(

--- a/crates/superbank-rpc/src/lib.rs
+++ b/crates/superbank-rpc/src/lib.rs
@@ -8,6 +8,7 @@
 mod clickhouse;
 mod metrics;
 mod processing;
+mod request_filter;
 
 mod config;
 #[cfg(feature = "disk-cache")]

--- a/crates/superbank-rpc/src/request_filter.rs
+++ b/crates/superbank-rpc/src/request_filter.rs
@@ -22,6 +22,8 @@ struct RpcFileConfig {
 ///
 /// The first lookup excludes unfiltered methods. The arity lookup then excludes
 /// differently-shaped calls before any structural JSON comparisons are needed.
+/// Single-address filters for address-history methods also match requests with
+/// trailing configuration parameters.
 #[derive(Debug, Default)]
 pub(crate) struct RpcParameterFilterSet {
     by_method_and_arity: HashMap<String, HashMap<usize, Vec<Vec<Value>>>>,
@@ -48,10 +50,17 @@ impl RpcParameterFilterSet {
         let Some(params) = params else {
             return false;
         };
-        self.by_method_and_arity
-            .get(method)
-            .and_then(|by_arity| by_arity.get(&params.len()))
+        let Some(by_arity) = self.by_method_and_arity.get(method) else {
+            return false;
+        };
+        if by_arity
+            .get(&params.len())
             .is_some_and(|candidates| candidates.iter().any(|candidate| candidate == params))
+        {
+            return true;
+        }
+
+        Self::matches_address_wide_filter(method, params, by_arity)
     }
 
     pub(crate) fn len(&self) -> usize {
@@ -103,6 +112,28 @@ impl RpcParameterFilterSet {
             source.display()
         )
     }
+
+    fn matches_address_wide_filter(
+        method: &str,
+        params: &[Value],
+        by_arity: &HashMap<usize, Vec<Vec<Value>>>,
+    ) -> bool {
+        if !matches!(
+            method,
+            "getSignaturesForAddress" | "getTransactionsForAddress"
+        ) {
+            return false;
+        }
+        let Some(address) = params.first().and_then(Value::as_str) else {
+            return false;
+        };
+
+        by_arity.get(&1).is_some_and(|candidates| {
+            candidates
+                .iter()
+                .any(|candidate| candidate.first().and_then(Value::as_str) == Some(address))
+        })
+    }
 }
 
 #[cfg(test)]
@@ -149,6 +180,32 @@ mod tests {
         ]]);
 
         assert!(filters.matches("getThing", Some(&[json!({"second": 2, "first": 1})])));
+    }
+
+    #[test]
+    fn address_only_filters_match_trailing_configs_for_address_history_methods() {
+        let address = "ComputeBudget111111111111111111111111111111";
+        let filters = filters(vec![
+            vec![json!("getSignaturesForAddress"), json!(address)],
+            vec![json!("getTransactionsForAddress"), json!(address)],
+        ]);
+
+        for method in ["getSignaturesForAddress", "getTransactionsForAddress"] {
+            assert!(filters.matches(method, Some(&[json!(address)])));
+            assert!(filters.matches(method, Some(&[json!(address), json!({"limit": 25})])));
+            assert!(!filters.matches(method, Some(&[json!("other-address"), json!({})])));
+        }
+    }
+
+    #[test]
+    fn address_wide_matching_requires_a_string_address() {
+        let filters = filters(vec![vec![json!("getSignaturesForAddress"), json!(42)]]);
+
+        assert!(filters.matches("getSignaturesForAddress", Some(&[json!(42)])));
+        assert!(!filters.matches(
+            "getSignaturesForAddress",
+            Some(&[json!(42), json!({"limit": 10})])
+        ));
     }
 
     #[test]

--- a/crates/superbank-rpc/src/request_filter.rs
+++ b/crates/superbank-rpc/src/request_filter.rs
@@ -15,6 +15,7 @@ use serde_json::Value;
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 struct RpcFileConfig {
+    rpc_method_filters: Vec<String>,
     rpc_parameter_filters: Vec<Vec<Value>>,
 }
 
@@ -28,6 +29,7 @@ struct RpcFileConfig {
 /// fields other than cursor presence do not require structural comparisons.
 #[derive(Debug, Default)]
 pub(crate) struct RpcParameterFilterSet {
+    blocked_methods: HashSet<String>,
     by_method_and_arity: HashMap<String, HashMap<usize, Vec<Vec<Value>>>>,
     cursor_filtered_addresses: HashMap<String, HashSet<String>>,
     len: usize,
@@ -43,12 +45,19 @@ impl RpcParameterFilterSet {
             .map_err(|err| format!("failed to read config file '{}': {err}", path.display()))?;
         let config: RpcFileConfig = serde_yaml::from_str(&contents)
             .map_err(|err| format!("failed to parse config file '{}': {err}", path.display()))?;
-        Self::from_entries(config.rpc_parameter_filters, Some(path))
+        Self::from_config(
+            config.rpc_method_filters,
+            config.rpc_parameter_filters,
+            Some(path),
+        )
     }
 
     pub(crate) fn matches(&self, method: &str, params: Option<&[Value]>) -> bool {
         if self.len == 0 {
             return false;
+        }
+        if self.blocked_methods.contains(method) {
+            return true;
         }
         let Some(params) = params else {
             return false;
@@ -73,11 +82,33 @@ impl RpcParameterFilterSet {
         self.len
     }
 
+    #[cfg(test)]
     pub(crate) fn from_entries(
         entries: Vec<Vec<Value>>,
         path: Option<&Path>,
     ) -> Result<Self, String> {
+        Self::from_config(Vec::new(), entries, path)
+    }
+
+    pub(crate) fn from_config(
+        methods: Vec<String>,
+        entries: Vec<Vec<Value>>,
+        path: Option<&Path>,
+    ) -> Result<Self, String> {
         let mut filters = Self::default();
+        for (index, method) in methods.into_iter().enumerate() {
+            if method.trim().is_empty() {
+                return Err(Self::method_entry_error(
+                    path,
+                    index,
+                    "method must not be empty",
+                ));
+            }
+            if filters.blocked_methods.insert(method) {
+                filters.len += 1;
+            }
+        }
+
         for (index, mut entry) in entries.into_iter().enumerate() {
             if entry.is_empty() {
                 return Err(Self::entry_error(path, index, "entry must not be empty"));
@@ -118,6 +149,17 @@ impl RpcParameterFilterSet {
             }
         }
         Ok(filters)
+    }
+
+    fn method_entry_error(path: Option<&Path>, index: usize, message: &str) -> String {
+        let source = path
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("<inline>"));
+        format!(
+            "invalid rpc-method-filters entry {} in '{}': {message}",
+            index + 1,
+            source.display()
+        )
     }
 
     fn entry_error(path: Option<&Path>, index: usize, message: &str) -> String {
@@ -201,6 +243,15 @@ mod tests {
         RpcParameterFilterSet::from_entries(entries, None).expect("valid filters")
     }
 
+    fn filters_with_methods(methods: Vec<&str>, entries: Vec<Vec<Value>>) -> RpcParameterFilterSet {
+        RpcParameterFilterSet::from_config(
+            methods.into_iter().map(str::to_owned).collect(),
+            entries,
+            None,
+        )
+        .expect("valid filters")
+    }
+
     use serde_json::Value;
 
     #[test]
@@ -225,6 +276,34 @@ mod tests {
             Some(&[json!("address"), json!({"mode": "full"}), json!(true)])
         ));
         assert!(!filters.matches("getThing", None));
+    }
+
+    #[test]
+    fn method_filters_match_any_parameter_shape() {
+        let filters = filters_with_methods(vec!["getTransactionsForAddress"], Vec::new());
+
+        assert!(filters.matches("getTransactionsForAddress", None));
+        assert!(filters.matches("getTransactionsForAddress", Some(&[])));
+        assert!(filters.matches(
+            "getTransactionsForAddress",
+            Some(&[json!("address"), json!({"limit": 25})])
+        ));
+        assert!(!filters.matches("gettransactionsforaddress", None));
+        assert!(!filters.matches("getSignaturesForAddress", None));
+    }
+
+    #[test]
+    fn method_filters_are_deduplicated_and_reject_blank_names() {
+        let filters = filters_with_methods(
+            vec!["getTransactionsForAddress", "getTransactionsForAddress"],
+            Vec::new(),
+        );
+        assert_eq!(filters.len(), 1);
+
+        let err = RpcParameterFilterSet::from_config(vec!["  ".to_string()], Vec::new(), None)
+            .expect_err("blank method must fail");
+        assert!(err.contains("rpc-method-filters entry 1"));
+        assert!(err.contains("method must not be empty"));
     }
 
     #[test]
@@ -378,11 +457,15 @@ source: grpc
 endpoint: https://example.invalid
 rpc-parameter-filters:
   - [getThing, address]
+rpc-method-filters:
+  - getTransactionsForAddress
 "#,
         )
         .expect("write config");
 
         let filters = RpcParameterFilterSet::load(Some(&path)).expect("load config");
         assert!(filters.matches("getThing", Some(&[json!("address")])));
+        assert!(filters.matches("getTransactionsForAddress", None));
+        assert_eq!(filters.len(), 2);
     }
 }

--- a/crates/superbank-rpc/src/request_filter.rs
+++ b/crates/superbank-rpc/src/request_filter.rs
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+/*
+ * Copyright 2025-2026 Triton One Limited. All rights reserved.
+ */
+
+use std::{
+    collections::HashMap,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use serde::Deserialize;
+use serde_json::Value;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, rename_all = "kebab-case")]
+struct RpcFileConfig {
+    rpc_parameter_filters: Vec<Vec<Value>>,
+}
+
+/// Startup-compiled RPC request filters.
+///
+/// The first lookup excludes unfiltered methods. The arity lookup then excludes
+/// differently-shaped calls before any structural JSON comparisons are needed.
+#[derive(Debug, Default)]
+pub(crate) struct RpcParameterFilterSet {
+    by_method_and_arity: HashMap<String, HashMap<usize, Vec<Vec<Value>>>>,
+    len: usize,
+}
+
+impl RpcParameterFilterSet {
+    pub(crate) fn load(path: Option<&Path>) -> Result<Self, String> {
+        let Some(path) = path else {
+            return Ok(Self::default());
+        };
+
+        let contents = fs::read_to_string(path)
+            .map_err(|err| format!("failed to read config file '{}': {err}", path.display()))?;
+        let config: RpcFileConfig = serde_yaml::from_str(&contents)
+            .map_err(|err| format!("failed to parse config file '{}': {err}", path.display()))?;
+        Self::from_entries(config.rpc_parameter_filters, Some(path))
+    }
+
+    pub(crate) fn matches(&self, method: &str, params: Option<&[Value]>) -> bool {
+        if self.len == 0 {
+            return false;
+        }
+        let Some(params) = params else {
+            return false;
+        };
+        self.by_method_and_arity
+            .get(method)
+            .and_then(|by_arity| by_arity.get(&params.len()))
+            .is_some_and(|candidates| candidates.iter().any(|candidate| candidate == params))
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.len
+    }
+
+    pub(crate) fn from_entries(
+        entries: Vec<Vec<Value>>,
+        path: Option<&Path>,
+    ) -> Result<Self, String> {
+        let mut filters = Self::default();
+        for (index, mut entry) in entries.into_iter().enumerate() {
+            if entry.is_empty() {
+                return Err(Self::entry_error(path, index, "entry must not be empty"));
+            }
+            let method = entry.remove(0);
+            let Value::String(method) = method else {
+                return Err(Self::entry_error(
+                    path,
+                    index,
+                    "first value must be a method string",
+                ));
+            };
+            if method.trim().is_empty() {
+                return Err(Self::entry_error(path, index, "method must not be empty"));
+            }
+
+            let candidates = filters
+                .by_method_and_arity
+                .entry(method)
+                .or_default()
+                .entry(entry.len())
+                .or_default();
+            if !candidates.contains(&entry) {
+                candidates.push(entry);
+                filters.len += 1;
+            }
+        }
+        Ok(filters)
+    }
+
+    fn entry_error(path: Option<&Path>, index: usize, message: &str) -> String {
+        let source = path
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("<inline>"));
+        format!(
+            "invalid rpc-parameter-filters entry {} in '{}': {message}",
+            index + 1,
+            source.display()
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::RpcParameterFilterSet;
+
+    fn filters(entries: Vec<Vec<Value>>) -> RpcParameterFilterSet {
+        RpcParameterFilterSet::from_entries(entries, None).expect("valid filters")
+    }
+
+    use serde_json::Value;
+
+    #[test]
+    fn exact_match_is_indexed_by_method_and_arity() {
+        let filters = filters(vec![
+            vec![json!("getThing"), json!("address")],
+            vec![json!("getThing"), json!("address"), json!({"mode": "full"})],
+        ]);
+
+        assert!(filters.matches("getThing", Some(&[json!("address")])));
+        assert!(filters.matches(
+            "getThing",
+            Some(&[json!("address"), json!({"mode": "full"})])
+        ));
+        assert!(!filters.matches("getthing", Some(&[json!("address")])));
+        assert!(!filters.matches(
+            "getThing",
+            Some(&[json!("address"), json!({"mode": "other"})])
+        ));
+        assert!(!filters.matches(
+            "getThing",
+            Some(&[json!("address"), json!({"mode": "full"}), json!(true)])
+        ));
+        assert!(!filters.matches("getThing", None));
+    }
+
+    #[test]
+    fn object_key_order_does_not_affect_equality() {
+        let filters = filters(vec![vec![
+            json!("getThing"),
+            json!({"first": 1, "second": 2}),
+        ]]);
+
+        assert!(filters.matches("getThing", Some(&[json!({"second": 2, "first": 1})])));
+    }
+
+    #[test]
+    fn duplicate_entries_are_removed() {
+        let filters = filters(vec![
+            vec![json!("getThing"), json!("address")],
+            vec![json!("getThing"), json!("address")],
+        ]);
+
+        assert_eq!(filters.len(), 1);
+    }
+
+    #[test]
+    fn invalid_entries_are_rejected_with_index() {
+        let err = RpcParameterFilterSet::from_entries(
+            vec![vec![json!("getThing"), json!(1)], vec![json!(42)]],
+            None,
+        )
+        .expect_err("non-string method must fail");
+
+        assert!(err.contains("entry 2"));
+        assert!(err.contains("first value must be a method string"));
+    }
+
+    #[test]
+    fn shared_yaml_ignores_ingestor_keys_and_loads_filters() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("superbank.yaml");
+        std::fs::write(
+            &path,
+            r#"
+source: grpc
+endpoint: https://example.invalid
+rpc-parameter-filters:
+  - [getThing, address]
+"#,
+        )
+        .expect("write config");
+
+        let filters = RpcParameterFilterSet::load(Some(&path)).expect("load config");
+        assert!(filters.matches("getThing", Some(&[json!("address")])));
+    }
+}

--- a/crates/superbank-rpc/src/request_filter.rs
+++ b/crates/superbank-rpc/src/request_filter.rs
@@ -4,7 +4,7 @@
  */
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fs,
     path::{Path, PathBuf},
 };
@@ -24,9 +24,12 @@ struct RpcFileConfig {
 /// differently-shaped calls before any structural JSON comparisons are needed.
 /// Single-address filters for address-history methods also match requests with
 /// trailing configuration parameters.
+/// Cursor-conditional address filters are indexed separately so request config
+/// fields other than cursor presence do not require structural comparisons.
 #[derive(Debug, Default)]
 pub(crate) struct RpcParameterFilterSet {
     by_method_and_arity: HashMap<String, HashMap<usize, Vec<Vec<Value>>>>,
+    cursor_filtered_addresses: HashMap<String, HashSet<String>>,
     len: usize,
 }
 
@@ -50,6 +53,9 @@ impl RpcParameterFilterSet {
         let Some(params) = params else {
             return false;
         };
+        if self.matches_cursor_filtered_address(method, params) {
+            return true;
+        }
         let Some(by_arity) = self.by_method_and_arity.get(method) else {
             return false;
         };
@@ -86,6 +92,18 @@ impl RpcParameterFilterSet {
             };
             if method.trim().is_empty() {
                 return Err(Self::entry_error(path, index, "method must not be empty"));
+            }
+
+            if let Some(address) = Self::cursor_filter_address(&method, &entry) {
+                if filters
+                    .cursor_filtered_addresses
+                    .entry(method)
+                    .or_default()
+                    .insert(address.to_owned())
+                {
+                    filters.len += 1;
+                }
+                continue;
             }
 
             let candidates = filters
@@ -133,6 +151,43 @@ impl RpcParameterFilterSet {
                 .iter()
                 .any(|candidate| candidate.first().and_then(Value::as_str) == Some(address))
         })
+    }
+
+    fn cursor_filter_address<'a>(method: &str, params: &'a [Value]) -> Option<&'a str> {
+        let [Value::String(address), Value::Object(config)] = params else {
+            return None;
+        };
+        Self::cursor_keys(method)
+            .iter()
+            .any(|key| config.contains_key(*key))
+            .then_some(address.as_str())
+    }
+
+    fn matches_cursor_filtered_address(&self, method: &str, params: &[Value]) -> bool {
+        let Some(addresses) = self.cursor_filtered_addresses.get(method) else {
+            return false;
+        };
+        let Some(address) = params.first().and_then(Value::as_str) else {
+            return false;
+        };
+        if !addresses.contains(address) {
+            return false;
+        }
+        let Some(config) = params.get(1).and_then(Value::as_object) else {
+            return false;
+        };
+
+        Self::cursor_keys(method)
+            .iter()
+            .any(|key| config.get(*key).is_some_and(|value| !value.is_null()))
+    }
+
+    fn cursor_keys(method: &str) -> &'static [&'static str] {
+        match method {
+            "getSignaturesForAddress" => &["before", "until"],
+            "getTransactionsForAddress" => &["paginationToken"],
+            _ => &[],
+        }
     }
 }
 
@@ -205,6 +260,88 @@ mod tests {
         assert!(!filters.matches(
             "getSignaturesForAddress",
             Some(&[json!(42), json!({"limit": 10})])
+        ));
+    }
+
+    #[test]
+    fn cursor_filters_ignore_values_and_other_config_fields() {
+        let gsfa_address = "ComputeBudget111111111111111111111111111111";
+        let gtfa_address = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr";
+        let filters = filters(vec![
+            vec![
+                json!("getSignaturesForAddress"),
+                json!(gsfa_address),
+                json!({"commitment": "confirmed", "limit": 10, "before": "ignored"}),
+            ],
+            vec![
+                json!("getTransactionsForAddress"),
+                json!(gtfa_address),
+                json!({"limit": 25, "paginationToken": "ignored"}),
+            ],
+        ]);
+
+        assert!(filters.matches(
+            "getSignaturesForAddress",
+            Some(&[json!(gsfa_address), json!({"before": "different"})])
+        ));
+        assert!(filters.matches(
+            "getSignaturesForAddress",
+            Some(&[
+                json!(gsfa_address),
+                json!({"commitment": "finalized", "limit": 100, "until": "different"})
+            ])
+        ));
+        assert!(filters.matches(
+            "getTransactionsForAddress",
+            Some(&[
+                json!(gtfa_address),
+                json!({"limit": 1, "paginationToken": "different", "sortOrder": "asc"})
+            ])
+        ));
+    }
+
+    #[test]
+    fn cursor_filters_require_a_non_null_cursor_for_the_same_address() {
+        let address = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr";
+        let filters = filters(vec![vec![
+            json!("getTransactionsForAddress"),
+            json!(address),
+            json!({"paginationToken": "ignored"}),
+        ]]);
+
+        assert!(!filters.matches(
+            "getTransactionsForAddress",
+            Some(&[json!(address), json!({"paginationToken": null})])
+        ));
+        assert!(!filters.matches(
+            "getTransactionsForAddress",
+            Some(&[json!(address), json!({"limit": 25})])
+        ));
+        assert!(!filters.matches(
+            "getTransactionsForAddress",
+            Some(&[
+                json!("different-address"),
+                json!({"paginationToken": "present"})
+            ])
+        ));
+    }
+
+    #[test]
+    fn gsfa_cursor_filter_treats_null_before_and_until_as_absent() {
+        let address = "ComputeBudget111111111111111111111111111111";
+        let filters = filters(vec![vec![
+            json!("getSignaturesForAddress"),
+            json!(address),
+            json!({"before": "ignored"}),
+        ]]);
+
+        assert!(!filters.matches(
+            "getSignaturesForAddress",
+            Some(&[json!(address), json!({"before": null, "until": null})])
+        ));
+        assert!(filters.matches(
+            "getSignaturesForAddress",
+            Some(&[json!(address), json!({"before": null, "until": "present"})])
         ));
     }
 

--- a/crates/superbank-rpc/src/server.rs
+++ b/crates/superbank-rpc/src/server.rs
@@ -27,6 +27,7 @@ use crate::handlers::handle_json_rpc_with_headers;
 use crate::metrics;
 use crate::metrics::metrics_handler;
 use crate::processing::ProcessingError;
+use crate::request_filter::RpcParameterFilterSet;
 use crate::state::{AppState, LatestBlockHeightCache, LatestSlotCache, MetricsHeaderCaptureConfig};
 
 #[cfg(feature = "grpc-streaming")]
@@ -109,6 +110,12 @@ pub enum RpcError {
 
 pub async fn run_server(args: RpcConfig) -> RpcResult<()> {
     info!("Starting Solana RPC server on {}:{}", args.host, args.port);
+    let rpc_parameter_filters =
+        RpcParameterFilterSet::load(args.config.as_deref()).map_err(RpcError::Config)?;
+    info!(
+        filters = rpc_parameter_filters.len(),
+        "RPC parameter filters loaded"
+    );
     info!(
         transport = ?args.clickhouse_transport,
         scope = ?args.clickhouse_scope,
@@ -319,6 +326,7 @@ pub async fn run_server(args: RpcConfig) -> RpcResult<()> {
 
     let state = Arc::new(AppState {
         clickhouse,
+        rpc_parameter_filters,
         max_signatures_limit: args.max_signatures_limit,
         rpc_max_batch_size: args.rpc_max_batch_size.max(1),
         rpc_batch_concurrency_limit: args.rpc_batch_concurrency_limit.max(1),

--- a/crates/superbank-rpc/src/server.rs
+++ b/crates/superbank-rpc/src/server.rs
@@ -114,7 +114,7 @@ pub async fn run_server(args: RpcConfig) -> RpcResult<()> {
         RpcParameterFilterSet::load(args.config.as_deref()).map_err(RpcError::Config)?;
     info!(
         filters = rpc_parameter_filters.len(),
-        "RPC parameter filters loaded"
+        "RPC request filters loaded"
     );
     info!(
         transport = ?args.clickhouse_transport,

--- a/crates/superbank-rpc/src/state.rs
+++ b/crates/superbank-rpc/src/state.rs
@@ -14,6 +14,7 @@ use tokio::sync::{Mutex, Notify, Semaphore};
 use crate::clickhouse::ClickHouseClient;
 use crate::metrics;
 use crate::processing::ProcessingError;
+use crate::request_filter::RpcParameterFilterSet;
 use crate::util::{current_time_millis, ttl_millis};
 
 #[cfg(feature = "disk-cache")]
@@ -31,6 +32,7 @@ pub(crate) struct MetricsHeaderCaptureConfig {
 
 pub(crate) struct AppState {
     pub(crate) clickhouse: ClickHouseClient,
+    pub(crate) rpc_parameter_filters: RpcParameterFilterSet,
     pub(crate) max_signatures_limit: u64,
     pub(crate) rpc_max_batch_size: usize,
     pub(crate) rpc_batch_concurrency_limit: usize,

--- a/crates/superbank-rpc/src/tests/mod.rs
+++ b/crates/superbank-rpc/src/tests/mod.rs
@@ -3575,6 +3575,40 @@ async fn address_only_parameter_filter_matches_trailing_config() {
 }
 
 #[tokio::test]
+async fn cursor_parameter_filter_allows_null_pagination_token() {
+    let address = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr";
+    let state = test_state_with_parameter_filters(vec![vec![
+        json!("getTransactionsForAddress"),
+        json!(address),
+        json!({"limit": 25, "paginationToken": "ignored"}),
+    ]]);
+    let blocked_request = json!({
+        "jsonrpc": "2.0",
+        "id": 42,
+        "method": "getTransactionsForAddress",
+        "params": [address, {"limit": 0, "paginationToken": "present"}]
+    });
+    let null_cursor_request = json!({
+        "jsonrpc": "2.0",
+        "id": 43,
+        "method": "getTransactionsForAddress",
+        "params": [address, {"limit": 0, "paginationToken": null}]
+    });
+
+    let blocked_response = handle_json_rpc_value(state.clone(), &blocked_request).await;
+    let null_cursor_response = handle_json_rpc_value(state, &null_cursor_request).await;
+
+    assert_eq!(blocked_response.status(), StatusCode::METHOD_NOT_ALLOWED);
+    assert_eq!(null_cursor_response.status(), StatusCode::OK);
+    let parsed = parse_json_rpc_response(null_cursor_response).await;
+    assert_eq!(parsed.id, json!(43));
+    assert_ne!(
+        parsed.error.expect("invalid limit error present").message,
+        "Method not allowed"
+    );
+}
+
+#[tokio::test]
 async fn parameter_filter_does_not_override_invalid_request_errors() {
     let state = test_state_with_parameter_filters(vec![vec![json!("unknownMethod"), json!(1)]]);
     let request = json!({

--- a/crates/superbank-rpc/src/tests/mod.rs
+++ b/crates/superbank-rpc/src/tests/mod.rs
@@ -3550,8 +3550,8 @@ async fn parameter_filter_returns_http_405_before_handler_dispatch() {
 }
 
 #[tokio::test]
-async fn parameter_filter_requires_complete_param_equality() {
-    let address = "So11111111111111111111111111111111111111112";
+async fn address_only_parameter_filter_matches_trailing_config() {
+    let address = "ComputeBudget111111111111111111111111111111";
     let state = test_state_with_parameter_filters(vec![vec![
         json!("getTransactionsForAddress"),
         json!(address),
@@ -3565,13 +3565,11 @@ async fn parameter_filter_requires_complete_param_equality() {
 
     let response = handle_json_rpc_value(state, &request).await;
 
-    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
     let parsed = parse_json_rpc_response(response).await;
-    assert_ne!(
-        parsed
-            .error
-            .expect("handler error proves dispatch occurred")
-            .message,
+    assert_eq!(parsed.id, json!(42));
+    assert_eq!(
+        parsed.error.expect("filter error present").message,
         "Method not allowed"
     );
 }

--- a/crates/superbank-rpc/src/tests/mod.rs
+++ b/crates/superbank-rpc/src/tests/mod.rs
@@ -188,6 +188,16 @@ fn test_state_with_parameter_filters(entries: Vec<Vec<Value>>) -> Arc<AppState> 
     Arc::new(state)
 }
 
+fn test_state_with_method_filters(methods: Vec<String>) -> Arc<AppState> {
+    let mut state = match Arc::try_unwrap(test_state()) {
+        Ok(state) => state,
+        Err(_) => panic!("test_state should have a single Arc owner"),
+    };
+    state.rpc_parameter_filters =
+        RpcParameterFilterSet::from_config(methods, Vec::new(), None).expect("valid test filters");
+    Arc::new(state)
+}
+
 fn test_state_with_metrics_header_capture(capture: MetricsHeaderCaptureConfig) -> Arc<AppState> {
     let mut state = match Arc::try_unwrap(test_state()) {
         Ok(state) => state,
@@ -3547,6 +3557,30 @@ async fn parameter_filter_returns_http_405_before_handler_dispatch() {
     assert_eq!(err.code, -32601);
     assert_eq!(err.message, "Method not allowed");
     assert!(err.data.is_none());
+}
+
+#[tokio::test]
+async fn method_filter_returns_http_405_for_any_params() {
+    let state = test_state_with_method_filters(vec!["getTransactionsForAddress".to_string()]);
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 41,
+        "method": "getTransactionsForAddress",
+        "params": [
+            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            {"limit": 25, "paginationToken": null}
+        ]
+    });
+
+    let response = handle_json_rpc_value(state, &request).await;
+
+    assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+    let parsed = parse_json_rpc_response(response).await;
+    assert_eq!(parsed.id, json!(41));
+    assert_eq!(
+        parsed.error.expect("filter error present").message,
+        "Method not allowed"
+    );
 }
 
 #[tokio::test]

--- a/crates/superbank-rpc/src/tests/mod.rs
+++ b/crates/superbank-rpc/src/tests/mod.rs
@@ -56,6 +56,7 @@ use crate::hydration::{
     parse_transaction_error_display,
 };
 use crate::metrics;
+use crate::request_filter::RpcParameterFilterSet;
 use crate::rpc::json_rpc_error_response;
 use crate::rpc::types::{JsonRpcRequest, JsonRpcResponse as JsonRpcResponseGeneric};
 use crate::state::{AppState, LatestBlockHeightCache, LatestSlotCache, MetricsHeaderCaptureConfig};
@@ -154,6 +155,7 @@ fn test_state_with_token_owner_activity_available(available: bool) -> Arc<AppSta
 
     Arc::new(AppState {
         clickhouse,
+        rpc_parameter_filters: Default::default(),
         max_signatures_limit: TEST_MAX_LIMIT,
         rpc_max_batch_size: 64,
         rpc_batch_concurrency_limit: 8,
@@ -174,6 +176,16 @@ fn test_state_with_token_owner_activity_available(available: bool) -> Arc<AppSta
 
 fn test_state() -> Arc<AppState> {
     test_state_with_token_owner_activity_available(true)
+}
+
+fn test_state_with_parameter_filters(entries: Vec<Vec<Value>>) -> Arc<AppState> {
+    let mut state = match Arc::try_unwrap(test_state()) {
+        Ok(state) => state,
+        Err(_) => panic!("test_state should have a single Arc owner"),
+    };
+    state.rpc_parameter_filters =
+        RpcParameterFilterSet::from_entries(entries, None).expect("valid test filters");
+    Arc::new(state)
 }
 
 fn test_state_with_metrics_header_capture(capture: MetricsHeaderCaptureConfig) -> Arc<AppState> {
@@ -235,6 +247,7 @@ fn test_state_with_clickhouse_url(clickhouse_url: &str) -> Arc<AppState> {
 
     Arc::new(AppState {
         clickhouse,
+        rpc_parameter_filters: Default::default(),
         max_signatures_limit: TEST_MAX_LIMIT,
         rpc_max_batch_size: 64,
         rpc_batch_concurrency_limit: 8,
@@ -292,6 +305,7 @@ async fn test_state_with_clickhouse_cached_signature_slot(
 
     Arc::new(AppState {
         clickhouse,
+        rpc_parameter_filters: Default::default(),
         max_signatures_limit: TEST_MAX_LIMIT,
         rpc_max_batch_size: 64,
         rpc_batch_concurrency_limit: 8,
@@ -341,6 +355,7 @@ fn test_state_with_head_cache(head_cache: Arc<HeadCache>) -> Arc<AppState> {
 
     Arc::new(AppState {
         clickhouse,
+        rpc_parameter_filters: Default::default(),
         max_signatures_limit: TEST_MAX_LIMIT,
         rpc_max_batch_size: 64,
         rpc_batch_concurrency_limit: 8,
@@ -392,6 +407,7 @@ fn test_state_with_head_cache_and_clickhouse_url(
 
     Arc::new(AppState {
         clickhouse,
+        rpc_parameter_filters: Default::default(),
         max_signatures_limit: TEST_MAX_LIMIT,
         rpc_max_batch_size: 64,
         rpc_batch_concurrency_limit: 8,
@@ -450,6 +466,7 @@ async fn test_state_with_head_cache_and_cached_signature_slot(
 
     Arc::new(AppState {
         clickhouse,
+        rpc_parameter_filters: Default::default(),
         max_signatures_limit: TEST_MAX_LIMIT,
         rpc_max_batch_size: 64,
         rpc_batch_concurrency_limit: 8,
@@ -3507,6 +3524,78 @@ async fn handle_json_rpc_method_not_found_returns_json_rpc_error() {
 }
 
 #[tokio::test]
+async fn parameter_filter_returns_http_405_before_handler_dispatch() {
+    let address = "So11111111111111111111111111111111111111112";
+    let state = test_state_with_parameter_filters(vec![vec![
+        json!("getTransactionsForAddress"),
+        json!(address),
+        json!({"transactionDetails": "signatures"}),
+    ]]);
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 42,
+        "method": "getTransactionsForAddress",
+        "params": [address, {"transactionDetails": "signatures"}]
+    });
+
+    let response = handle_json_rpc_value(state, &request).await;
+
+    assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+    let parsed = parse_json_rpc_response(response).await;
+    assert_eq!(parsed.id, json!(42));
+    let err = parsed.error.expect("error present");
+    assert_eq!(err.code, -32601);
+    assert_eq!(err.message, "Method not allowed");
+    assert!(err.data.is_none());
+}
+
+#[tokio::test]
+async fn parameter_filter_requires_complete_param_equality() {
+    let address = "So11111111111111111111111111111111111111112";
+    let state = test_state_with_parameter_filters(vec![vec![
+        json!("getTransactionsForAddress"),
+        json!(address),
+    ]]);
+    let request = json!({
+        "jsonrpc": "2.0",
+        "id": 42,
+        "method": "getTransactionsForAddress",
+        "params": [address, {"transactionDetails": "signatures"}]
+    });
+
+    let response = handle_json_rpc_value(state, &request).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let parsed = parse_json_rpc_response(response).await;
+    assert_ne!(
+        parsed
+            .error
+            .expect("handler error proves dispatch occurred")
+            .message,
+        "Method not allowed"
+    );
+}
+
+#[tokio::test]
+async fn parameter_filter_does_not_override_invalid_request_errors() {
+    let state = test_state_with_parameter_filters(vec![vec![json!("unknownMethod"), json!(1)]]);
+    let request = json!({
+        "jsonrpc": "1.0",
+        "id": 7,
+        "method": "unknownMethod",
+        "params": [1]
+    });
+
+    let response = handle_json_rpc_value(state, &request).await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let parsed = parse_json_rpc_response(response).await;
+    let err = parsed.error.expect("error present");
+    assert_eq!(err.code, -32600);
+    assert_eq!(err.message, "Invalid JSON-RPC version");
+}
+
+#[tokio::test]
 async fn handle_json_rpc_minimum_ledger_slot_routes_to_handler() {
     let state = test_state_with_clickhouse_url("http://127.0.0.1:1");
 
@@ -3643,6 +3732,40 @@ async fn handle_json_rpc_batch_preserves_input_order() {
     assert_eq!(results.len(), 2);
     assert_eq!(results[0].get("id"), Some(&json!(1)));
     assert_eq!(results[1].get("id"), Some(&json!(2)));
+}
+
+#[tokio::test]
+async fn parameter_filter_marks_mixed_batch_405_and_executes_allowed_items() {
+    let state =
+        test_state_with_parameter_filters(vec![vec![json!("blockedMethod"), json!("blocked")]]);
+    let request = json!([
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "blockedMethod",
+            "params": ["blocked"]
+        },
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "unknownMethod",
+            "params": []
+        }
+    ]);
+
+    let response = handle_json_rpc_value(state, &request).await;
+
+    assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+    let parsed = parse_json_value_response(response).await;
+    let results = parsed.as_array().expect("batch response array");
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0]["id"], json!(1));
+    assert_eq!(results[0]["error"]["message"], json!("Method not allowed"));
+    assert_eq!(results[1]["id"], json!(2));
+    assert_eq!(
+        results[1]["error"]["message"],
+        json!("Method not found: unknownMethod")
+    );
 }
 
 #[tokio::test]

--- a/crates/superbank/src/cli.rs
+++ b/crates/superbank/src/cli.rs
@@ -633,6 +633,8 @@ pub(crate) struct Args {
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 struct FileConfig {
+    #[serde(rename = "rpc-parameter-filters")]
+    _rpc_parameter_filters: Option<Vec<Vec<serde_json::Value>>>,
     source: Option<IngestSource>,
     endpoint: Option<String>,
     #[serde(alias = "x_token")]
@@ -1685,6 +1687,25 @@ mod tests {
             .expect_err("typo'd key should not silently parse");
 
         assert!(err.to_string().contains("fumarole-creat-consumer-group"));
+    }
+
+    #[test]
+    fn file_config_accepts_rpc_parameter_filters() {
+        let config = serde_yaml::from_str::<FileConfig>(
+            r#"
+rpc-parameter-filters:
+  - [getTransactionsForAddress, So11111111111111111111111111111111111111112]
+"#,
+        )
+        .expect("parse shared config");
+
+        assert_eq!(
+            config
+                ._rpc_parameter_filters
+                .as_ref()
+                .map(|filters| filters.len()),
+            Some(1)
+        );
     }
 
     #[test]

--- a/crates/superbank/src/cli.rs
+++ b/crates/superbank/src/cli.rs
@@ -633,6 +633,8 @@ pub(crate) struct Args {
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
 struct FileConfig {
+    #[serde(rename = "rpc-method-filters")]
+    _rpc_method_filters: Option<Vec<String>>,
     #[serde(rename = "rpc-parameter-filters")]
     _rpc_parameter_filters: Option<Vec<Vec<serde_json::Value>>>,
     source: Option<IngestSource>,
@@ -1690,15 +1692,21 @@ mod tests {
     }
 
     #[test]
-    fn file_config_accepts_rpc_parameter_filters() {
+    fn file_config_accepts_rpc_request_filters() {
         let config = serde_yaml::from_str::<FileConfig>(
             r#"
+rpc-method-filters:
+  - getTransactionsForAddress
 rpc-parameter-filters:
   - [getTransactionsForAddress, So11111111111111111111111111111111111111112]
 "#,
         )
         .expect("parse shared config");
 
+        assert_eq!(
+            config._rpc_method_filters.as_deref(),
+            Some(&["getTransactionsForAddress".to_string()][..])
+        );
         assert_eq!(
             config
                 ._rpc_parameter_filters

--- a/superbank.example.yaml
+++ b/superbank.example.yaml
@@ -2,13 +2,15 @@
 # Copy to superbank.yaml and pass via --config / SUPERBANK_CONFIG.
 #
 # Optional superbank-rpc request filters. Pass this same file to superbank-rpc
-# with --config / SUPERBANK_CONFIG. Entries are exact except that a gSFA/gTFA
-# method plus one string address matches any trailing config for that address.
-# Matching calls return HTTP 405 with a JSON-RPC "Method not allowed" error and
-# do not reach RPC handlers.
+# with --config / SUPERBANK_CONFIG. Entries are exact except for the documented
+# address-wide and cursor-conditional gSFA/gTFA forms. Cursor selector values
+# are ignored; missing or null request cursors do not match. Matching calls
+# return HTTP 405 and do not reach RPC handlers.
 # rpc-parameter-filters:
 #   - [getSignaturesForAddress, ComputeBudget111111111111111111111111111111]
 #   - [getTransactionsForAddress, ComputeBudget111111111111111111111111111111]
+#   - [getSignaturesForAddress, Vote111111111111111111111111111111111111111, {before: any}]
+#   - [getTransactionsForAddress, MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr, {paginationToken: any}]
 #   - [getTransactionsForAddress, So11111111111111111111111111111111111111112, {transactionDetails: signatures}]
 
 source: "grpc" # fumarole | grpc | rpc | bigtable | solparq

--- a/superbank.example.yaml
+++ b/superbank.example.yaml
@@ -1,5 +1,13 @@
 # Superbank ingestor example configuration.
 # Copy to superbank.yaml and pass via --config / SUPERBANK_CONFIG.
+#
+# Optional superbank-rpc exact request filters. Pass this same file to
+# superbank-rpc with --config / SUPERBANK_CONFIG. Each entry contains the
+# method followed by its complete params array. Matching calls return HTTP 405
+# with a JSON-RPC "Method not allowed" error and do not reach RPC handlers.
+# rpc-parameter-filters:
+#   - [getTransactionsForAddress, So11111111111111111111111111111111111111112]
+#   - [getTransactionsForAddress, So11111111111111111111111111111111111111112, {transactionDetails: signatures}]
 
 source: "grpc" # fumarole | grpc | rpc | bigtable | solparq
 

--- a/superbank.example.yaml
+++ b/superbank.example.yaml
@@ -1,12 +1,14 @@
 # Superbank ingestor example configuration.
 # Copy to superbank.yaml and pass via --config / SUPERBANK_CONFIG.
 #
-# Optional superbank-rpc exact request filters. Pass this same file to
-# superbank-rpc with --config / SUPERBANK_CONFIG. Each entry contains the
-# method followed by its complete params array. Matching calls return HTTP 405
-# with a JSON-RPC "Method not allowed" error and do not reach RPC handlers.
+# Optional superbank-rpc request filters. Pass this same file to superbank-rpc
+# with --config / SUPERBANK_CONFIG. Entries are exact except that a gSFA/gTFA
+# method plus one string address matches any trailing config for that address.
+# Matching calls return HTTP 405 with a JSON-RPC "Method not allowed" error and
+# do not reach RPC handlers.
 # rpc-parameter-filters:
-#   - [getTransactionsForAddress, So11111111111111111111111111111111111111112]
+#   - [getSignaturesForAddress, ComputeBudget111111111111111111111111111111]
+#   - [getTransactionsForAddress, ComputeBudget111111111111111111111111111111]
 #   - [getTransactionsForAddress, So11111111111111111111111111111111111111112, {transactionDetails: signatures}]
 
 source: "grpc" # fumarole | grpc | rpc | bigtable | solparq

--- a/superbank.example.yaml
+++ b/superbank.example.yaml
@@ -6,6 +6,8 @@
 # address-wide and cursor-conditional gSFA/gTFA forms. Cursor selector values
 # are ignored; missing or null request cursors do not match. Matching calls
 # return HTTP 405 and do not reach RPC handlers.
+# rpc-method-filters:
+#   - getTransactionsForAddress
 # rpc-parameter-filters:
 #   - [getSignaturesForAddress, ComputeBudget111111111111111111111111111111]
 #   - [getTransactionsForAddress, ComputeBudget111111111111111111111111111111]


### PR DESCRIPTION
Alternative where we can block all heavy calls that include cursors, e.g:
```
  - [getTransactionsForAddress, So11111111111111111111111111111111111111112, {paginationToken: any}]
  - [getTransactionsForAddress, MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr, {paginationToken: any}]
  - [getTransactionsForAddress, HLnpSz9h2S4hiLQ43rnSD9XkcUThA7B8hQMKmDaiTLcC, {paginationToken: any}]
  - [getTransactionsForAddress, ComputeBudget111111111111111111111111111111, {paginationToken: any}]
  - [getSignaturesForAddress, ComputeBudget111111111111111111111111111111, {before: any, until: any}]
```

Such addresses without any cursor parameter or cursor set to `null` will still work, but any calls with cursor will be blocked and return "Method not allowed"