### PR TITLE
fix(rpc): optimize paginated getTransactionsForAddress queries

### DIFF
--- a/crates/superbank-rpc/README.md
+++ b/crates/superbank-rpc/README.md
@@ -384,8 +384,8 @@ CLI flags and environment variables (see `crates/superbank-rpc/src/config.rs`):
 | `--clickhouse-tcp-pool-min` | `CLICKHOUSE_TCP_POOL_MIN` | `10` | Minimum connections retained per shard in each ClickHouse native (TCP) connection pool. |
 | `--clickhouse-tcp-pool-max` | `CLICKHOUSE_TCP_POOL_MAX` | `20` | Maximum connections per shard in each ClickHouse native (TCP) connection pool. Total native connections per instance are bounded by this value times the number of shards, so size it against the ClickHouse connection budget. |
 | `--clickhouse-cluster` | `CLICKHOUSE_CLUSTER` | `{cluster}` | — |
-| `--clickhouse-topology-config` | `CLICKHOUSE_TOPOLOGY_CONFIG` | — | Optional authoritative YAML shard topology. When set, superbank-rpc skips `system.clusters` discovery at startup and uses the YAML shard/IP/port mapping directly for shard-local connections. |
-| `--clickhouse-gsfa-local-table` | `CLICKHOUSE_GSFA_LOCAL_TABLE` | — | Required for shard-direct GSFA routing. |
+| `--clickhouse-topology-config` | `CLICKHOUSE_TOPOLOGY_CONFIG` | — | Optional authoritative YAML shard topology. When set, superbank-rpc skips `system.clusters` discovery, uses the YAML shard/IP/port mapping for shard-local connections, and routes `getTransactionsForAddress` to the address-owner shard. |
+| `--clickhouse-gsfa-local-table` | `CLICKHOUSE_GSFA_LOCAL_TABLE` | — | Local GSFA table used by shard-direct reads and owner-shard `getTransactionsForAddress` routing. |
 | `--clickhouse-hot-address` | `CLICKHOUSE_GSFA_HOT_ADDRESSES` | empty | Repeatable; env accepts comma-separated values. |
 | `--clickhouse-gsfa-hot-table` | `CLICKHOUSE_GSFA_HOT_TABLE` | `default.gsfa_hot` | Distributed hot table used for active hot-address reads. |
 | `--clickhouse-gsfa-hot-local-table` | `CLICKHOUSE_GSFA_HOT_LOCAL_TABLE` | `default.gsfa_hot_local` | Shard-local backing table behind `CLICKHOUSE_GSFA_HOT_TABLE`. |
@@ -410,7 +410,10 @@ Table selection (environment variables, read at startup):
 Shard routing:
 When `CLICKHOUSE_SCOPE=shard-direct`, superbank-rpc discovers shards from `system.clusters` and
 validates local table schemas. Local tables default to `{table}_local` when not provided
-explicitly. `CLICKHOUSE_TRANSPORT` selects the shard-direct transport (`tcp` or `http`).
+explicitly. `CLICKHOUSE_TRANSPORT` selects the shard-direct transport (`tcp` or `http`). When a
+topology is available in distributed scope, `getTransactionsForAddress` also uses the address
+hash to query the owner shard's local GSFA table; a failed owner-shard query is returned as an
+error instead of being retried against the distributed table.
 Set `CLICKHOUSE_TOPOLOGY_CONFIG` (or `--clickhouse-topology-config`) to make a YAML topology file
 authoritative for shard-local connection targets and skip `system.clusters` discovery at startup.
 When multiple YAML nodes are listed for the same shard, the first node listed for that shard is

--- a/crates/superbank-rpc/src/clickhouse/client.rs
+++ b/crates/superbank-rpc/src/clickhouse/client.rs
@@ -1110,9 +1110,7 @@ impl ClickHouseClient {
             None
         };
 
-        if self.scope_shard_direct()
-            && let Some(topology) = &self.shard_topology
-        {
+        if let Some(topology) = &self.shard_topology {
             if let Some(router) = &self.gsfa_router {
                 let local_modulus = detect_bucket_modulus_on_shards(
                     topology,
@@ -1130,7 +1128,9 @@ impl ClickHouseClient {
                 )?;
             }
 
-            if let Some(local_table) = &self.signatures_local_table {
+            if self.scope_shard_direct()
+                && let Some(local_table) = &self.signatures_local_table
+            {
                 let local_modulus = detect_bucket_modulus_on_shards(
                     topology,
                     local_table,
@@ -1526,65 +1526,62 @@ impl ClickHouseClient {
                     let topology = Arc::new(topology);
                     self.shard_topology = Some(topology.clone());
 
-                    if self.scope_shard_direct() {
-                        if let Some(local_table) = config.gsfa_local_table.clone() {
-                            if let Err(e) = validate_table_schema_on_shards(
-                                topology.as_ref(),
-                                &local_table,
-                                &GSFA_REQUIRED_COLUMNS,
-                                self.query_timeout,
-                            )
-                            .await
-                            {
-                                tracing::warn!(
-                                    "GSFA shard routing disabled; local table validation failed: {}",
-                                    e
-                                );
-                            } else {
-                                self.validate_gsfa_shard_layout(&local_table).await?;
-                                self.gsfa_router = Some(GsfaShardRouter {
-                                    local_table,
-                                    topology: topology.clone(),
-                                    query_timeout: self.shard_tcp_query_timeout(),
-                                });
-                            }
+                    if let Some(local_table) = config.gsfa_local_table.clone() {
+                        if let Err(e) = validate_table_schema_on_shards(
+                            topology.as_ref(),
+                            &local_table,
+                            &GSFA_REQUIRED_COLUMNS,
+                            self.query_timeout,
+                        )
+                        .await
+                        {
+                            tracing::warn!(
+                                "GSFA shard routing disabled; local table validation failed: {}",
+                                e
+                            );
                         } else {
-                            tracing::warn!(
-                                "GSFA shard routing disabled; local table not configured"
-                            );
+                            self.validate_gsfa_shard_layout(&local_table).await?;
+                            self.gsfa_router = Some(GsfaShardRouter {
+                                local_table,
+                                topology: topology.clone(),
+                                query_timeout: self.shard_tcp_query_timeout(),
+                            });
                         }
+                    } else {
+                        tracing::warn!("GSFA shard routing disabled; local table not configured");
+                    }
 
-                        if let Some(local_table) = config.signatures_local_table.clone()
-                            && let Err(e) = validate_table_schema_on_shards(
-                                topology.as_ref(),
-                                &local_table,
-                                &SIGNATURES_REQUIRED_COLUMNS,
-                                self.query_timeout,
-                            )
-                            .await
-                        {
-                            tracing::warn!(
-                                "Signature shard routing disabled; local table validation failed: {}",
-                                e
-                            );
-                            self.signatures_local_table = None;
-                        }
+                    if self.scope_shard_direct()
+                        && let Some(local_table) = config.signatures_local_table.clone()
+                        && let Err(e) = validate_table_schema_on_shards(
+                            topology.as_ref(),
+                            &local_table,
+                            &SIGNATURES_REQUIRED_COLUMNS,
+                            self.query_timeout,
+                        )
+                        .await
+                    {
+                        tracing::warn!(
+                            "Signature shard routing disabled; local table validation failed: {}",
+                            e
+                        );
+                        self.signatures_local_table = None;
+                    }
 
-                        if let Some(local_table) = config.token_owner_activity_local_table.clone()
-                            && let Err(e) = validate_table_schema_on_shards(
-                                topology.as_ref(),
-                                &local_table,
-                                &TOKEN_OWNER_REQUIRED_COLUMNS,
-                                self.query_timeout,
-                            )
-                            .await
-                        {
-                            tracing::warn!(
-                                "Token owner shard routing disabled; local table validation failed: {}",
-                                e
-                            );
-                            self.token_owner_activity_local_table = None;
-                        }
+                    if let Some(local_table) = config.token_owner_activity_local_table.clone()
+                        && let Err(e) = validate_table_schema_on_shards(
+                            topology.as_ref(),
+                            &local_table,
+                            &TOKEN_OWNER_REQUIRED_COLUMNS,
+                            self.query_timeout,
+                        )
+                        .await
+                    {
+                        tracing::warn!(
+                            "Token owner shard routing disabled; local table validation failed: {}",
+                            e
+                        );
+                        self.token_owner_activity_local_table = None;
                     }
 
                     if hot_routing_configured {

--- a/crates/superbank-rpc/src/clickhouse/queries.rs
+++ b/crates/superbank-rpc/src/clickhouse/queries.rs
@@ -305,15 +305,6 @@ fn append_transactions_for_address_slot_filter_conditions(
     }
 }
 
-fn signature_position_for_token(slot: u64, idx: u32) -> SignaturePositionExpr {
-    SignaturePositionExpr {
-        slot_expr: slot.to_string(),
-        idx_expr: idx.to_string(),
-        nullable: false,
-        with_parts: Vec::new(),
-    }
-}
-
 fn signature_position_for_signature(
     signatures_table: &str,
     signature_bucket_modulus: u64,
@@ -493,23 +484,33 @@ fn apply_pagination_token(
     with_parts: &mut Vec<String>,
     conditions: &mut Vec<String>,
 ) -> ProcessingResult<()> {
-    let expr = match pagination {
-        PaginationToken::SlotIndex { slot, idx } => signature_position_for_token(*slot, *idx),
-        PaginationToken::Signature(sig) => signature_position_for_signature(
-            signatures_table,
-            signature_bucket_modulus,
-            sig,
-            "page",
-        )?,
-    };
-
     let comparison = match sort_order {
         SortOrder::Desc => SlotIdxComparison::Lt,
         SortOrder::Asc => SlotIdxComparison::Gt,
     };
-    let condition = slot_idx_condition(&expr, comparison);
-    with_parts.extend(expr.with_parts);
-    conditions.push(condition);
+
+    match pagination {
+        PaginationToken::SlotIndex { slot, idx } => {
+            conditions.push(slot_idx_condition_for_position(
+                SignatureSlot {
+                    slot: *slot,
+                    slot_idx: *idx,
+                },
+                comparison,
+            ));
+        }
+        PaginationToken::Signature(sig) => {
+            let expr = signature_position_for_signature(
+                signatures_table,
+                signature_bucket_modulus,
+                sig,
+                "page",
+            )?;
+            let condition = slot_idx_condition(&expr, comparison);
+            with_parts.extend(expr.with_parts);
+            conditions.push(condition);
+        }
+    }
 
     Ok(())
 }
@@ -731,40 +732,54 @@ pub(crate) fn build_transactions_for_address_query(
         union_parts.push(token_subquery);
     }
 
-    let union_sql = if union_parts.len() == 1 {
-        union_parts[0].clone()
-    } else {
-        union_parts.join("\nUNION ALL\n")
-    };
-
     let order_dir = match query.sort_order {
         SortOrder::Asc => "ASC",
         SortOrder::Desc => "DESC",
     };
 
-    Ok(format!(
-        "{with_clause}SELECT
+    let select = if union_parts.len() == 1 {
+        format!(
+            "{with_clause}SELECT
             base58Encode(signature) AS signature,
             slot,
             slot_idx,
             err,
             memo,
             block_time
-         FROM (
-            SELECT signature, slot, slot_idx, err, memo, block_time
-            FROM (
+         FROM {gsfa_table}
+         PREWHERE addr_bucket = {addr_bucket} AND address = {address_literal}
+         WHERE {where_clause}",
+            with_clause = with_clause,
+            gsfa_table = tables.gsfa_table,
+            addr_bucket = gsfa_addr_bucket,
+            address_literal = address_literal,
+            where_clause = where_clause,
+        )
+    } else {
+        format!(
+            "{with_clause}SELECT
+                base58Encode(signature) AS signature,
+                slot,
+                slot_idx,
+                err,
+                memo,
+                block_time
+             FROM (
                 {union_sql}
-            )
-            WHERE {where_clause}
-            ORDER BY slot {order_dir}, slot_idx {order_dir}, signature {order_dir}
-            LIMIT 1 BY signature
-         )
+             )
+             WHERE {where_clause}",
+            with_clause = with_clause,
+            union_sql = union_parts.join("\nUNION ALL\n"),
+            where_clause = where_clause,
+        )
+    };
+
+    Ok(format!(
+        "{select}
          ORDER BY slot {order_dir}, slot_idx {order_dir}, signature {order_dir}
          LIMIT {limit}
          {settings_clause}",
-        with_clause = with_clause,
-        union_sql = union_sql,
-        where_clause = where_clause,
+        select = select,
         order_dir = order_dir,
         limit = query.limit,
         settings_clause = settings_clause
@@ -829,14 +844,9 @@ pub(crate) fn build_transactions_for_address_hot_query(
             err,
             memo,
             block_time
-         FROM (
-            SELECT signature, slot, slot_idx, err, memo, block_time
-            FROM {gsfa_table}
-            PREWHERE addr_bucket = {addr_bucket} AND address = {address_literal}
-            WHERE {where_clause}
-            ORDER BY slot {order_dir}, slot_idx {order_dir}, signature {order_dir}
-            LIMIT 1 BY signature
-         )
+         FROM {gsfa_table}
+         PREWHERE addr_bucket = {addr_bucket} AND address = {address_literal}
+         WHERE {where_clause}
          ORDER BY slot {order_dir}, slot_idx {order_dir}, signature {order_dir}
          LIMIT {limit}
          {settings_clause}",
@@ -1051,6 +1061,85 @@ mod tests {
     }
 
     #[test]
+    fn transactions_for_address_query_uses_raw_cursor_and_no_limit_by() {
+        let query = TransactionsForAddressQuery {
+            address: bs58::encode([9_u8; 32]).into_string(),
+            limit: 64,
+            sort_order: SortOrder::Desc,
+            pagination: Some(crate::clickhouse::PaginationToken::SlotIndex {
+                slot: 436_663_495,
+                idx: 1_387,
+            }),
+            resolved_pagination: Some(SignatureSlot {
+                slot: 436_663_495,
+                slot_idx: 1_387,
+            }),
+            slot_filter: None,
+            block_time_filter: None,
+            signature_filter: None,
+            resolved_signature_filter: None,
+            status: TransactionStatusFilter::Any,
+            token_accounts: TokenAccountsFilter::None,
+        };
+        let tables = TransactionsForAddressTables {
+            gsfa_table: "default.gsfa_local",
+            gsfa_bucket_modulus: 32,
+            token_owner_table: "default.token_owner_activity_local",
+            token_owner_bucket_modulus: 32,
+            signatures_table: "default.signatures",
+            signature_bucket_modulus: 32,
+        };
+
+        let sql = normalize_sql(
+            &build_transactions_for_address_query(&tables, &query, "").expect("query"),
+        );
+
+        assert!(sql.contains("WHERE (slot < 436663495 OR (slot = 436663495 AND slot_idx < 1387))"));
+        assert!(!sql.contains("slot + toUInt64(0) < 436663495"));
+        assert!(!sql.contains("LIMIT BY"));
+        assert!(sql.contains("ORDER BY slot DESC, slot_idx DESC, signature DESC LIMIT 64"));
+        assert!(!sql.contains("FROM ( SELECT signature"));
+    }
+
+    #[test]
+    fn transactions_for_address_ascending_cursor_uses_raw_key_predicate() {
+        let query = TransactionsForAddressQuery {
+            address: bs58::encode([9_u8; 32]).into_string(),
+            limit: 64,
+            sort_order: SortOrder::Asc,
+            pagination: Some(crate::clickhouse::PaginationToken::SlotIndex {
+                slot: 436_663_495,
+                idx: 1_387,
+            }),
+            resolved_pagination: Some(SignatureSlot {
+                slot: 436_663_495,
+                slot_idx: 1_387,
+            }),
+            slot_filter: None,
+            block_time_filter: None,
+            signature_filter: None,
+            resolved_signature_filter: None,
+            status: TransactionStatusFilter::Any,
+            token_accounts: TokenAccountsFilter::None,
+        };
+        let tables = TransactionsForAddressTables {
+            gsfa_table: "default.gsfa_local",
+            gsfa_bucket_modulus: 32,
+            token_owner_table: "default.token_owner_activity_local",
+            token_owner_bucket_modulus: 32,
+            signatures_table: "default.signatures",
+            signature_bucket_modulus: 32,
+        };
+
+        let sql = normalize_sql(
+            &build_transactions_for_address_query(&tables, &query, "").expect("query"),
+        );
+
+        assert!(sql.contains("WHERE (slot > 436663495 OR (slot = 436663495 AND slot_idx > 1387))"));
+        assert!(sql.contains("ORDER BY slot ASC, slot_idx ASC, signature ASC LIMIT 64"));
+    }
+
+    #[test]
     fn hot_transactions_for_address_query_uses_resolved_numeric_bounds() {
         let query = TransactionsForAddressQuery {
             address: bs58::encode([9_u8; 32]).into_string(),
@@ -1096,6 +1185,7 @@ mod tests {
         assert!(!sql.contains("slot_idx + toUInt32(0) < 678"));
         assert!(!sql.contains("FROM default.signatures"));
         assert!(!sql.contains("ignored"));
+        assert!(!sql.contains("LIMIT BY"));
     }
 
     #[test]

--- a/crates/superbank-rpc/src/clickhouse/transactions.rs
+++ b/crates/superbank-rpc/src/clickhouse/transactions.rs
@@ -27,8 +27,8 @@ use super::queries::{
 use super::rows::{TransactionRow, fetch_single_transaction_row, map_transaction_row};
 use super::sharding::ShardTopology;
 use super::types::{
-    QueryTimings, SortOrder, StoredTransactionRecord, TokenAccountsFilter,
-    TransactionsForAddressQuery, TransactionsForAddressRecord,
+    PaginationToken, QueryTimings, SignatureSlot, SortOrder, StoredTransactionRecord,
+    TokenAccountsFilter, TransactionsForAddressQuery, TransactionsForAddressRecord,
 };
 use super::util::{
     append_max_execution_time_setting, format_gsfa_memo, parse_err_json,
@@ -80,26 +80,40 @@ fn compare_transactions_for_address_records(
     }
 }
 
-fn merge_hot_transactions_for_address_records(
+const TRANSACTIONS_FOR_ADDRESS_MIN_BATCH_SIZE: u64 = 64;
+const TRANSACTIONS_FOR_ADDRESS_MAX_BATCH_SIZE: u64 = 2_000;
+
+fn transactions_for_address_batch_size(remaining: u64) -> u64 {
+    remaining.saturating_mul(2).clamp(
+        TRANSACTIONS_FOR_ADDRESS_MIN_BATCH_SIZE,
+        TRANSACTIONS_FOR_ADDRESS_MAX_BATCH_SIZE,
+    )
+}
+
+fn order_transactions_for_address_records(
     mut records: Vec<TransactionsForAddressRecord>,
     sort_order: SortOrder,
     limit: u64,
 ) -> Vec<TransactionsForAddressRecord> {
     records.sort_unstable_by(|a, b| compare_transactions_for_address_records(sort_order, a, b));
+    records.truncate(limit as usize);
+    records
+}
 
-    let mut seen = HashSet::with_capacity(records.len());
-    let mut merged = Vec::with_capacity(records.len().min(limit as usize));
-    for record in records {
-        if !seen.insert(record.signature.clone()) {
-            continue;
-        }
-        merged.push(record);
-        if merged.len() >= limit as usize {
-            break;
+fn append_unique_transactions_for_address_records(
+    output: &mut Vec<TransactionsForAddressRecord>,
+    seen: &mut HashSet<String>,
+    batch: Vec<TransactionsForAddressRecord>,
+    limit: usize,
+) {
+    for record in batch {
+        if seen.insert(record.signature.clone()) {
+            output.push(record);
+            if output.len() >= limit {
+                break;
+            }
         }
     }
-
-    merged
 }
 
 fn decode_transaction_signature(signature: &str) -> ProcessingResult<([u8; 64], String)> {
@@ -186,102 +200,179 @@ impl ClickHouseClient {
                 )));
             }
 
-            if self.should_use_gsfa_hot_fanout(&pubkey)
-                && query.token_accounts == TokenAccountsFilter::None
-            {
-                return self
-                    .get_hot_transactions_for_address_signatures(query, &pubkey)
-                    .await;
-            }
+            let requested_limit = query.limit;
+            let mut page_query = query.clone();
+            let mut seen = HashSet::with_capacity(requested_limit as usize);
+            let mut records = Vec::with_capacity(requested_limit as usize);
+            let mut timings = QueryTimings::zero();
 
-            if self.should_use_gsfa_shard_routing(&pubkey)
-                && let Some(router) = &self.gsfa_router
-            {
-                let token_owner_local_table = if query.token_accounts != TokenAccountsFilter::None {
-                    self.token_owner_activity_local_table.as_deref()
-                } else {
-                    Some(self.token_owner_activity_table.as_str())
+            while records.len() < requested_limit as usize {
+                let remaining = requested_limit.saturating_sub(records.len() as u64);
+                let batch_limit = transactions_for_address_batch_size(remaining);
+                page_query.limit = batch_limit;
+
+                let (mut batch, batch_timings) = self
+                    .get_transactions_for_address_signatures_batch(&page_query, &pubkey)
+                    .await?;
+                timings.add(batch_timings);
+
+                batch.sort_unstable_by(|a, b| {
+                    compare_transactions_for_address_records(query.sort_order, a, b)
+                });
+                let raw_count = batch.len() as u64;
+                let continuation = batch.last().map(|record| SignatureSlot {
+                    slot: record.slot,
+                    slot_idx: record.slot_idx,
+                });
+
+                append_unique_transactions_for_address_records(
+                    &mut records,
+                    &mut seen,
+                    batch,
+                    requested_limit as usize,
+                );
+
+                if records.len() >= requested_limit as usize || raw_count < batch_limit {
+                    break;
+                }
+
+                let Some(continuation) = continuation else {
+                    break;
                 };
-                let mut allow_local_http = self.transport_http();
-
-                if self.transport_tcp() {
-                    match self
-                        .try_get_transactions_for_address_signatures_tcp(
-                            router,
-                            token_owner_local_table,
-                            query,
-                            &pubkey,
-                        )
-                        .await?
-                    {
-                        Some(result) => return Ok(result),
-                        None => allow_local_http = true,
-                    }
+                if page_query.resolved_pagination == Some(continuation) {
+                    break;
                 }
-
-                if allow_local_http
-                    && let Some(result) = self
-                        .try_get_transactions_for_address_signatures_http(
-                            router,
-                            token_owner_local_table,
-                            query,
-                            &pubkey,
-                        )
-                        .await?
-                {
-                    return Ok(result);
-                }
+                page_query.pagination = Some(PaginationToken::SlotIndex {
+                    slot: continuation.slot,
+                    idx: continuation.slot_idx,
+                });
+                page_query.resolved_pagination = Some(continuation);
             }
 
-            let settings_clause = self.select_settings_clause_with_condition_cache(
-                "get_transactions_for_address_signatures",
-                QueryFreshnessClass::Historical,
-            );
-            let gsfa_table = self.gsfa_table_for_address(&pubkey);
-            let gsfa_bucket_modulus = self.gsfa_bucket_modulus_for_address(&pubkey);
-            let tables = TransactionsForAddressTables {
-                gsfa_table,
-                gsfa_bucket_modulus,
-                token_owner_table: &self.token_owner_activity_table,
-                token_owner_bucket_modulus: self.token_owner_bucket_modulus(),
-                signatures_table: &self.signature_statuses_table,
-                signature_bucket_modulus: self.signatures_bucket_modulus(),
-            };
-            let query = build_transactions_for_address_query(&tables, query, &settings_clause)?;
-
-            let start = Instant::now();
-            let mut cursor = self
-                .client
-                .query(&query)
-                .fetch::<TransactionsForAddressQueryRow>()
-                .map_err(|e| ProcessingError::database(e.to_string(), e))?;
-
-            let mut results = Vec::new();
-            while let Some(row) = cursor
-                .next()
-                .await
-                .map_err(|e| ProcessingError::database(e.to_string(), e))?
-            {
-                results.push(row);
-            }
-
-            let records = results
-                .into_iter()
-                .map(map_transactions_for_address_row)
-                .collect::<Vec<_>>();
-
-            let timings = QueryTimings {
-                elapsed_ms: start.elapsed().as_millis() as u64,
-                received_bytes: cursor.received_bytes(),
-                decoded_bytes: cursor.decoded_bytes(),
-                rows_read: Some(0),
-                rows_read_unknown: true,
-                rows_returned: records.len() as u64,
-            };
-
+            timings.rows_returned = records.len() as u64;
             Ok((records, timings))
         })
         .await
+    }
+
+    async fn get_transactions_for_address_signatures_batch(
+        &self,
+        query: &TransactionsForAddressQuery,
+        pubkey: &Pubkey,
+    ) -> ProcessingResult<(Vec<TransactionsForAddressRecord>, QueryTimings)> {
+        if self.should_use_gsfa_hot_fanout(pubkey)
+            && query.token_accounts == TokenAccountsFilter::None
+        {
+            return self
+                .get_hot_transactions_for_address_signatures(query, pubkey)
+                .await;
+        }
+
+        if self.should_use_gsfa_shard_routing(pubkey) && self.shard_topology.is_some() {
+            let router = self.gsfa_router.as_ref().ok_or_else(|| {
+                ProcessingError::database_msg(
+                    "Shard topology is configured but GSFA owner-shard routing is unavailable",
+                )
+            })?;
+            let token_owner_local_table = if query.token_accounts != TokenAccountsFilter::None {
+                Some(
+                    self.token_owner_activity_local_table
+                        .as_deref()
+                        .ok_or_else(|| {
+                            ProcessingError::database_msg(
+                                "Shard topology is configured but token-owner shard routing is unavailable",
+                            )
+                        })?,
+                )
+            } else {
+                Some(self.token_owner_activity_table.as_str())
+            };
+
+            let mut allow_local_http = self.transport_http();
+
+            if self.transport_tcp() {
+                match self
+                    .try_get_transactions_for_address_signatures_tcp(
+                        router,
+                        token_owner_local_table,
+                        query,
+                        pubkey,
+                    )
+                    .await?
+                {
+                    Some(result) => return Ok(result),
+                    None => allow_local_http = true,
+                }
+            }
+
+            if allow_local_http {
+                return self
+                    .try_get_transactions_for_address_signatures_http(
+                        router,
+                        token_owner_local_table,
+                        query,
+                        pubkey,
+                    )
+                    .await?
+                    .ok_or_else(|| {
+                        ProcessingError::database_msg(
+                            "Shard-local getTransactionsForAddress query was unavailable",
+                        )
+                    });
+            }
+
+            return Err(ProcessingError::database_msg(
+                "No shard-local transport is available for getTransactionsForAddress",
+            ));
+        }
+
+        let settings_clause = self.select_settings_clause_with_condition_cache(
+            "get_transactions_for_address_signatures",
+            QueryFreshnessClass::Historical,
+        );
+        let gsfa_table = self.gsfa_table_for_address(pubkey);
+        let gsfa_bucket_modulus = self.gsfa_bucket_modulus_for_address(pubkey);
+        let tables = TransactionsForAddressTables {
+            gsfa_table,
+            gsfa_bucket_modulus,
+            token_owner_table: &self.token_owner_activity_table,
+            token_owner_bucket_modulus: self.token_owner_bucket_modulus(),
+            signatures_table: &self.signature_statuses_table,
+            signature_bucket_modulus: self.signatures_bucket_modulus(),
+        };
+        let query = build_transactions_for_address_query(&tables, query, &settings_clause)?;
+
+        let start = Instant::now();
+        let mut cursor = self
+            .client
+            .query(&query)
+            .fetch::<TransactionsForAddressQueryRow>()
+            .map_err(|e| ProcessingError::database(e.to_string(), e))?;
+
+        let mut results = Vec::new();
+        while let Some(row) = cursor
+            .next()
+            .await
+            .map_err(|e| ProcessingError::database(e.to_string(), e))?
+        {
+            results.push(row);
+        }
+
+        let records = results
+            .into_iter()
+            .map(map_transactions_for_address_row)
+            .collect::<Vec<_>>();
+
+        let timings = QueryTimings {
+            elapsed_ms: start.elapsed().as_millis() as u64,
+            received_bytes: cursor.received_bytes(),
+            decoded_bytes: cursor.decoded_bytes(),
+            rows_read: Some(0),
+            rows_read_unknown: true,
+            rows_returned: records.len() as u64,
+        };
+
+        Ok((records, timings))
     }
 
     async fn get_hot_transactions_for_address_signatures(
@@ -837,7 +928,7 @@ impl ClickHouseClient {
         }
 
         let records =
-            merge_hot_transactions_for_address_records(records, query.sort_order, query.limit);
+            order_transactions_for_address_records(records, query.sort_order, query.limit);
         timings.rows_returned = records.len() as u64;
         Ok((records, timings))
     }
@@ -886,19 +977,13 @@ impl ClickHouseClient {
         let mut cursor = match shard.http_client.query(&query_sql).fetch::<QueryResult>() {
             Ok(cursor) => cursor,
             Err(err) => {
-                crate::metrics::clickhouse_transport_fallback(
-                    "get_transactions_for_address_signatures_local_http",
-                    "http",
-                    "distributed",
-                    "query_init",
-                );
-                tracing::warn!(
-                    "Shard {}:{} HTTP query failed; falling back to distributed table: {}",
-                    shard.host,
-                    shard.tcp_port,
-                    err
-                );
-                return Ok(None);
+                return Err(ProcessingError::database(
+                    format!(
+                        "Shard {}:{} HTTP getTransactionsForAddress query failed",
+                        shard.host, shard.tcp_port
+                    ),
+                    err,
+                ));
             }
         };
 
@@ -920,19 +1005,13 @@ impl ClickHouseClient {
                 }
                 Ok(None) => break,
                 Err(err) => {
-                    crate::metrics::clickhouse_transport_fallback(
-                        "get_transactions_for_address_signatures_local_http",
-                        "http",
-                        "distributed",
-                        "stream_error",
-                    );
-                    tracing::warn!(
-                        "Shard {}:{} HTTP query stream failed; falling back to distributed table: {}",
-                        shard.host,
-                        shard.tcp_port,
-                        err
-                    );
-                    return Ok(None);
+                    return Err(ProcessingError::database(
+                        format!(
+                            "Shard {}:{} HTTP getTransactionsForAddress query stream failed",
+                            shard.host, shard.tcp_port
+                        ),
+                        err,
+                    ));
                 }
             }
         }
@@ -1050,7 +1129,7 @@ impl ClickHouseClient {
         }
 
         let records =
-            merge_hot_transactions_for_address_records(records, query.sort_order, query.limit);
+            order_transactions_for_address_records(records, query.sort_order, query.limit);
         timings.rows_returned = records.len() as u64;
         Ok((records, timings))
     }
@@ -1187,6 +1266,64 @@ mod tests {
 
     fn normalize_sql(sql: &str) -> String {
         sql.split_whitespace().collect::<Vec<_>>().join(" ")
+    }
+
+    fn transactions_for_address_record(
+        signature: &str,
+        slot: u64,
+        slot_idx: u32,
+    ) -> TransactionsForAddressRecord {
+        TransactionsForAddressRecord {
+            signature: signature.to_string(),
+            slot,
+            slot_idx,
+            err: None,
+            memo: None,
+            block_time: None,
+        }
+    }
+
+    #[test]
+    fn transactions_for_address_batch_size_overfetches_with_bounds() {
+        assert_eq!(transactions_for_address_batch_size(1), 64);
+        assert_eq!(transactions_for_address_batch_size(100), 200);
+        assert_eq!(transactions_for_address_batch_size(1_000), 2_000);
+        assert_eq!(transactions_for_address_batch_size(u64::MAX), 2_000);
+    }
+
+    #[test]
+    fn transactions_for_address_deduplicates_across_internal_batches() {
+        let mut output = Vec::new();
+        let mut seen = HashSet::new();
+
+        append_unique_transactions_for_address_records(
+            &mut output,
+            &mut seen,
+            vec![
+                transactions_for_address_record("sig-c", 30, 3),
+                transactions_for_address_record("sig-c", 30, 3),
+                transactions_for_address_record("sig-b", 20, 2),
+            ],
+            3,
+        );
+        append_unique_transactions_for_address_records(
+            &mut output,
+            &mut seen,
+            vec![
+                transactions_for_address_record("sig-b", 20, 2),
+                transactions_for_address_record("sig-a", 10, 1),
+                transactions_for_address_record("sig-old", 5, 0),
+            ],
+            3,
+        );
+
+        assert_eq!(
+            output
+                .iter()
+                .map(|record| record.signature.as_str())
+                .collect::<Vec<_>>(),
+            vec!["sig-c", "sig-b", "sig-a"]
+        );
     }
 
     #[test]

--- a/crates/superbank-rpc/src/config.rs
+++ b/crates/superbank-rpc/src/config.rs
@@ -348,12 +348,12 @@ pub struct RpcConfig {
     #[arg(long, env = "CLICKHOUSE_CLUSTER", default_value = "{cluster}")]
     pub(crate) clickhouse_cluster: String,
 
-    /// Optional authoritative YAML topology file for shard-direct ClickHouse connections.
+    /// Optional authoritative YAML topology file for shard-local ClickHouse connections.
     /// When set, superbank-rpc skips system.clusters discovery and uses the YAML mapping directly.
     #[arg(long, env = "CLICKHOUSE_TOPOLOGY_CONFIG")]
     pub(crate) clickhouse_topology_config: Option<String>,
 
-    /// Local gsfa table name on each shard (required for CLICKHOUSE_SCOPE=shard-direct).
+    /// Local gsfa table used by shard-direct and owner-shard address queries.
     #[arg(long, env = "CLICKHOUSE_GSFA_LOCAL_TABLE")]
     pub(crate) clickhouse_gsfa_local_table: Option<String>,
 

--- a/crates/superbank-rpc/src/handlers/transactions.rs
+++ b/crates/superbank-rpc/src/handlers/transactions.rs
@@ -912,8 +912,6 @@ pub(crate) async fn handle_get_transactions_for_address(
     });
 
     let address_pubkey = Pubkey::from_str(address).expect("validated address");
-    let hot_fanout_eligible = state.clickhouse.is_gsfa_hot_address(&address_pubkey)
-        && token_accounts == TokenAccountsFilter::None;
 
     let mut query = TransactionsForAddressQuery {
         address: address.to_string(),
@@ -935,61 +933,64 @@ pub(crate) async fn handle_get_transactions_for_address(
     let disk_candidate = false;
 
     let mut prequery_timings = QueryTimings::zero();
-    if hot_fanout_eligible || disk_candidate {
-        match query.pagination.as_ref() {
-            Some(PaginationToken::SlotIndex { slot, idx }) => {
-                query.resolved_pagination = Some(SignatureSlot {
-                    slot: *slot,
-                    slot_idx: *idx,
-                });
-            }
-            Some(PaginationToken::Signature(signature)) => {
-                let (position, timings) =
-                    match resolve_signature_slot_for_bounds(state.as_ref(), signature).await {
-                        Ok(result) => result,
-                        Err(e) => {
-                            metrics::backend_error("get_signature_slot");
-                            error!(
-                                "Failed to resolve hot pagination signature {signature}: {}",
-                                e
-                            );
-                            return Ok(json_rpc_internal_error_response(id));
-                        }
-                    };
-                prequery_timings.add(timings);
-                query.resolved_pagination = position;
-            }
-            None => {}
+    match query.pagination.clone() {
+        Some(PaginationToken::SlotIndex { slot, idx }) => {
+            query.resolved_pagination = Some(SignatureSlot {
+                slot,
+                slot_idx: idx,
+            });
         }
-
-        if let Some(signature_filter) = query.signature_filter.as_ref() {
-            let mut resolved = ResolvedSignatureFilter::default();
-            for (label, maybe_signature, slot_ref) in [
-                ("gte", signature_filter.gte.as_deref(), &mut resolved.gte),
-                ("gt", signature_filter.gt.as_deref(), &mut resolved.gt),
-                ("lte", signature_filter.lte.as_deref(), &mut resolved.lte),
-                ("lt", signature_filter.lt.as_deref(), &mut resolved.lt),
-            ] {
-                let Some(signature) = maybe_signature else {
-                    continue;
+        Some(PaginationToken::Signature(signature)) => {
+            let (position, timings) =
+                match resolve_signature_slot_for_bounds(state.as_ref(), &signature).await {
+                    Ok(result) => result,
+                    Err(e) => {
+                        metrics::backend_error("get_signature_slot");
+                        error!("Failed to resolve pagination signature {signature}: {}", e);
+                        return Ok(json_rpc_internal_error_response(id));
+                    }
                 };
-                let (position, timings) =
-                    match resolve_signature_slot_for_bounds(state.as_ref(), signature).await {
-                        Ok(result) => result,
-                        Err(e) => {
-                            metrics::backend_error("get_signature_slot");
-                            error!(
-                                "Failed to resolve hot signature filter {label}={signature}: {}",
-                                e
-                            );
-                            return Ok(json_rpc_internal_error_response(id));
-                        }
-                    };
-                prequery_timings.add(timings);
-                *slot_ref = position;
-            }
-            query.resolved_signature_filter = Some(resolved);
+            prequery_timings.add(timings);
+            query.resolved_pagination = position;
+            query.pagination = position.map(|position| PaginationToken::SlotIndex {
+                slot: position.slot,
+                idx: position.slot_idx,
+            });
         }
+        None => {}
+    }
+
+    let hot_fanout_eligible = state.clickhouse.is_gsfa_hot_address(&address_pubkey)
+        && token_accounts == TokenAccountsFilter::None;
+    if (hot_fanout_eligible || disk_candidate)
+        && let Some(signature_filter) = query.signature_filter.as_ref()
+    {
+        let mut resolved = ResolvedSignatureFilter::default();
+        for (label, maybe_signature, slot_ref) in [
+            ("gte", signature_filter.gte.as_deref(), &mut resolved.gte),
+            ("gt", signature_filter.gt.as_deref(), &mut resolved.gt),
+            ("lte", signature_filter.lte.as_deref(), &mut resolved.lte),
+            ("lt", signature_filter.lt.as_deref(), &mut resolved.lt),
+        ] {
+            let Some(signature) = maybe_signature else {
+                continue;
+            };
+            let (position, timings) =
+                match resolve_signature_slot_for_bounds(state.as_ref(), signature).await {
+                    Ok(result) => result,
+                    Err(e) => {
+                        metrics::backend_error("get_signature_slot");
+                        error!(
+                            "Failed to resolve hot signature filter {label}={signature}: {}",
+                            e
+                        );
+                        return Ok(json_rpc_internal_error_response(id));
+                    }
+                };
+            prequery_timings.add(timings);
+            *slot_ref = position;
+        }
+        query.resolved_signature_filter = Some(resolved);
     }
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
Resolve signature pagination tokens before querying GSFA and use raw slot/transaction-index predicates that follow the table sort key.

Route non-hot address reads directly to the owner shard when topology is available. Replace ClickHouse LIMIT BY deduplication with bounded client-side overfetch and deduplication to avoid expensive query plans.

Add coverage for ascending and descending cursors, batching, and duplicate
records, and document the owner-shard routing behavior.

Refs BLO-517