### PR TITLE
fix(solparq): floor archived-data delete start at lowest archived slot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6744,7 +6744,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "superbank"
-version = "0.5.0-solparq.17"
+version = "0.5.0-solparq.18"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -6796,7 +6796,7 @@ dependencies = [
 
 [[package]]
 name = "superbank-rpc"
-version = "0.5.0-solparq.17"
+version = "0.5.0-solparq.18"
 dependencies = [
  "async-stream",
  "axum 0.8.8",
@@ -6855,7 +6855,7 @@ dependencies = [
 
 [[package]]
 name = "superbank-solparq"
-version = "0.5.0-solparq.17"
+version = "0.5.0-solparq.18"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -6887,7 +6887,7 @@ dependencies = [
 
 [[package]]
 name = "superbank-workspace"
-version = "0.5.0-solparq.17"
+version = "0.5.0-solparq.18"
 
 [[package]]
 name = "symbolic-common"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors.workspace = true
 publish = false
 
 [workspace.package]
-version = "0.5.0-solparq.17"
+version = "0.5.0-solparq.18"
 edition = "2024"
 license = "AGPL-3.0-only"
 authors = [

--- a/crates/superbank-solparq/README.md
+++ b/crates/superbank-solparq/README.md
@@ -607,8 +607,9 @@ boundaries. Notes:
 - Aligning skips any leading partial window: if the earliest slot is `10_500`, the
   first `custom:1000` archive is `11000-11999` and slots `10_500–10_999` are not
   archived by this kind — the same trade-off `epoch` already makes for a partial
-  leading epoch. Take care when `custom` is the only configured kind combined with
-  `--delete-archived-data-range`.
+  leading epoch. `--delete-archived-data-range` preserves this never-archived
+  leading window by flooring the delete at the lowest archived start slot; pass
+  `--delete-archived-data-from-slot-zero` if you want it purged too.
 - Enabling it on an existing unaligned custom history realigns forward from the
   next boundary after the last archive.
 
@@ -747,14 +748,28 @@ To delete the archived ClickHouse data range after a successful archive:
 When multiple archive types are configured, ClickHouse data deletion is gated by
 the completed archive high-watermark for every configured type. After any
 archive succeeds, `superbank-solparq` checks the latest completed archive for each type
-and deletes everything from the beginning of the table up to the highest slot
-that all configured types have already covered. Sweeping from slot `0` (rather
-than only the current archive's range) ensures no older slots are stranded when
-one archive type was lagging while an earlier range was written. For example, if
-`custom:500` and `hourly` are both configured, early `custom:500` archives will
-defer deletion until an `hourly` archive covers the same slots. Once the
-`hourly` archive exists, later `custom:500` completions can delete every slot up
-to their safe high-watermark without waiting for another hourly cycle.
+and deletes up to the highest slot that all configured types have already
+covered. For example, if `custom:500` and `hourly` are both configured, early
+`custom:500` archives will defer deletion until an `hourly` archive covers the
+same slots. Once the `hourly` archive exists, later `custom:500` completions can
+delete every slot up to their safe high-watermark without waiting for another
+hourly cycle.
+
+The delete range starts at the **lowest archived start slot** across the
+configured types, not at slot `0`. Aligned kinds do not archive from the earliest
+ingested slot: `epoch` (and `custom` with `--custom-aligned`) begins its first
+archive at an `align_up` boundary, so the window between the earliest ingested
+slot and that boundary is never captured by any archive. Flooring the delete
+start at the lowest archived start slot keeps that never-archived leading window
+in ClickHouse instead of dropping data that lives in no archive.
+
+To instead sweep from slot `0` — purging the leading, never-archived window too —
+add `--delete-archived-data-from-slot-zero` (server mode only, off by default):
+
+```bash
+--delete-archived-data-range \
+--delete-archived-data-from-slot-zero
+```
 
 That deletes matching slots from:
 
@@ -797,6 +812,8 @@ Common defaults:
 - `--custom-aligned` unset (off; only affects `custom` — see [Aligned custom archives](#aligned-custom-archives))
 - `--no-continue-from-last-archive` unset
 - `--log-file` unset
+- `--delete-archived-data-range` unset (off)
+- `--delete-archived-data-from-slot-zero` unset (off; server mode only)
 - `--repair-mismatches` unset (off)
 - `--allow-rpc-validation-failure` unset (off)
 - `--backfill-gaps` unset (off)

--- a/crates/superbank-solparq/src/archive.rs
+++ b/crates/superbank-solparq/src/archive.rs
@@ -298,12 +298,18 @@ pub fn plan_archive_slot_range(
 /// Compute the ClickHouse slot range that is safe to delete after an archive is
 /// created.
 ///
-/// Deletion always starts from slot `0`, not from the current archive's start
-/// slot: once every configured archive type has archived a slot, that slot (and
-/// everything before it) is redundant in ClickHouse regardless of which archive
-/// run first covered it. Starting from the current archive's start slot would
-/// strand older slots that were left behind when another archive type was
-/// lagging.
+/// Deletion starts from the **lowest archived start slot** across the configured
+/// archive types, not from slot `0`. Aligned kinds do not archive from the
+/// earliest ingested slot: `epoch` (and `custom` with `--custom-aligned`) begins
+/// its first archive at an `align_up` boundary, so the window between the
+/// earliest ingested slot and that boundary is never captured by any archive.
+/// Flooring the delete start at the lowest archived start slot keeps that
+/// never-archived prefix in ClickHouse; any slot at or above it exists in at
+/// least one archive and can be safely reclaimed.
+///
+/// `--delete-archived-data-from-slot-zero` (server mode only) opts back into the
+/// original behaviour of sweeping from slot `0`, for setups that intentionally
+/// want the leading, never-archived window purged too.
 ///
 /// The range end (`safe_end_slot`) is the highest slot that *every* configured
 /// archive type has archived — the minimum of each type's latest archive end
@@ -321,6 +327,7 @@ pub fn safe_delete_archived_data_range(
     }
 
     let mut safe_end_slot = current_end_slot;
+    let mut floor_start_slot = u64::MAX;
     for kind in config.archive_kinds.iter().copied() {
         let Some(latest_archive_name) = latest_archive_names
             .iter()
@@ -339,9 +346,25 @@ pub fn safe_delete_archived_data_range(
             ));
         }
         safe_end_slot = safe_end_slot.min(parsed.end_slot);
+        floor_start_slot = floor_start_slot.min(parsed.start_slot);
     }
 
-    Ok(Some(crate::clickhouse::SlotRange::new(0, safe_end_slot)))
+    // Floor the delete start at the lowest archived start slot so slots that no
+    // archive type ever captured (the pre-`align_up` leading window) are kept,
+    // unless the operator explicitly opts into sweeping from slot 0. Clamp to
+    // `safe_end_slot` so the range is never inverted. `floor_start_slot` is set
+    // at least once here: the loop returns early for any kind without an archive,
+    // so reaching this point means every configured kind contributed a start.
+    let start_slot = if config.delete_archived_data_from_slot_zero {
+        0
+    } else {
+        floor_start_slot.min(safe_end_slot)
+    };
+
+    Ok(Some(crate::clickhouse::SlotRange::new(
+        start_slot,
+        safe_end_slot,
+    )))
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/superbank-solparq/src/config.rs
+++ b/crates/superbank-solparq/src/config.rs
@@ -83,6 +83,10 @@ pub struct Config {
     /// fewer archived rows than declared); re-ingest re-inserts and dedups.
     pub backfill_include_undercounts: bool,
     pub delete_archived_data_range: bool,
+    /// Sweep the ClickHouse delete range from slot `0` rather than flooring it at
+    /// the lowest archived start slot. Server mode only; off by default. See
+    /// [`crate::archive::safe_delete_archived_data_range`].
+    pub delete_archived_data_from_slot_zero: bool,
     pub server_mode: bool,
     pub ops_port: u16,
     pub metrics_port: u16,
@@ -133,6 +137,11 @@ impl Config {
         if cli.server_mode && cli.archive_slot_range.is_some() {
             return Err(anyhow!(
                 "--archive-slot-range is only supported for one-shot archives and cannot be used with --server-mode"
+            ));
+        }
+        if cli.delete_archived_data_from_slot_zero && !cli.server_mode {
+            return Err(anyhow!(
+                "--delete-archived-data-from-slot-zero is only supported with --server-mode"
             ));
         }
 
@@ -208,6 +217,7 @@ impl Config {
             backfill_superbank_bin: cli.backfill_superbank_bin,
             backfill_include_undercounts: cli.backfill_include_undercounts,
             delete_archived_data_range: cli.delete_archived_data_range,
+            delete_archived_data_from_slot_zero: cli.delete_archived_data_from_slot_zero,
             server_mode: cli.server_mode,
             ops_port: cli.ops_port,
             metrics_port: cli.metrics_port,
@@ -498,6 +508,18 @@ struct Cli {
         default_value_t = false
     )]
     delete_archived_data_range: bool,
+
+    /// Sweep the ClickHouse delete range from slot `0` instead of flooring it at
+    /// the lowest archived start slot. Only valid with `--server-mode`. Off by
+    /// default so the never-archived leading window (slots before an aligned
+    /// kind's first `align_up` boundary) is preserved; enable it only when that
+    /// leading window should be purged too.
+    #[arg(
+        long = "delete-archived-data-from-slot-zero",
+        env = "SOLPARQ_DELETE_ARCHIVED_DATA_FROM_SLOT_ZERO",
+        default_value_t = false
+    )]
+    delete_archived_data_from_slot_zero: bool,
 
     /// Attempt to repair overcount transaction mismatches before archiving by
     /// running `OPTIMIZE ... FINAL DEDUPLICATE` on affected epoch partitions,

--- a/crates/superbank-solparq/src/server.rs
+++ b/crates/superbank-solparq/src/server.rs
@@ -446,6 +446,7 @@ async fn status(State(ops): State<OpsState>) -> Json<serde_json::Value> {
             "archives_to_keep": ops.config.archives_to_keep,
             "continue_from_last_archive": ops.config.continue_from_last_archive,
             "delete_archived_data_range": ops.config.delete_archived_data_range,
+            "delete_archived_data_from_slot_zero": ops.config.delete_archived_data_from_slot_zero,
             "force_archive": ops.config.force_archive,
             "archive_check_interval_secs": ops.config.archive_check_interval_secs
         }

--- a/crates/superbank-solparq/tests/core.rs
+++ b/crates/superbank-solparq/tests/core.rs
@@ -933,7 +933,7 @@ fn clickhouse_cleanup_deletes_only_safe_prefix_when_other_kinds_lag() {
 }
 
 #[test]
-fn clickhouse_cleanup_removes_slots_before_current_archive_start() {
+fn clickhouse_cleanup_floors_delete_start_at_lowest_archived_start() {
     let config = Config::try_parse_from([
         "superbank-solparq",
         "--db-server",
@@ -949,9 +949,44 @@ fn clickhouse_cleanup_removes_slots_before_current_archive_start() {
     ])
     .expect("valid config");
 
-    // A continuation archive covering the second epoch (432000-863999). Older
-    // slots from the first epoch (0-431999) must still be swept even though this
-    // archive does not start at slot 0.
+    // A continuation archive covering the second epoch (432000-863999). The
+    // first epoch's aligned start means slots before 432000 (the earliest
+    // ingested slot up to the first `align_up` boundary) were never archived by
+    // any kind, so the delete must be floored at the archive start rather than
+    // reaching back to slot 0.
+    let delete_range = safe_delete_archived_data_range(
+        &config,
+        863_999,
+        &[(
+            ArchiveKind::Epoch,
+            Some("epoch_1_432000-863999".to_string()),
+        )],
+    )
+    .expect("safe delete check");
+
+    assert_eq!(delete_range, Some(SlotRange::new(432_000, 863_999)));
+}
+
+#[test]
+fn clickhouse_cleanup_sweeps_from_slot_zero_when_opted_in() {
+    let config = Config::try_parse_from([
+        "superbank-solparq",
+        "--db-server",
+        "127.0.0.1",
+        "--db-user",
+        "admin",
+        "--db-password",
+        "secret",
+        "--archive-range-type",
+        "epoch",
+        "--server-mode",
+        "--delete-archived-data-range",
+        "--delete-archived-data-from-slot-zero",
+    ])
+    .expect("valid config");
+
+    // With `--delete-archived-data-from-slot-zero`, the delete reaches back to
+    // slot 0 even though the archive starts at an aligned boundary.
     let delete_range = safe_delete_archived_data_range(
         &config,
         863_999,
@@ -963,6 +998,29 @@ fn clickhouse_cleanup_removes_slots_before_current_archive_start() {
     .expect("safe delete check");
 
     assert_eq!(delete_range, Some(SlotRange::new(0, 863_999)));
+}
+
+#[test]
+fn delete_archived_data_from_slot_zero_requires_server_mode() {
+    let err = Config::try_parse_from([
+        "superbank-solparq",
+        "--db-server",
+        "127.0.0.1",
+        "--db-user",
+        "admin",
+        "--db-password",
+        "secret",
+        "--archive-range-type",
+        "epoch",
+        "--delete-archived-data-range",
+        "--delete-archived-data-from-slot-zero",
+    ])
+    .expect_err("--delete-archived-data-from-slot-zero requires --server-mode");
+
+    assert!(
+        err.to_string().contains("--server-mode"),
+        "unexpected error: {err}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Problem

Fixes #61.

`--delete-archived-data-range` always started its ClickHouse delete at slot `0`. Aligned kinds don't archive from the earliest ingested slot: `epoch` (and `custom` with `--custom-aligned`) begin their first archive at an `align_up` boundary, so the window between the earliest ingested slot and that boundary is never captured by any archive.

With deletion starting at `0`, that never-archived window still fell inside `[0, safe_end]` and got wiped — dropping data that existed in **no** archive. Example: ingest starts at slot `100` with epoch archiving; the first epoch archive is `[432000, 863999]`, but the delete swept `[0, 863999]`, so `100..431999` was gone from ClickHouse and in no archive. ([Original review comment](https://github.com/solana-rpc/superbank/pull/55#discussion_r3617952186).)

## Fix

Floor the delete start at the **lowest archived start slot** across the configured kinds instead of `0`. Any slot at or above it exists in at least one archive and can be safely reclaimed; the never-archived leading window stays in ClickHouse. `safe_end` (the min of each kind's latest archive end) is unchanged, so the "delete only once every kind has covered it" high-watermark still holds.

For setups that intentionally want the leading, never-archived window purged too, add `--delete-archived-data-from-slot-zero` (env `SOLPARQ_DELETE_ARCHIVED_DATA_FROM_SLOT_ZERO`) — **server mode only, off by default** — which restores sweeping from slot `0`.

## Changes

- `safe_delete_archived_data_range` now tracks `min(parsed.start_slot)` alongside `min(parsed.end_slot)` and floors the delete start there (clamped to `safe_end`), unless the new opt-out flag is set.
- New `--delete-archived-data-from-slot-zero` CLI flag + `Config` field, gated to `--server-mode` (errors otherwise). Exposed in the ops JSON.
- Updated `crates/superbank-solparq/README.md` (Cleanup section, aligned-custom caveat, Options list).

## Testing

- `cargo test -p superbank-solparq --locked` — all pass. Updated the epoch-continuation cleanup test to expect the floored start, and added tests for the from-slot-zero opt-in and the server-mode-only validation.
- `cargo clippy -p superbank-solparq --all-targets --locked -- -D warnings` and `cargo fmt --all -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)