### PR TITLE
feat: add commission_bps field to responses

### DIFF
--- a/crates/superbank-rpc/README.md
+++ b/crates/superbank-rpc/README.md
@@ -33,6 +33,9 @@ Notes:
 - `getInflationReward` reads the payout epoch boundary and only the reward partitions selected by
   the requested addresses. It never expands reward arrays across a complete epoch; dedicated
   address, concurrency, timeout, thread, memory, and read-byte limits are enabled by default.
+- Reward objects expose the optional Agave `commissionBps` field when the ingested source supplied
+  it. Legacy rows ingested before the basis-point columns were deployed omit the field; Superbank
+  does not infer it from the legacy percentage `commission` value.
 - `processed` commitment is supported for a subset of methods when compiled with
   `--features grpc-head-cache` and enabled at runtime with `HEAD_CACHE_ENABLED=true`
   (see "Optional gRPC head cache" below).

--- a/crates/superbank-rpc/build.rs
+++ b/crates/superbank-rpc/build.rs
@@ -23,6 +23,9 @@ fn emit_git_sha() {
 #[cfg(feature = "grpc-streaming")]
 fn compile_protos() -> Result<(), Box<dyn std::error::Error>> {
     let protos = ["proto/superbank.proto", "proto/confirmed_block.proto"];
+    for proto in &protos {
+        println!("cargo:rerun-if-changed={proto}");
+    }
     tonic_prost_build::configure().compile_protos(&protos, &["proto"])?;
     Ok(())
 }

--- a/crates/superbank-rpc/proto/confirmed_block.proto
+++ b/crates/superbank-rpc/proto/confirmed_block.proto
@@ -120,6 +120,7 @@ message Reward {
     uint64 post_balance = 3;
     RewardType reward_type = 4;
     string commission = 5;
+    string commission_bps = 6;
 }
 
 message Rewards {

--- a/crates/superbank-rpc/src/clickhouse/blocks.rs
+++ b/crates/superbank-rpc/src/clickhouse/blocks.rs
@@ -86,6 +86,7 @@ struct InflationRewardRow {
     lamports: i64,
     post_balance: u64,
     commission: Option<u8>,
+    commission_bps: Option<u16>,
 }
 
 fn build_inflation_boundary_query(
@@ -168,11 +169,12 @@ fn build_inflation_rewards_query(
             tupleElement(latest, 1) AS effective_slot,
             tupleElement(latest, 2) AS lamports,
             tupleElement(latest, 3) AS post_balance,
-            tupleElement(latest, 4) AS commission
+            tupleElement(latest, 4) AS commission,
+            tupleElement(latest, 5) AS commission_bps
          FROM (
             SELECT
                 reward.1 AS pubkey,
-                argMax(tuple(slot, reward.2, reward.3, reward.5), slot) AS latest
+                argMax(tuple(slot, reward.2, reward.3, reward.5, reward.6), slot) AS latest
             FROM (
                 SELECT
                     slot,
@@ -180,7 +182,12 @@ fn build_inflation_rewards_query(
                     rewards_lamports,
                     rewards_post_balance,
                     rewards_type,
-                    rewards_commission
+                    rewards_commission,
+                    if(
+                        empty(rewards_commission_bps),
+                        arrayMap(_ -> CAST(NULL, 'Nullable(UInt16)'), rewards_pubkey),
+                        rewards_commission_bps
+                    ) AS rewards_commission_bps
                 FROM {table}
                 PREWHERE slot IN ({slot_literals})
                 WHERE rewards_present = 1 AND hasAny(rewards_pubkey, target_pubkeys)
@@ -190,7 +197,8 @@ fn build_inflation_rewards_query(
                 rewards_lamports,
                 rewards_post_balance,
                 rewards_type,
-                rewards_commission
+                rewards_commission,
+                rewards_commission_bps
             ) AS reward
             WHERE has(target_pubkeys, reward.1) AND {reward_type_predicate}
             GROUP BY pubkey
@@ -1140,6 +1148,7 @@ impl ClickHouseClient {
                         lamports: row.lamports,
                         post_balance: row.post_balance,
                         commission: row.commission,
+                        commission_bps: row.commission_bps,
                     },
                 );
             }
@@ -1338,6 +1347,7 @@ impl ClickHouseClient {
                         lamports: row.lamports,
                         post_balance: row.post_balance,
                         commission: row.commission,
+                        commission_bps: row.commission_bps,
                     },
                 );
                 partition_reward_count = partition_reward_count.saturating_add(1);
@@ -2307,6 +2317,9 @@ mod tests {
         assert!(query.contains("PREWHERE slot IN (121392000, 121392017)"));
         assert!(!query.contains("PREWHERE slot >="));
         assert!(query.contains("ARRAY JOIN arrayZip"));
+        assert!(query.contains("AS rewards_commission_bps"));
+        assert!(query.contains("CAST(NULL, 'Nullable(UInt16)')"));
+        assert!(query.contains("tupleElement(latest, 5) AS commission_bps"));
         assert!(query.contains("= 'staking'"));
         assert!(query.contains("max_threads=2"));
         assert!(query.contains("max_memory_usage=536870912"));

--- a/crates/superbank-rpc/src/clickhouse/queries.rs
+++ b/crates/superbank-rpc/src/clickhouse/queries.rs
@@ -73,6 +73,7 @@ pub(crate) const TRANSACTION_SELECT_COLUMNS: &str = "signature,
                 meta_reward_post_balance,
                 meta_reward_type,
                 meta_reward_commission,
+                meta_reward_commission_bps,
                 meta_loaded_addresses_writable,
                 meta_loaded_addresses_readonly,
                 meta_return_data_present,
@@ -100,6 +101,7 @@ pub(crate) const BLOCK_METADATA_REWARD_COLUMNS: &[&str] = &[
     "rewards_post_balance",
     "rewards_type",
     "rewards_commission",
+    "rewards_commission_bps",
 ];
 
 pub(crate) const BLOCK_SIGNATURE_COLUMNS: &[&str] = &["signature"];
@@ -146,6 +148,7 @@ pub(crate) const BLOCK_TRANSACTION_REWARD_COLUMNS: &[&str] = &[
     "meta_reward_post_balance",
     "meta_reward_type",
     "meta_reward_commission",
+    "meta_reward_commission_bps",
 ];
 
 pub(crate) const BLOCK_FULL_BASE_COLUMNS: &[&str] = &[

--- a/crates/superbank-rpc/src/clickhouse/rows.rs
+++ b/crates/superbank-rpc/src/clickhouse/rows.rs
@@ -74,6 +74,7 @@ pub(crate) struct TransactionRow {
     pub(crate) meta_reward_post_balance: Vec<u64>,
     pub(crate) meta_reward_type: Vec<Option<String>>,
     pub(crate) meta_reward_commission: Vec<Option<u8>>,
+    pub(crate) meta_reward_commission_bps: Vec<Option<u16>>,
     pub(crate) meta_loaded_addresses_writable: Vec<Array<u8, 32>>,
     pub(crate) meta_loaded_addresses_readonly: Vec<Array<u8, 32>>,
     pub(crate) meta_return_data_present: bool,
@@ -99,6 +100,7 @@ pub(crate) struct BlockMetadataRow {
     pub(crate) rewards_post_balance: Vec<u64>,
     pub(crate) rewards_type: Vec<Option<String>>,
     pub(crate) rewards_commission: Vec<Option<u8>>,
+    pub(crate) rewards_commission_bps: Vec<Option<u16>>,
     pub(crate) rewards_num_partitions: Option<u64>,
 }
 
@@ -158,6 +160,7 @@ pub(crate) struct BlockAccountsTransactionRow {
     pub(crate) meta_reward_post_balance: Vec<u64>,
     pub(crate) meta_reward_type: Vec<Option<String>>,
     pub(crate) meta_reward_commission: Vec<Option<u8>>,
+    pub(crate) meta_reward_commission_bps: Vec<Option<u16>>,
     pub(crate) meta_loaded_addresses_writable: Vec<Array<u8, 32>>,
     pub(crate) meta_loaded_addresses_readonly: Vec<Array<u8, 32>>,
 }
@@ -217,6 +220,7 @@ pub(crate) struct BlockFullTransactionRow {
     pub(crate) meta_reward_post_balance: Vec<u64>,
     pub(crate) meta_reward_type: Vec<Option<String>>,
     pub(crate) meta_reward_commission: Vec<Option<u8>>,
+    pub(crate) meta_reward_commission_bps: Vec<Option<u16>>,
     pub(crate) meta_loaded_addresses_writable: Vec<Array<u8, 32>>,
     pub(crate) meta_loaded_addresses_readonly: Vec<Array<u8, 32>>,
     pub(crate) meta_return_data_present: bool,
@@ -326,6 +330,7 @@ pub(crate) fn map_transaction_row(row: TransactionRow) -> StoredTransactionRecor
         meta_reward_post_balance: row.meta_reward_post_balance,
         meta_reward_type: row.meta_reward_type,
         meta_reward_commission: row.meta_reward_commission,
+        meta_reward_commission_bps: row.meta_reward_commission_bps,
         meta_loaded_addresses_writable: row
             .meta_loaded_addresses_writable
             .into_iter()
@@ -360,6 +365,7 @@ pub(crate) fn map_block_metadata_base_row(row: BlockMetadataBaseRow) -> BlockMet
         rewards_post_balance: Vec::new(),
         rewards_type: Vec::new(),
         rewards_commission: Vec::new(),
+        rewards_commission_bps: Vec::new(),
         rewards_num_partitions: row.rewards_num_partitions,
     }
 }
@@ -432,6 +438,7 @@ pub(crate) fn map_block_accounts_transaction_row(
         meta_reward_post_balance: row.meta_reward_post_balance,
         meta_reward_type: row.meta_reward_type,
         meta_reward_commission: row.meta_reward_commission,
+        meta_reward_commission_bps: row.meta_reward_commission_bps,
         meta_loaded_addresses_writable: row
             .meta_loaded_addresses_writable
             .into_iter()
@@ -549,6 +556,7 @@ pub(crate) fn map_block_full_transaction_row(
         meta_reward_post_balance: row.meta_reward_post_balance,
         meta_reward_type: row.meta_reward_type,
         meta_reward_commission: row.meta_reward_commission,
+        meta_reward_commission_bps: row.meta_reward_commission_bps,
         meta_loaded_addresses_writable: row
             .meta_loaded_addresses_writable
             .into_iter()
@@ -645,6 +653,7 @@ pub(crate) fn map_block_metadata_row(row: BlockMetadataRow) -> BlockMetadataReco
         rewards_post_balance: row.rewards_post_balance,
         rewards_type: row.rewards_type,
         rewards_commission: row.rewards_commission,
+        rewards_commission_bps: row.rewards_commission_bps,
         rewards_num_partitions: row.rewards_num_partitions,
     }
 }

--- a/crates/superbank-rpc/src/clickhouse/types.rs
+++ b/crates/superbank-rpc/src/clickhouse/types.rs
@@ -253,6 +253,7 @@ pub struct BlockMetadataRecord {
     pub rewards_post_balance: Vec<u64>,
     pub rewards_type: Vec<Option<String>>,
     pub rewards_commission: Vec<Option<u8>>,
+    pub rewards_commission_bps: Vec<Option<u16>>,
     pub rewards_num_partitions: Option<u64>,
 }
 
@@ -263,6 +264,7 @@ pub struct InflationRewardRecord {
     pub lamports: i64,
     pub post_balance: u64,
     pub commission: Option<u8>,
+    pub commission_bps: Option<u16>,
 }
 
 #[derive(Debug, Clone)]
@@ -309,6 +311,7 @@ pub struct StoredAccountsTransactionRecord {
     pub meta_reward_post_balance: Vec<u64>,
     pub meta_reward_type: Vec<Option<String>>,
     pub meta_reward_commission: Vec<Option<u8>>,
+    pub meta_reward_commission_bps: Vec<Option<u16>>,
     pub meta_loaded_addresses_writable: Vec<[u8; 32]>,
     pub meta_loaded_addresses_readonly: Vec<[u8; 32]>,
 }
@@ -352,6 +355,7 @@ impl From<StoredTransactionRecord> for StoredAccountsTransactionRecord {
             meta_reward_post_balance: record.meta_reward_post_balance,
             meta_reward_type: record.meta_reward_type,
             meta_reward_commission: record.meta_reward_commission,
+            meta_reward_commission_bps: record.meta_reward_commission_bps,
             meta_loaded_addresses_writable: record.meta_loaded_addresses_writable,
             meta_loaded_addresses_readonly: record.meta_loaded_addresses_readonly,
         }
@@ -462,6 +466,7 @@ pub struct StoredTransactionRecord {
     pub meta_reward_post_balance: Vec<u64>,
     pub meta_reward_type: Vec<Option<String>>,
     pub meta_reward_commission: Vec<Option<u8>>,
+    pub meta_reward_commission_bps: Vec<Option<u16>>,
     pub meta_loaded_addresses_writable: Vec<[u8; 32]>,
     pub meta_loaded_addresses_readonly: Vec<[u8; 32]>,
     pub meta_return_data_present: bool,

--- a/crates/superbank-rpc/src/disk_cache/index.rs
+++ b/crates/superbank-rpc/src/disk_cache/index.rs
@@ -899,6 +899,7 @@ mod tests {
             meta_reward_post_balance: Vec::new(),
             meta_reward_type: Vec::new(),
             meta_reward_commission: Vec::new(),
+            meta_reward_commission_bps: Vec::new(),
             meta_loaded_addresses_writable: Vec::new(),
             meta_loaded_addresses_readonly: Vec::new(),
             meta_return_data_present: false,

--- a/crates/superbank-rpc/src/disk_cache/mod.rs
+++ b/crates/superbank-rpc/src/disk_cache/mod.rs
@@ -1105,6 +1105,7 @@ pub(crate) mod tests {
             rewards_post_balance: Vec::new(),
             rewards_type: Vec::new(),
             rewards_commission: Vec::new(),
+            rewards_commission_bps: Vec::new(),
             rewards_num_partitions: None,
         }
     }
@@ -1170,6 +1171,7 @@ pub(crate) mod tests {
             meta_reward_post_balance: Vec::new(),
             meta_reward_type: Vec::new(),
             meta_reward_commission: Vec::new(),
+            meta_reward_commission_bps: Vec::new(),
             meta_loaded_addresses_writable: Vec::new(),
             meta_loaded_addresses_readonly: Vec::new(),
             meta_return_data_present: false,

--- a/crates/superbank-rpc/src/disk_cache/schema.rs
+++ b/crates/superbank-rpc/src/disk_cache/schema.rs
@@ -21,7 +21,7 @@ use rocksdb::{
     Options, SliceTransform, compaction_filter::Decision,
 };
 
-pub(crate) const SCHEMA_VERSION: u32 = 1;
+pub(crate) const SCHEMA_VERSION: u32 = 2;
 
 pub(crate) const CF_META: &str = "meta";
 pub(crate) const CF_SLOT_COVERAGE: &str = "slot_coverage";
@@ -369,6 +369,7 @@ mod tests {
             meta_reward_post_balance: Vec::new(),
             meta_reward_type: Vec::new(),
             meta_reward_commission: Vec::new(),
+            meta_reward_commission_bps: Vec::new(),
             meta_loaded_addresses_writable: vec![[11u8; 32]],
             meta_loaded_addresses_readonly: Vec::new(),
             meta_return_data_present: true,
@@ -384,7 +385,7 @@ mod tests {
         assert_eq!(decoded.tx_signatures, record.tx_signatures);
         assert_eq!(
             fingerprint(&tx_bytes),
-            0x7448_21a9_4fd3_d7bb,
+            0x89b0_a948_0cb6_929b,
             "tx layout drift"
         );
 
@@ -403,12 +404,13 @@ mod tests {
             rewards_post_balance: vec![99],
             rewards_type: vec![Some("Fee".to_string())],
             rewards_commission: vec![Some(7)],
+            rewards_commission_bps: vec![Some(725)],
             rewards_num_partitions: Some(4),
         };
         let meta_bytes = bincode::serialize(&meta).expect("serialize meta");
         assert_eq!(
             fingerprint(&meta_bytes),
-            0x3200_ea90_2cf4_50dc,
+            0xf372_e612_a68f_ed8f,
             "block-meta layout drift"
         );
     }

--- a/crates/superbank-rpc/src/grpc/wire.rs
+++ b/crates/superbank-rpc/src/grpc/wire.rs
@@ -280,6 +280,8 @@ fn encode_rewards(metadata: &BlockMetadataRecord) -> Result<Vec<u8>, Status> {
         || metadata.rewards_post_balance.len() != len
         || metadata.rewards_type.len() != len
         || metadata.rewards_commission.len() != len
+        || (!metadata.rewards_commission_bps.is_empty()
+            && metadata.rewards_commission_bps.len() != len)
     {
         return Err(Status::new(
             Code::Internal,
@@ -301,6 +303,13 @@ fn encode_rewards(metadata: &BlockMetadataRecord) -> Result<Vec<u8>, Status> {
                     reward_type: reward_type as i32,
                     commission: metadata.rewards_commission[idx]
                         .map(|commission| commission.to_string())
+                        .unwrap_or_default(),
+                    commission_bps: metadata
+                        .rewards_commission_bps
+                        .get(idx)
+                        .copied()
+                        .flatten()
+                        .map(|commission_bps| commission_bps.to_string())
                         .unwrap_or_default(),
                 }
             })
@@ -325,6 +334,10 @@ fn encode_reward(reward: &Reward) -> storage_proto::Reward {
         commission: reward
             .commission
             .map(|commission| commission.to_string())
+            .unwrap_or_default(),
+        commission_bps: reward
+            .commission_bps
+            .map(|commission_bps| commission_bps.to_string())
             .unwrap_or_default(),
     }
 }
@@ -468,6 +481,7 @@ mod tests {
             meta_reward_post_balance: Vec::new(),
             meta_reward_type: Vec::new(),
             meta_reward_commission: Vec::new(),
+            meta_reward_commission_bps: Vec::new(),
             meta_loaded_addresses_writable: Vec::new(),
             meta_loaded_addresses_readonly: Vec::new(),
             meta_return_data_present: false,

--- a/crates/superbank-rpc/src/handlers/blocks.rs
+++ b/crates/superbank-rpc/src/handlers/blocks.rs
@@ -2260,6 +2260,7 @@ pub(crate) async fn handle_get_inflation_reward(
                 amount: row.lamports.unsigned_abs(),
                 post_balance: row.post_balance,
                 commission: row.commission,
+                commission_bps: row.commission_bps,
             },
         );
     }

--- a/crates/superbank-rpc/src/handlers/types.rs
+++ b/crates/superbank-rpc/src/handlers/types.rs
@@ -253,6 +253,8 @@ pub(crate) struct InflationRewardInfo {
     pub(crate) amount: u64,
     pub(crate) post_balance: u64,
     pub(crate) commission: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) commission_bps: Option<u16>,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/superbank-rpc/src/head_cache/convert.rs
+++ b/crates/superbank-rpc/src/head_cache/convert.rs
@@ -90,6 +90,7 @@ type RewardsConversion = (
     Vec<u64>,
     Vec<Option<String>>,
     Vec<Option<u8>>,
+    Vec<Option<u16>>,
 );
 type ReturnDataConversion = (bool, Option<[u8; 32]>, Option<Vec<u8>>);
 
@@ -291,6 +292,7 @@ fn convert_rewards(rewards: &[yellowstone_grpc_proto::prelude::Reward]) -> Rewar
     let mut post_balances = Vec::with_capacity(rewards.len());
     let mut reward_types = Vec::with_capacity(rewards.len());
     let mut commissions = Vec::with_capacity(rewards.len());
+    let mut commission_bps = Vec::with_capacity(rewards.len());
 
     for reward in rewards {
         pubkeys.push(reward.pubkey.clone());
@@ -298,9 +300,17 @@ fn convert_rewards(rewards: &[yellowstone_grpc_proto::prelude::Reward]) -> Rewar
         post_balances.push(reward.post_balance);
         reward_types.push(reward_type_to_string(reward.reward_type));
         commissions.push(parse_commission(&reward.commission));
+        commission_bps.push(parse_commission_bps(&reward.commission_bps));
     }
 
-    (pubkeys, lamports, post_balances, reward_types, commissions)
+    (
+        pubkeys,
+        lamports,
+        post_balances,
+        reward_types,
+        commissions,
+        commission_bps,
+    )
 }
 
 fn reward_type_to_string(value: i32) -> Option<String> {
@@ -316,6 +326,13 @@ fn parse_commission(value: &str) -> Option<u8> {
         return None;
     }
     value.parse::<u8>().ok()
+}
+
+fn parse_commission_bps(value: &str) -> Option<u16> {
+    if value.is_empty() {
+        return None;
+    }
+    value.parse::<u16>().ok()
 }
 
 fn convert_pubkeys(keys: &[Vec<u8>], what: &'static str) -> Result<Vec<[u8; 32]>, ConvertError> {
@@ -441,6 +458,7 @@ pub(crate) fn stored_record_from_transaction_info(
         meta_reward_post_balance,
         meta_reward_type,
         meta_reward_commission,
+        meta_reward_commission_bps,
     ) = convert_rewards(&meta.rewards);
 
     // gRPC does not distinguish between absent and empty rewards. Treat empty as present.
@@ -520,6 +538,7 @@ pub(crate) fn stored_record_from_transaction_info(
         meta_reward_post_balance,
         meta_reward_type,
         meta_reward_commission,
+        meta_reward_commission_bps,
         meta_loaded_addresses_writable,
         meta_loaded_addresses_readonly,
         meta_return_data_present,

--- a/crates/superbank-rpc/src/head_cache/dragonsmouth.rs
+++ b/crates/superbank-rpc/src/head_cache/dragonsmouth.rs
@@ -306,6 +306,7 @@ fn apply_block_meta(
         rewards_post_balance,
         rewards_type,
         rewards_commission,
+        rewards_commission_bps,
         rewards_num_partitions,
     ) = match parse_block_rewards(slot, meta.rewards.as_ref()) {
         Some(parts) => parts,
@@ -327,6 +328,7 @@ fn apply_block_meta(
         rewards_post_balance,
         rewards_type,
         rewards_commission,
+        rewards_commission_bps,
         rewards_num_partitions,
     });
 }
@@ -356,6 +358,7 @@ type ParsedRewards = (
     Vec<u64>,
     Vec<Option<String>>,
     Vec<Option<u8>>,
+    Vec<Option<u16>>,
     Option<u64>,
 );
 
@@ -371,6 +374,7 @@ fn parse_block_rewards(
             Vec::new(),
             Vec::new(),
             Vec::new(),
+            Vec::new(),
             None,
         ));
     };
@@ -380,6 +384,7 @@ fn parse_block_rewards(
     let mut rewards_post_balance = Vec::with_capacity(rewards.rewards.len());
     let mut rewards_type = Vec::with_capacity(rewards.rewards.len());
     let mut rewards_commission = Vec::with_capacity(rewards.rewards.len());
+    let mut rewards_commission_bps = Vec::with_capacity(rewards.rewards.len());
 
     for reward in &rewards.rewards {
         let pubkey = match reward.pubkey.parse::<Pubkey>() {
@@ -433,6 +438,21 @@ fn parse_block_rewards(
                 }
             }
         });
+        rewards_commission_bps.push(if reward.commission_bps.is_empty() {
+            None
+        } else {
+            match reward.commission_bps.parse::<u16>() {
+                Ok(value) => Some(value),
+                Err(err) => {
+                    warn!(
+                        slot,
+                        commission_bps = reward.commission_bps.as_str(),
+                        "head cache: failed to parse reward commission bps from BlockMeta: {err}"
+                    );
+                    return None;
+                }
+            }
+        });
     }
 
     Some((
@@ -442,6 +462,7 @@ fn parse_block_rewards(
         rewards_post_balance,
         rewards_type,
         rewards_commission,
+        rewards_commission_bps,
         rewards
             .num_partitions
             .as_ref()
@@ -549,7 +570,7 @@ mod tests {
                         post_balance: 99,
                         reward_type: yellowstone_grpc_proto::prelude::RewardType::Fee as i32,
                         commission: "7".to_string(),
-                        commission_bps: String::new(),
+                        commission_bps: "725".to_string(),
                     }],
                     num_partitions: Some(yellowstone_grpc_proto::prelude::NumPartitions {
                         num_partitions: 4,
@@ -593,6 +614,7 @@ mod tests {
         assert_eq!(metadata.rewards_post_balance, vec![99]);
         assert_eq!(metadata.rewards_type, vec![Some("Fee".to_string())]);
         assert_eq!(metadata.rewards_commission, vec![Some(7)]);
+        assert_eq!(metadata.rewards_commission_bps, vec![Some(725)]);
         assert_eq!(metadata.rewards_num_partitions, Some(4));
     }
 }

--- a/crates/superbank-rpc/src/head_cache/mod.rs
+++ b/crates/superbank-rpc/src/head_cache/mod.rs
@@ -954,6 +954,7 @@ mod tests {
             meta_reward_post_balance: Vec::new(),
             meta_reward_type: Vec::new(),
             meta_reward_commission: Vec::new(),
+            meta_reward_commission_bps: Vec::new(),
             meta_loaded_addresses_writable: Vec::new(),
             meta_loaded_addresses_readonly: Vec::new(),
             meta_return_data_present: false,
@@ -980,6 +981,7 @@ mod tests {
             rewards_post_balance: Vec::new(),
             rewards_type: Vec::new(),
             rewards_commission: Vec::new(),
+            rewards_commission_bps: Vec::new(),
             rewards_num_partitions: None,
         }
     }

--- a/crates/superbank-rpc/src/hydration/block.rs
+++ b/crates/superbank-rpc/src/hydration/block.rs
@@ -241,6 +241,7 @@ fn build_block_rewards(metadata: &BlockMetadataRecord) -> Result<Vec<Reward>, Bl
             || !metadata.rewards_post_balance.is_empty()
             || !metadata.rewards_type.is_empty()
             || !metadata.rewards_commission.is_empty()
+            || !metadata.rewards_commission_bps.is_empty()
         {
             return Err(BlockHydrationError::InvalidBlockMetadata(
                 "rewards fields populated without rewards_present".to_string(),
@@ -254,13 +255,16 @@ fn build_block_rewards(metadata: &BlockMetadataRecord) -> Result<Vec<Reward>, Bl
         || metadata.rewards_post_balance.len() != len
         || metadata.rewards_type.len() != len
         || metadata.rewards_commission.len() != len
+        || (!metadata.rewards_commission_bps.is_empty()
+            && metadata.rewards_commission_bps.len() != len)
     {
         return Err(BlockHydrationError::InvalidBlockMetadata(format!(
-            "reward length mismatch (pubkey={len}, lamports={}, post_balance={}, reward_type={}, commission={})",
+            "reward length mismatch (pubkey={len}, lamports={}, post_balance={}, reward_type={}, commission={}, commission_bps={})",
             metadata.rewards_lamports.len(),
             metadata.rewards_post_balance.len(),
             metadata.rewards_type.len(),
-            metadata.rewards_commission.len()
+            metadata.rewards_commission.len(),
+            metadata.rewards_commission_bps.len()
         )));
     }
 
@@ -272,7 +276,7 @@ fn build_block_rewards(metadata: &BlockMetadataRecord) -> Result<Vec<Reward>, Bl
             post_balance: metadata.rewards_post_balance[idx],
             reward_type: parse_reward_type(&metadata.rewards_type[idx])?,
             commission: metadata.rewards_commission[idx],
-            commission_bps: None,
+            commission_bps: metadata.rewards_commission_bps.get(idx).copied().flatten(),
         });
     }
 

--- a/crates/superbank-rpc/src/hydration/meta.rs
+++ b/crates/superbank-rpc/src/hydration/meta.rs
@@ -130,6 +130,7 @@ pub(crate) fn build_transaction_status_meta(
             || !record.meta_reward_post_balance.is_empty()
             || !record.meta_reward_type.is_empty()
             || !record.meta_reward_commission.is_empty()
+            || !record.meta_reward_commission_bps.is_empty()
         {
             return Err(TransactionHydrationError::InvalidStoredMetadata(
                 "rewards populated without meta_rewards_present".to_string(),
@@ -276,6 +277,7 @@ pub(crate) fn build_transaction_status_meta_for_accounts(
             &record.meta_reward_post_balance,
             &record.meta_reward_type,
             &record.meta_reward_commission,
+            &record.meta_reward_commission_bps,
         )?)
     } else {
         if !record.meta_reward_pubkey.is_empty()
@@ -283,6 +285,7 @@ pub(crate) fn build_transaction_status_meta_for_accounts(
             || !record.meta_reward_post_balance.is_empty()
             || !record.meta_reward_type.is_empty()
             || !record.meta_reward_commission.is_empty()
+            || !record.meta_reward_commission_bps.is_empty()
         {
             return Err(TransactionHydrationError::InvalidStoredMetadata(
                 "rewards populated without meta_rewards_present".to_string(),
@@ -376,6 +379,7 @@ fn meta_is_missing(record: &StoredTransactionRecord) -> bool {
         || !record.meta_reward_post_balance.is_empty()
         || !record.meta_reward_type.is_empty()
         || !record.meta_reward_commission.is_empty()
+        || !record.meta_reward_commission_bps.is_empty()
     {
         return false;
     }
@@ -440,6 +444,7 @@ fn accounts_meta_is_missing(record: &StoredAccountsTransactionRecord) -> bool {
         || !record.meta_reward_post_balance.is_empty()
         || !record.meta_reward_type.is_empty()
         || !record.meta_reward_commission.is_empty()
+        || !record.meta_reward_commission_bps.is_empty()
     {
         return false;
     }
@@ -860,6 +865,7 @@ fn build_rewards(
         &record.meta_reward_post_balance,
         &record.meta_reward_type,
         &record.meta_reward_commission,
+        &record.meta_reward_commission_bps,
     )
 }
 
@@ -869,19 +875,22 @@ fn build_rewards_from_fields(
     post_balances: &[u64],
     reward_types: &[Option<String>],
     commissions: &[Option<u8>],
+    commission_bps: &[Option<u16>],
 ) -> Result<Vec<Reward>, TransactionHydrationError> {
     let len = pubkeys.len();
     if lamports.len() != len
         || post_balances.len() != len
         || reward_types.len() != len
         || commissions.len() != len
+        || (!commission_bps.is_empty() && commission_bps.len() != len)
     {
         return Err(TransactionHydrationError::InvalidStoredMetadata(format!(
-            "reward length mismatch (pubkey={len}, lamports={}, post_balance={}, reward_type={}, commission={})",
+            "reward length mismatch (pubkey={len}, lamports={}, post_balance={}, reward_type={}, commission={}, commission_bps={})",
             lamports.len(),
             post_balances.len(),
             reward_types.len(),
-            commissions.len()
+            commissions.len(),
+            commission_bps.len()
         )));
     }
 
@@ -893,7 +902,7 @@ fn build_rewards_from_fields(
             post_balance: post_balances[idx],
             reward_type: parse_reward_type(&reward_types[idx])?,
             commission: commissions[idx],
-            commission_bps: None,
+            commission_bps: commission_bps.get(idx).copied().flatten(),
         });
     }
 

--- a/crates/superbank-rpc/src/tests/mod.rs
+++ b/crates/superbank-rpc/src/tests/mod.rs
@@ -46,7 +46,7 @@ use crate::handlers::signatures::{
     handle_get_signature_statuses, handle_get_signatures_for_address,
 };
 use crate::handlers::transactions::handle_get_transactions_for_address;
-use crate::handlers::types::MAX_GET_BLOCKS_RANGE;
+use crate::handlers::types::{InflationRewardInfo, MAX_GET_BLOCKS_RANGE};
 use crate::hydration::BlockHydrationError;
 use crate::hydration::build_transaction_status_meta;
 use crate::hydration::build_transaction_status_meta_for_accounts;
@@ -571,6 +571,7 @@ fn base_transaction_record() -> StoredTransactionRecord {
         meta_reward_post_balance: Vec::new(),
         meta_reward_type: Vec::new(),
         meta_reward_commission: Vec::new(),
+        meta_reward_commission_bps: Vec::new(),
         meta_loaded_addresses_writable: Vec::new(),
         meta_loaded_addresses_readonly: Vec::new(),
         meta_return_data_present: false,
@@ -598,6 +599,7 @@ fn base_block_record(slot: u64) -> StoredBlockRecord {
             rewards_post_balance: Vec::new(),
             rewards_type: Vec::new(),
             rewards_commission: Vec::new(),
+            rewards_commission_bps: Vec::new(),
             rewards_num_partitions: None,
         },
         transactions: Vec::new(),
@@ -782,6 +784,7 @@ fn hydrate_transaction_record_base64_round_trip() {
         meta_reward_post_balance: Vec::new(),
         meta_reward_type: Vec::new(),
         meta_reward_commission: Vec::new(),
+        meta_reward_commission_bps: Vec::new(),
         meta_loaded_addresses_writable: Vec::new(),
         meta_loaded_addresses_readonly: Vec::new(),
         meta_return_data_present: false,
@@ -3444,6 +3447,7 @@ fn build_v0_transaction_allows_missing_lookup_flag_when_empty() {
         meta_reward_post_balance: Vec::new(),
         meta_reward_type: Vec::new(),
         meta_reward_commission: Vec::new(),
+        meta_reward_commission_bps: Vec::new(),
         meta_loaded_addresses_writable: Vec::new(),
         meta_loaded_addresses_readonly: Vec::new(),
         meta_return_data_present: false,
@@ -6078,6 +6082,52 @@ fn build_transaction_status_meta_emits_empty_lists_when_present() {
 }
 
 #[test]
+fn build_transaction_status_meta_preserves_commission_bps() {
+    let mut record = base_transaction_record();
+    record.meta_rewards_present = true;
+    record.meta_reward_pubkey = vec![solana_sdk::pubkey::Pubkey::new_unique().to_string()];
+    record.meta_reward_lamports = vec![10];
+    record.meta_reward_post_balance = vec![20];
+    record.meta_reward_type = vec![Some("Staking".to_string())];
+    record.meta_reward_commission = vec![None];
+    record.meta_reward_commission_bps = vec![Some(300)];
+
+    let meta = build_transaction_status_meta(&record)
+        .expect("build meta")
+        .expect("meta present");
+    let reward = &meta.rewards.expect("rewards")[0];
+
+    assert_eq!(reward.commission, None);
+    assert_eq!(reward.commission_bps, Some(300));
+}
+
+#[test]
+fn inflation_reward_serialization_omits_unavailable_commission_bps() {
+    let reward = InflationRewardInfo {
+        epoch: 1005,
+        effective_slot: 434_592_000,
+        amount: 1,
+        post_balance: 2,
+        commission: None,
+        commission_bps: None,
+    };
+    let value = serde_json::to_value(&reward).expect("serialize reward");
+    assert!(
+        !value
+            .as_object()
+            .expect("object")
+            .contains_key("commissionBps")
+    );
+
+    let value = serde_json::to_value(InflationRewardInfo {
+        commission_bps: Some(300),
+        ..reward
+    })
+    .expect("serialize reward");
+    assert_eq!(value["commissionBps"], 300);
+}
+
+#[test]
 fn build_transaction_status_meta_for_accounts_emits_empty_rewards_when_absent() {
     let mut record = base_transaction_record();
     record.meta_pre_balances = vec![1];
@@ -6137,6 +6187,38 @@ fn hydrate_block_record_rejects_reward_length_mismatch() {
             assert!(msg.contains("reward length mismatch"));
         }
         other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[test]
+fn hydrate_block_record_supports_legacy_and_populated_commission_bps() {
+    for commission_bps in [Vec::new(), vec![Some(300)]] {
+        let mut record = base_block_record(10);
+        record.metadata.rewards_present = true;
+        record.metadata.rewards_pubkey.push([9u8; 32]);
+        record.metadata.rewards_lamports.push(1);
+        record.metadata.rewards_post_balance.push(2);
+        record
+            .metadata
+            .rewards_type
+            .push(Some("Staking".to_string()));
+        record.metadata.rewards_commission.push(None);
+        record.metadata.rewards_commission_bps = commission_bps.clone();
+
+        let block = hydrate_block_record(
+            record,
+            UiTransactionEncoding::Json,
+            TransactionDetails::Signatures,
+            true,
+            None,
+        )
+        .expect("hydrate block");
+        let reward = &block.rewards.expect("rewards")[0];
+
+        assert_eq!(
+            reward.commission_bps,
+            commission_bps.first().copied().flatten()
+        );
     }
 }
 

--- a/crates/superbank/src/clickhouse.rs
+++ b/crates/superbank/src/clickhouse.rs
@@ -74,6 +74,7 @@ pub(crate) struct TransactionRow {
     pub(crate) meta_reward_post_balance: Vec<u64>,
     pub(crate) meta_reward_type: Vec<Option<String>>,
     pub(crate) meta_reward_commission: Vec<Option<u8>>,
+    pub(crate) meta_reward_commission_bps: Vec<Option<u16>>,
     pub(crate) meta_loaded_addresses_writable: Vec<Array<u8, 32>>,
     pub(crate) meta_loaded_addresses_readonly: Vec<Array<u8, 32>>,
     pub(crate) meta_return_data_present: u8,
@@ -99,6 +100,7 @@ pub(crate) struct BlockMetadataRow {
     pub(crate) rewards_post_balance: Vec<u64>,
     pub(crate) rewards_type: Vec<Option<String>>,
     pub(crate) rewards_commission: Vec<Option<u8>>,
+    pub(crate) rewards_commission_bps: Vec<Option<u16>>,
     pub(crate) rewards_num_partitions: Option<u64>,
 }
 

--- a/crates/superbank/src/ingest/grpc.rs
+++ b/crates/superbank/src/ingest/grpc.rs
@@ -877,6 +877,7 @@ fn map_block_metadata(block: &SubscribeUpdateBlock) -> Result<BlockMetadataRow> 
     let mut rewards_post_balance = Vec::new();
     let mut rewards_type = Vec::new();
     let mut rewards_commission = Vec::new();
+    let mut rewards_commission_bps = Vec::new();
     let mut rewards_num_partitions = None;
 
     if let Some(rewards) = block.rewards.as_ref() {
@@ -887,6 +888,7 @@ fn map_block_metadata(block: &SubscribeUpdateBlock) -> Result<BlockMetadataRow> 
             rewards_post_balance.push(reward.post_balance);
             rewards_type.push(reward_type_to_string(reward.reward_type));
             rewards_commission.push(parse_commission(&reward.commission));
+            rewards_commission_bps.push(parse_commission_bps(&reward.commission_bps));
         }
         rewards_num_partitions = rewards.num_partitions.as_ref().map(|p| p.num_partitions);
     }
@@ -906,6 +908,7 @@ fn map_block_metadata(block: &SubscribeUpdateBlock) -> Result<BlockMetadataRow> 
         rewards_post_balance,
         rewards_type,
         rewards_commission,
+        rewards_commission_bps,
         rewards_num_partitions,
     })
 }
@@ -1039,6 +1042,7 @@ fn map_transaction(
         meta_reward_post_balance,
         meta_reward_type,
         meta_reward_commission,
+        meta_reward_commission_bps,
     ) = convert_rewards(&meta.rewards);
 
     // gRPC does not distinguish between absent and empty rewards. Treat empty as present.
@@ -1121,6 +1125,7 @@ fn map_transaction(
         meta_reward_post_balance,
         meta_reward_type,
         meta_reward_commission,
+        meta_reward_commission_bps,
         meta_loaded_addresses_writable,
         meta_loaded_addresses_readonly,
         meta_return_data_present,
@@ -1256,6 +1261,7 @@ type RewardsConversion = (
     Vec<u64>,
     Vec<Option<String>>,
     Vec<Option<u8>>,
+    Vec<Option<u16>>,
 );
 
 fn convert_instructions(
@@ -1421,6 +1427,7 @@ fn convert_rewards(rewards: &[yellowstone_grpc_proto::prelude::Reward]) -> Rewar
     let mut post_balances = Vec::with_capacity(rewards.len());
     let mut reward_types = Vec::with_capacity(rewards.len());
     let mut commissions = Vec::with_capacity(rewards.len());
+    let mut commission_bps = Vec::with_capacity(rewards.len());
 
     for reward in rewards {
         pubkeys.push(reward.pubkey.clone());
@@ -1428,9 +1435,17 @@ fn convert_rewards(rewards: &[yellowstone_grpc_proto::prelude::Reward]) -> Rewar
         post_balances.push(reward.post_balance);
         reward_types.push(reward_type_to_string(reward.reward_type));
         commissions.push(parse_commission(&reward.commission));
+        commission_bps.push(parse_commission_bps(&reward.commission_bps));
     }
 
-    (pubkeys, lamports, post_balances, reward_types, commissions)
+    (
+        pubkeys,
+        lamports,
+        post_balances,
+        reward_types,
+        commissions,
+        commission_bps,
+    )
 }
 
 fn convert_pubkeys(keys: &[Vec<u8>]) -> Result<Vec<Array<u8, 32>>> {
@@ -1482,6 +1497,13 @@ fn parse_commission(value: &str) -> Option<u8> {
     value.parse::<u8>().ok()
 }
 
+fn parse_commission_bps(value: &str) -> Option<u16> {
+    if value.is_empty() {
+        return None;
+    }
+    value.parse::<u16>().ok()
+}
+
 fn decode_transaction_error(
     err: Option<&yellowstone_grpc_proto::prelude::TransactionError>,
 ) -> Result<(u8, Option<String>)> {
@@ -1508,9 +1530,18 @@ mod tests {
     use super::{
         BlockMetadataRow, FromSlotMode, grpc_health_status_is_serving, grpc_health_status_label,
         grpc_status_summary, is_oversized_grpc_message, map_transaction, max_block_slot,
-        next_subscribe_from_slot, next_subscribe_from_slot_mode,
+        next_subscribe_from_slot, next_subscribe_from_slot_mode, parse_commission_bps,
     };
     use serde_big_array::Array;
+
+    #[test]
+    fn parses_reward_commission_bps() {
+        assert_eq!(parse_commission_bps("300"), Some(300));
+        assert_eq!(parse_commission_bps("10000"), Some(10_000));
+        assert_eq!(parse_commission_bps(""), None);
+        assert_eq!(parse_commission_bps("invalid"), None);
+        assert_eq!(parse_commission_bps("65536"), None);
+    }
     use tonic::Status;
     use yellowstone_grpc_proto::prelude::{
         CompiledInstruction, Message, MessageHeader, SubscribeUpdateTransactionInfo, Transaction,
@@ -1676,6 +1707,7 @@ mod tests {
             rewards_post_balance: Vec::new(),
             rewards_type: Vec::new(),
             rewards_commission: Vec::new(),
+            rewards_commission_bps: Vec::new(),
             rewards_num_partitions: None,
         }
     }

--- a/crates/superbank/src/ingest/rpc.rs
+++ b/crates/superbank/src/ingest/rpc.rs
@@ -113,6 +113,7 @@ type RewardsFields = (
     Vec<u64>,
     Vec<Option<String>>,
     Vec<Option<u8>>,
+    Vec<Option<u16>>,
 );
 type LoadedAddressFields = (Vec<Array<u8, 32>>, Vec<Array<u8, 32>>);
 type RpcInstructionFields = (Vec<u8>, Vec<Vec<u8>>, Vec<serde_bytes::ByteBuf>);
@@ -124,6 +125,7 @@ type RpcBlockRewardsFields = (
     Vec<u64>,
     Vec<Option<String>>,
     Vec<Option<u8>>,
+    Vec<Option<u16>>,
 );
 
 pub(crate) async fn run_rpc_ingest(args: &Args) -> Result<()> {
@@ -1007,6 +1009,7 @@ pub(crate) fn map_rpc_block_metadata(
         rewards_post_balance,
         rewards_type,
         rewards_commission,
+        rewards_commission_bps,
     ) = convert_rpc_block_rewards(block.rewards.as_ref())?;
 
     Ok(BlockMetadataRow {
@@ -1024,6 +1027,7 @@ pub(crate) fn map_rpc_block_metadata(
         rewards_post_balance,
         rewards_type,
         rewards_commission,
+        rewards_commission_bps,
         rewards_num_partitions: block.num_reward_partitions,
     })
 }
@@ -1163,6 +1167,7 @@ fn map_rpc_transaction(
         meta_reward_post_balance: meta_fields.meta_reward_post_balance,
         meta_reward_type: meta_fields.meta_reward_type,
         meta_reward_commission: meta_fields.meta_reward_commission,
+        meta_reward_commission_bps: meta_fields.meta_reward_commission_bps,
         meta_loaded_addresses_writable: meta_fields.meta_loaded_addresses_writable,
         meta_loaded_addresses_readonly: meta_fields.meta_loaded_addresses_readonly,
         meta_return_data_present: meta_fields.meta_return_data_present,
@@ -1189,6 +1194,7 @@ pub(crate) fn map_bigtable_block_metadata(
         rewards_post_balance,
         rewards_type,
         rewards_commission,
+        rewards_commission_bps,
     ) = convert_rpc_block_rewards(Some(&block.rewards))?;
 
     Ok(BlockMetadataRow {
@@ -1206,6 +1212,7 @@ pub(crate) fn map_bigtable_block_metadata(
         rewards_post_balance,
         rewards_type,
         rewards_commission,
+        rewards_commission_bps,
         rewards_num_partitions: block.num_partitions,
     })
 }
@@ -1386,6 +1393,7 @@ fn map_versioned_transaction_with_meta(
         meta_reward_post_balance: meta_fields.meta_reward_post_balance,
         meta_reward_type: meta_fields.meta_reward_type,
         meta_reward_commission: meta_fields.meta_reward_commission,
+        meta_reward_commission_bps: meta_fields.meta_reward_commission_bps,
         meta_loaded_addresses_writable: meta_fields.meta_loaded_addresses_writable,
         meta_loaded_addresses_readonly: meta_fields.meta_loaded_addresses_readonly,
         meta_return_data_present: meta_fields.meta_return_data_present,
@@ -1434,6 +1442,7 @@ struct RpcMetaFields {
     meta_reward_post_balance: Vec<u64>,
     meta_reward_type: Vec<Option<String>>,
     meta_reward_commission: Vec<Option<u8>>,
+    meta_reward_commission_bps: Vec<Option<u16>>,
     meta_loaded_addresses_writable: Vec<Array<u8, 32>>,
     meta_loaded_addresses_readonly: Vec<Array<u8, 32>>,
     meta_return_data_present: u8,
@@ -1483,6 +1492,7 @@ impl RpcMetaFields {
             meta_reward_post_balance: Vec::new(),
             meta_reward_type: Vec::new(),
             meta_reward_commission: Vec::new(),
+            meta_reward_commission_bps: Vec::new(),
             meta_loaded_addresses_writable: Vec::new(),
             meta_loaded_addresses_readonly: Vec::new(),
             meta_return_data_present: 0,
@@ -1548,6 +1558,7 @@ fn map_rpc_meta_fields(meta: Option<&UiTransactionStatusMeta>) -> Result<RpcMeta
         meta_reward_post_balance,
         meta_reward_type,
         meta_reward_commission,
+        meta_reward_commission_bps,
     ) = convert_rpc_rewards(&meta.rewards)?;
 
     let (meta_loaded_addresses_writable, meta_loaded_addresses_readonly) =
@@ -1597,6 +1608,7 @@ fn map_rpc_meta_fields(meta: Option<&UiTransactionStatusMeta>) -> Result<RpcMeta
         meta_reward_post_balance,
         meta_reward_type,
         meta_reward_commission,
+        meta_reward_commission_bps,
         meta_loaded_addresses_writable,
         meta_loaded_addresses_readonly,
         meta_return_data_present,
@@ -1661,6 +1673,7 @@ fn map_native_meta_fields(meta: Option<&TransactionStatusMeta>) -> Result<RpcMet
         meta_reward_post_balance,
         meta_reward_type,
         meta_reward_commission,
+        meta_reward_commission_bps,
     ) = convert_native_rewards(&meta.rewards)?;
 
     let (meta_loaded_addresses_writable, meta_loaded_addresses_readonly) =
@@ -1714,6 +1727,7 @@ fn map_native_meta_fields(meta: Option<&TransactionStatusMeta>) -> Result<RpcMet
         meta_reward_post_balance,
         meta_reward_type,
         meta_reward_commission,
+        meta_reward_commission_bps,
         meta_loaded_addresses_writable,
         meta_loaded_addresses_readonly,
         meta_return_data_present,
@@ -1873,6 +1887,7 @@ fn convert_native_rewards(rewards: &Option<Vec<UiReward>>) -> Result<RewardsFiel
             Vec::new(),
             Vec::new(),
             Vec::new(),
+            Vec::new(),
         ));
     };
 
@@ -1881,6 +1896,7 @@ fn convert_native_rewards(rewards: &Option<Vec<UiReward>>) -> Result<RewardsFiel
     let mut post_balances = Vec::with_capacity(rewards.len());
     let mut reward_types = Vec::with_capacity(rewards.len());
     let mut commissions = Vec::with_capacity(rewards.len());
+    let mut commission_bps = Vec::with_capacity(rewards.len());
 
     for reward in rewards {
         pubkeys.push(reward.pubkey.clone());
@@ -1888,6 +1904,7 @@ fn convert_native_rewards(rewards: &Option<Vec<UiReward>>) -> Result<RewardsFiel
         post_balances.push(reward.post_balance);
         reward_types.push(reward.reward_type.map(|ty| ty.to_string()));
         commissions.push(reward.commission);
+        commission_bps.push(reward.commission_bps);
     }
 
     Ok((
@@ -1897,6 +1914,7 @@ fn convert_native_rewards(rewards: &Option<Vec<UiReward>>) -> Result<RewardsFiel
         post_balances,
         reward_types,
         commissions,
+        commission_bps,
     ))
 }
 
@@ -2099,6 +2117,7 @@ fn convert_rpc_rewards(rewards: &OptionSerializer<Vec<UiReward>>) -> Result<Rewa
             Vec::new(),
             Vec::new(),
             Vec::new(),
+            Vec::new(),
         ));
     };
 
@@ -2107,6 +2126,7 @@ fn convert_rpc_rewards(rewards: &OptionSerializer<Vec<UiReward>>) -> Result<Rewa
     let mut post_balances = Vec::with_capacity(rewards.len());
     let mut reward_types = Vec::with_capacity(rewards.len());
     let mut commissions = Vec::with_capacity(rewards.len());
+    let mut commission_bps = Vec::with_capacity(rewards.len());
 
     for reward in rewards {
         pubkeys.push(reward.pubkey.clone());
@@ -2114,6 +2134,7 @@ fn convert_rpc_rewards(rewards: &OptionSerializer<Vec<UiReward>>) -> Result<Rewa
         post_balances.push(reward.post_balance);
         reward_types.push(reward.reward_type.map(|ty| ty.to_string()));
         commissions.push(reward.commission);
+        commission_bps.push(reward.commission_bps);
     }
 
     Ok((
@@ -2123,6 +2144,7 @@ fn convert_rpc_rewards(rewards: &OptionSerializer<Vec<UiReward>>) -> Result<Rewa
         post_balances,
         reward_types,
         commissions,
+        commission_bps,
     ))
 }
 
@@ -2177,6 +2199,7 @@ fn convert_rpc_block_rewards(rewards: Option<&Vec<UiReward>>) -> Result<RpcBlock
             Vec::new(),
             Vec::new(),
             Vec::new(),
+            Vec::new(),
         ));
     };
 
@@ -2185,6 +2208,7 @@ fn convert_rpc_block_rewards(rewards: Option<&Vec<UiReward>>) -> Result<RpcBlock
     let mut post_balances = Vec::with_capacity(rewards.len());
     let mut reward_types = Vec::with_capacity(rewards.len());
     let mut commissions = Vec::with_capacity(rewards.len());
+    let mut commission_bps = Vec::with_capacity(rewards.len());
 
     for reward in rewards {
         pubkeys.push(decode_base58_32(&reward.pubkey).context("decode reward pubkey")?);
@@ -2192,6 +2216,7 @@ fn convert_rpc_block_rewards(rewards: Option<&Vec<UiReward>>) -> Result<RpcBlock
         post_balances.push(reward.post_balance);
         reward_types.push(reward.reward_type.map(|ty| ty.to_string()));
         commissions.push(reward.commission);
+        commission_bps.push(reward.commission_bps);
     }
 
     Ok((
@@ -2201,6 +2226,7 @@ fn convert_rpc_block_rewards(rewards: Option<&Vec<UiReward>>) -> Result<RpcBlock
         post_balances,
         reward_types,
         commissions,
+        commission_bps,
     ))
 }
 

--- a/ddl/README.md
+++ b/ddl/README.md
@@ -18,6 +18,9 @@ Each folder contains the same file basenames:
 - `token_owner_activity.sql`
 
 Pick one folder and apply the matching schema set consistently.
+The schema files include idempotent `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` statements for
+additive upgrades. Apply DDL before deploying binaries that write or query newly added columns;
+running these repository files never occurs automatically against an existing deployment.
 Apply `transactions.sql` before materialized-view files such as `gsfa*.sql`, `signatures.sql`, and
 `token_owner_activity.sql`; those views select from the transactions table and will fail if it does
 not exist yet.

--- a/ddl/cluster/blocks_metadata.sql
+++ b/ddl/cluster/blocks_metadata.sql
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS default.blocks_metadata_local ON CLUSTER '{cluster}'
     rewards_post_balance         Array(UInt64),
     rewards_type                 Array(Nullable(String)),
     rewards_commission           Array(Nullable(UInt8)),
+    rewards_commission_bps       Array(Nullable(UInt16)),
     rewards_num_partitions       Nullable(UInt64)
 )
 ENGINE = ReplacingMergeTree(slot)
@@ -42,6 +43,12 @@ CREATE TABLE IF NOT EXISTS default.blocks_metadata ON CLUSTER '{cluster}'
     rewards_post_balance         Array(UInt64),
     rewards_type                 Array(Nullable(String)),
     rewards_commission           Array(Nullable(UInt8)),
+    rewards_commission_bps       Array(Nullable(UInt16)),
     rewards_num_partitions       Nullable(UInt64)
 )
 ENGINE = Distributed('{cluster}', 'default', 'blocks_metadata_local', intDiv(slot, 432000));
+
+ALTER TABLE default.blocks_metadata_local ON CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS rewards_commission_bps Array(Nullable(UInt16)) AFTER rewards_commission;
+ALTER TABLE default.blocks_metadata ON CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS rewards_commission_bps Array(Nullable(UInt16)) AFTER rewards_commission;

--- a/ddl/cluster/transactions.sql
+++ b/ddl/cluster/transactions.sql
@@ -63,6 +63,7 @@ CREATE TABLE IF NOT EXISTS default.transactions_local ON CLUSTER '{cluster}'
     meta_reward_post_balance           Array(UInt64) CODEC(ZSTD(1)),
     meta_reward_type                   Array(Nullable(String)) CODEC(ZSTD(1)),
     meta_reward_commission             Array(Nullable(UInt8)),
+    meta_reward_commission_bps         Array(Nullable(UInt16)),
     meta_loaded_addresses_writable     Array(FixedString(32)),
     meta_loaded_addresses_readonly     Array(FixedString(32)),
     meta_return_data_present           UInt8,
@@ -135,6 +136,7 @@ CREATE TABLE IF NOT EXISTS default.transactions ON CLUSTER '{cluster}'
     meta_reward_post_balance           Array(UInt64) CODEC(ZSTD(1)),
     meta_reward_type                   Array(Nullable(String)) CODEC(ZSTD(1)),
     meta_reward_commission             Array(Nullable(UInt8)),
+    meta_reward_commission_bps         Array(Nullable(UInt16)),
     meta_loaded_addresses_writable     Array(FixedString(32)),
     meta_loaded_addresses_readonly     Array(FixedString(32)),
     meta_return_data_present           UInt8,
@@ -144,3 +146,8 @@ CREATE TABLE IF NOT EXISTS default.transactions ON CLUSTER '{cluster}'
     meta_cost_units                    Nullable(UInt64)
 )
 ENGINE = Distributed('{cluster}', 'default', 'transactions_local', intDiv(slot, 432000));
+
+ALTER TABLE default.transactions_local ON CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS meta_reward_commission_bps Array(Nullable(UInt16)) AFTER meta_reward_commission;
+ALTER TABLE default.transactions ON CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS meta_reward_commission_bps Array(Nullable(UInt16)) AFTER meta_reward_commission;

--- a/ddl/local/blocks_metadata.sql
+++ b/ddl/local/blocks_metadata.sql
@@ -20,8 +20,13 @@ CREATE TABLE IF NOT EXISTS default.blocks_metadata
     rewards_post_balance         Array(UInt64),
     rewards_type                 Array(Nullable(String)),
     rewards_commission           Array(Nullable(UInt8)),
+    rewards_commission_bps       Array(Nullable(UInt16)),
     rewards_num_partitions       Nullable(UInt64)
 )
 ENGINE = ReplacingMergeTree(slot)
 PARTITION BY intDiv(slot, 432000)
 ORDER BY (slot);
+
+ALTER TABLE default.blocks_metadata
+    ADD COLUMN IF NOT EXISTS rewards_commission_bps Array(Nullable(UInt16))
+    AFTER rewards_commission;

--- a/ddl/local/transactions.sql
+++ b/ddl/local/transactions.sql
@@ -63,6 +63,7 @@ CREATE TABLE IF NOT EXISTS default.transactions
     meta_reward_post_balance           Array(UInt64) CODEC(ZSTD(1)),
     meta_reward_type                   Array(Nullable(String)) CODEC(ZSTD(1)),
     meta_reward_commission             Array(Nullable(UInt8)),
+    meta_reward_commission_bps         Array(Nullable(UInt16)),
     meta_loaded_addresses_writable     Array(FixedString(32)),
     meta_loaded_addresses_readonly     Array(FixedString(32)),
     meta_return_data_present           UInt8,
@@ -75,3 +76,7 @@ CREATE TABLE IF NOT EXISTS default.transactions
 ENGINE = ReplacingMergeTree(slot)
 PARTITION BY intDiv(slot, 432000) -- Solana epoch (432k slots)
 ORDER BY (slot, slot_idx, signature);
+
+ALTER TABLE default.transactions
+    ADD COLUMN IF NOT EXISTS meta_reward_commission_bps Array(Nullable(UInt16))
+    AFTER meta_reward_commission;

--- a/ddl/replicated/blocks_metadata.sql
+++ b/ddl/replicated/blocks_metadata.sql
@@ -20,6 +20,7 @@ CREATE TABLE IF NOT EXISTS default.blocks_metadata_local ON CLUSTER '{cluster}'
     rewards_post_balance         Array(UInt64),
     rewards_type                 Array(Nullable(String)),
     rewards_commission           Array(Nullable(UInt8)),
+    rewards_commission_bps       Array(Nullable(UInt16)),
     rewards_num_partitions       Nullable(UInt64)
 )
 ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{cluster}/{database}/{table}/{shard}', '{replica}', slot)
@@ -42,6 +43,12 @@ CREATE TABLE IF NOT EXISTS default.blocks_metadata ON CLUSTER '{cluster}'
     rewards_post_balance         Array(UInt64),
     rewards_type                 Array(Nullable(String)),
     rewards_commission           Array(Nullable(UInt8)),
+    rewards_commission_bps       Array(Nullable(UInt16)),
     rewards_num_partitions       Nullable(UInt64)
 )
 ENGINE = Distributed('{cluster}', 'default', 'blocks_metadata_local', intDiv(slot, 432000));
+
+ALTER TABLE default.blocks_metadata_local ON CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS rewards_commission_bps Array(Nullable(UInt16)) AFTER rewards_commission;
+ALTER TABLE default.blocks_metadata ON CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS rewards_commission_bps Array(Nullable(UInt16)) AFTER rewards_commission;

--- a/ddl/replicated/transactions.sql
+++ b/ddl/replicated/transactions.sql
@@ -63,6 +63,7 @@ CREATE TABLE IF NOT EXISTS default.transactions_local ON CLUSTER '{cluster}'
     meta_reward_post_balance           Array(UInt64) CODEC(ZSTD(1)),
     meta_reward_type                   Array(Nullable(String)) CODEC(ZSTD(1)),
     meta_reward_commission             Array(Nullable(UInt8)),
+    meta_reward_commission_bps         Array(Nullable(UInt16)),
     meta_loaded_addresses_writable     Array(FixedString(32)),
     meta_loaded_addresses_readonly     Array(FixedString(32)),
     meta_return_data_present           UInt8,
@@ -135,6 +136,7 @@ CREATE TABLE IF NOT EXISTS default.transactions ON CLUSTER '{cluster}'
     meta_reward_post_balance           Array(UInt64) CODEC(ZSTD(1)),
     meta_reward_type                   Array(Nullable(String)) CODEC(ZSTD(1)),
     meta_reward_commission             Array(Nullable(UInt8)),
+    meta_reward_commission_bps         Array(Nullable(UInt16)),
     meta_loaded_addresses_writable     Array(FixedString(32)),
     meta_loaded_addresses_readonly     Array(FixedString(32)),
     meta_return_data_present           UInt8,
@@ -144,3 +146,8 @@ CREATE TABLE IF NOT EXISTS default.transactions ON CLUSTER '{cluster}'
     meta_cost_units                    Nullable(UInt64)
 )
 ENGINE = Distributed('{cluster}', 'default', 'transactions_local', intDiv(slot, 432000));
+
+ALTER TABLE default.transactions_local ON CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS meta_reward_commission_bps Array(Nullable(UInt16)) AFTER meta_reward_commission;
+ALTER TABLE default.transactions ON CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS meta_reward_commission_bps Array(Nullable(UInt16)) AFTER meta_reward_commission;

--- a/ingest/jetstreamer-clickhouse-plugin/src/lib.rs
+++ b/ingest/jetstreamer-clickhouse-plugin/src/lib.rs
@@ -1039,6 +1039,7 @@ struct BlocksMetadataRow {
     rewards_post_balance: Vec<u64>,
     rewards_type: Vec<Option<String>>,
     rewards_commission: Vec<Option<u8>>,
+    rewards_commission_bps: Vec<Option<u16>>,
     rewards_num_partitions: Option<u64>,
 }
 
@@ -1061,6 +1062,7 @@ impl BlocksMetadataRow {
                 let mut rewards_post_balance = Vec::with_capacity(rewards.keyed_rewards.len());
                 let mut rewards_type = Vec::with_capacity(rewards.keyed_rewards.len());
                 let mut rewards_commission = Vec::with_capacity(rewards.keyed_rewards.len());
+                let mut rewards_commission_bps = Vec::with_capacity(rewards.keyed_rewards.len());
 
                 for (pubkey, reward) in rewards.keyed_rewards.iter() {
                     rewards_pubkey.push(pubkey.to_bytes());
@@ -1068,6 +1070,7 @@ impl BlocksMetadataRow {
                     rewards_post_balance.push(reward.post_balance);
                     rewards_type.push(Some(reward.reward_type.to_string()));
                     rewards_commission.push(reward.commission);
+                    rewards_commission_bps.push(None);
                 }
 
                 let rewards_present =
@@ -1088,6 +1091,7 @@ impl BlocksMetadataRow {
                     rewards_post_balance,
                     rewards_type,
                     rewards_commission,
+                    rewards_commission_bps,
                     rewards_num_partitions: rewards.num_partitions,
                 })
             }
@@ -1181,6 +1185,7 @@ struct TransactionRow {
     meta_reward_post_balance: Vec<u64>,
     meta_reward_type: Vec<Option<String>>,
     meta_reward_commission: Vec<Option<u8>>,
+    meta_reward_commission_bps: Vec<Option<u16>>,
     meta_loaded_addresses_writable: Vec<[u8; 32]>,
     meta_loaded_addresses_readonly: Vec<[u8; 32]>,
     meta_return_data_present: u8,
@@ -1267,6 +1272,7 @@ impl TransactionRow {
             rewards_post_balance,
             rewards_type,
             rewards_commission,
+            rewards_commission_bps,
         ) = map_rewards(meta.rewards.as_ref());
 
         let (return_present, return_program, return_data) =
@@ -1348,6 +1354,7 @@ impl TransactionRow {
             meta_reward_post_balance: rewards_post_balance,
             meta_reward_type: rewards_type,
             meta_reward_commission: rewards_commission,
+            meta_reward_commission_bps: rewards_commission_bps,
             meta_loaded_addresses_writable: loaded_writable,
             meta_loaded_addresses_readonly: loaded_readonly,
             meta_return_data_present: return_present,
@@ -1469,6 +1476,7 @@ type RewardColumns = (
     Vec<u64>,
     Vec<Option<String>>,
     Vec<Option<u8>>,
+    Vec<Option<u16>>,
 );
 
 fn map_rewards(rewards: Option<&Vec<solana_transaction_status::Reward>>) -> RewardColumns {
@@ -1478,6 +1486,7 @@ fn map_rewards(rewards: Option<&Vec<solana_transaction_status::Reward>>) -> Rewa
     let mut post_balance = Vec::new();
     let mut reward_type = Vec::new();
     let mut commission = Vec::new();
+    let mut commission_bps = Vec::new();
 
     if let Some(rewards) = rewards {
         pubkeys.reserve(rewards.len());
@@ -1485,12 +1494,14 @@ fn map_rewards(rewards: Option<&Vec<solana_transaction_status::Reward>>) -> Rewa
         post_balance.reserve(rewards.len());
         reward_type.reserve(rewards.len());
         commission.reserve(rewards.len());
+        commission_bps.reserve(rewards.len());
         for reward in rewards.iter() {
             pubkeys.push(reward.pubkey.clone());
             lamports.push(reward.lamports);
             post_balance.push(reward.post_balance);
             reward_type.push(reward.reward_type.map(|t| t.to_string()));
             commission.push(reward.commission);
+            commission_bps.push(None);
         }
     }
 
@@ -1501,6 +1512,7 @@ fn map_rewards(rewards: Option<&Vec<solana_transaction_status::Reward>>) -> Rewa
         post_balance,
         reward_type,
         commission,
+        commission_bps,
     )
 }
 

--- a/tests/k6/scenarios/validation/superbank-rpc-validate-get-inflation-reward.js
+++ b/tests/k6/scenarios/validation/superbank-rpc-validate-get-inflation-reward.js
@@ -69,6 +69,11 @@ function normalizeInflationRewardResponse(body) {
         entry.commission !== undefined
           ? entry.commission
           : null,
+      commissionBps:
+        Object.prototype.hasOwnProperty.call(entry, 'commissionBps') &&
+        entry.commissionBps !== undefined
+          ? entry.commissionBps
+          : null,
     };
   });
 


### PR DESCRIPTION
This pull request adds support for the new `commission_bps` (basis points) field for reward objects throughout the Superbank RPC codebase. This enables ingestion, storage, and exposure of validator commission rates in basis points, in addition to the legacy percentage format. The changes touch the database schema, protobuf definitions, query logic, Rust data structures, and tests to ensure the new field is handled consistently and backward compatibility is maintained.

Key changes include:

**Schema and Data Model Updates:**
- Added the `commission_bps` field to reward-related structs in Rust (`InflationRewardRow`, `BlockMetadataRow`, `TransactionRow`, etc.), as well as to the corresponding types used for storage and API responses. [[1]](diffhunk://#diff-d096863cdf86c597f7d28d2e522dcd9ea21ca24d4420899e3a81dfdfa5d50244R89) [[2]](diffhunk://#diff-f0e06fb83e3da05bb9a204864053aee74ea9d0e7aa57421e379604c38235c39dR103) [[3]](diffhunk://#diff-f0e06fb83e3da05bb9a204864053aee74ea9d0e7aa57421e379604c38235c39dR77) [[4]](diffhunk://#diff-bd425bf773159aac7201bbfa4d85f790166b0614242db41a0dd3a800c74df492R267) [[5]](diffhunk://#diff-bd425bf773159aac7201bbfa4d85f790166b0614242db41a0dd3a800c74df492R256) [[6]](diffhunk://#diff-bd425bf773159aac7201bbfa4d85f790166b0614242db41a0dd3a800c74df492R314) [[7]](diffhunk://#diff-bd425bf773159aac7201bbfa4d85f790166b0614242db41a0dd3a800c74df492R469)
- Updated the schema version in `disk_cache/schema.rs` to 2 to reflect the addition of the new field.

**Database and Query Logic:**
- Modified ClickHouse queries and column lists to select and handle the new `commission_bps` field, including fallback logic for legacy rows that lack this field. [[1]](diffhunk://#diff-e70480be3a07427aeae559f65b7402247bdfbd04be55a3d941c16f1b0aecc92eR104) [[2]](diffhunk://#diff-e70480be3a07427aeae559f65b7402247bdfbd04be55a3d941c16f1b0aecc92eR76) [[3]](diffhunk://#diff-e70480be3a07427aeae559f65b7402247bdfbd04be55a3d941c16f1b0aecc92eR151) [[4]](diffhunk://#diff-d096863cdf86c597f7d28d2e522dcd9ea21ca24d4420899e3a81dfdfa5d50244L171-R190) [[5]](diffhunk://#diff-d096863cdf86c597f7d28d2e522dcd9ea21ca24d4420899e3a81dfdfa5d50244L193-R201)
- Updated mapping and transformation functions to propagate the new field through all layers of the application. [[1]](diffhunk://#diff-f0e06fb83e3da05bb9a204864053aee74ea9d0e7aa57421e379604c38235c39dR333) [[2]](diffhunk://#diff-f0e06fb83e3da05bb9a204864053aee74ea9d0e7aa57421e379604c38235c39dR368) [[3]](diffhunk://#diff-f0e06fb83e3da05bb9a204864053aee74ea9d0e7aa57421e379604c38235c39dR441) [[4]](diffhunk://#diff-f0e06fb83e3da05bb9a204864053aee74ea9d0e7aa57421e379604c38235c39dR559) [[5]](diffhunk://#diff-f0e06fb83e3da05bb9a204864053aee74ea9d0e7aa57421e379604c38235c39dR656) [[6]](diffhunk://#diff-bd425bf773159aac7201bbfa4d85f790166b0614242db41a0dd3a800c74df492R358) [[7]](diffhunk://#diff-d096863cdf86c597f7d28d2e522dcd9ea21ca24d4420899e3a81dfdfa5d50244R1151) [[8]](diffhunk://#diff-d096863cdf86c597f7d28d2e522dcd9ea21ca24d4420899e3a81dfdfa5d50244R1350)

**Protobuf and API Surface:**
- Extended the `Reward` message in the protobuf definition to include the new `commission_bps` field, ensuring it can be returned by the API when available.

**Documentation and Testing:**
- Updated documentation to describe the new `commission_bps` field and its semantics regarding legacy data.
- Enhanced tests to check for the presence and correct handling of the new field in queries, mappings, and schema versioning. [[1]](diffhunk://#diff-d096863cdf86c597f7d28d2e522dcd9ea21ca24d4420899e3a81dfdfa5d50244R2320-R2322) [[2]](diffhunk://#diff-8fde2d6cf44ec20f0d3816b9efdd6eaa6fe93d4fb9be83db10fed8d526f35942R902) [[3]](diffhunk://#diff-01a4ab21a482877c9f92aeb5b2dcce6b6706a9832641aa44b6aa2dbfc0f1e75fR1108) [[4]](diffhunk://#diff-01a4ab21a482877c9f92aeb5b2dcce6b6706a9832641aa44b6aa2dbfc0f1e75fR1174) [[5]](diffhunk://#diff-71f1b500fbc5872967779a3e07b282a618c72e6f6c218a363485f2e9315871d4R372) [[6]](diffhunk://#diff-71f1b500fbc5872967779a3e07b282a618c72e6f6c218a363485f2e9315871d4L387-R388)

**Build System:**
- Improved the build script to rerun when proto files change, ensuring protobuf changes are always picked up.