### PR TITLE
fix: fall back to distributed getTransactionsForAddress when owner-shard router is unconfigured

### DIFF
--- a/crates/superbank-rpc/src/clickhouse/transactions.rs
+++ b/crates/superbank-rpc/src/clickhouse/transactions.rs
@@ -80,6 +80,32 @@ fn compare_transactions_for_address_records(
     }
 }
 
+enum GsfaOwnerRoute<'a> {
+    ShardLocal { token_owner_table: &'a str },
+    Distributed,
+}
+
+fn gsfa_owner_route<'a>(
+    use_owner_shard_routing: bool,
+    router_configured: bool,
+    has_token_account_filter: bool,
+    token_owner_shard_local_table: Option<&'a str>,
+    token_owner_table: &'a str,
+) -> GsfaOwnerRoute<'a> {
+    if !use_owner_shard_routing || !router_configured {
+        return GsfaOwnerRoute::Distributed;
+    }
+    let token_owner_table = if has_token_account_filter {
+        match token_owner_shard_local_table {
+            Some(table) => table,
+            None => return GsfaOwnerRoute::Distributed,
+        }
+    } else {
+        token_owner_table
+    };
+    GsfaOwnerRoute::ShardLocal { token_owner_table }
+}
+
 const TRANSACTIONS_FOR_ADDRESS_MIN_BATCH_SIZE: u64 = 64;
 const TRANSACTIONS_FOR_ADDRESS_MAX_BATCH_SIZE: u64 = 2_000;
 
@@ -268,33 +294,25 @@ impl ClickHouseClient {
                 .await;
         }
 
-        if self.should_use_gsfa_shard_routing(pubkey) && self.shard_topology.is_some() {
-            let router = self.gsfa_router.as_ref().ok_or_else(|| {
-                ProcessingError::database_msg(
-                    "Shard topology is configured but GSFA owner-shard routing is unavailable",
-                )
-            })?;
-            let token_owner_local_table = if query.token_accounts != TokenAccountsFilter::None {
-                Some(
-                    self.token_owner_activity_local_table
-                        .as_deref()
-                        .ok_or_else(|| {
-                            ProcessingError::database_msg(
-                                "Shard topology is configured but token-owner shard routing is unavailable",
-                            )
-                        })?,
-                )
-            } else {
-                Some(self.token_owner_activity_table.as_str())
-            };
-
+        if let GsfaOwnerRoute::ShardLocal { token_owner_table } = gsfa_owner_route(
+            self.should_use_gsfa_shard_routing(pubkey),
+            self.gsfa_router.is_some(),
+            query.token_accounts != TokenAccountsFilter::None,
+            self.token_owner_activity_local_table.as_deref(),
+            &self.token_owner_activity_table,
+        ) {
+            // `gsfa_owner_route` returns `ShardLocal` only when the router is configured.
+            let router = self
+                .gsfa_router
+                .as_ref()
+                .expect("owner-shard router configured when routing shard-local");
             let mut allow_local_http = self.transport_http();
 
             if self.transport_tcp() {
                 match self
                     .try_get_transactions_for_address_signatures_tcp(
                         router,
-                        token_owner_local_table,
+                        Some(token_owner_table),
                         query,
                         pubkey,
                     )
@@ -309,7 +327,7 @@ impl ClickHouseClient {
                 return self
                     .try_get_transactions_for_address_signatures_http(
                         router,
-                        token_owner_local_table,
+                        Some(token_owner_table),
                         query,
                         pubkey,
                     )
@@ -1282,6 +1300,46 @@ mod tests {
             memo: None,
             block_time: None,
         }
+    }
+
+    #[test]
+    fn gsfa_owner_route_falls_back_to_distributed_when_router_absent() {
+        assert!(matches!(
+            gsfa_owner_route(true, false, false, None, "token_owner"),
+            GsfaOwnerRoute::Distributed
+        ));
+    }
+
+    #[test]
+    fn gsfa_owner_route_falls_back_when_token_owner_shard_local_absent() {
+        assert!(matches!(
+            gsfa_owner_route(true, true, true, None, "token_owner"),
+            GsfaOwnerRoute::Distributed
+        ));
+    }
+
+    #[test]
+    fn gsfa_owner_route_uses_shard_local_when_configured() {
+        assert!(matches!(
+            gsfa_owner_route(true, true, false, None, "token_owner"),
+            GsfaOwnerRoute::ShardLocal {
+                token_owner_table: "token_owner"
+            }
+        ));
+        assert!(matches!(
+            gsfa_owner_route(true, true, true, Some("token_owner_local"), "token_owner"),
+            GsfaOwnerRoute::ShardLocal {
+                token_owner_table: "token_owner_local"
+            }
+        ));
+    }
+
+    #[test]
+    fn gsfa_owner_route_distributed_for_hot_address() {
+        assert!(matches!(
+            gsfa_owner_route(false, true, true, Some("token_owner_local"), "token_owner"),
+            GsfaOwnerRoute::Distributed
+        ));
     }
 
     #[test]


### PR DESCRIPTION
### What's broken

`getTransactionsForAddress` returns a hard error for every non-hot address whenever GSFA owner-shard routing is half-configured: the shard topology is built but the owner-shard router isn't. It should fall back to the distributed query, the way it did before #71.

### How you hit it

You hit it when hot addresses are configured (so a shard topology gets built) but `CLICKHOUSE_GSFA_LOCAL_TABLE` is unset, on the default `distributed` scope.

The router only comes up when the local table is set and its shard schema validates. When it doesn't, the client logs `GSFA shard routing disabled` and keeps serving. But since #71 the routing gate is:

```rust
if self.should_use_gsfa_shard_routing(pubkey) && self.shard_topology.is_some() {
    let router = self.gsfa_router.as_ref().ok_or_else(|| { /* error */ })?;
```

`should_use_gsfa_shard_routing(pubkey)` is `!is_gsfa_hot_address(pubkey)`, so it's true for every non-hot address. `shard_topology` is `Some`. `gsfa_router` is `None`. The `ok_or_else` fires and the request errors, every time. The token-owner-table branch has the same shape.

Before #71 the gate was `... && let Some(router) = &self.gsfa_router`, so a missing router fell through to the distributed query. #71 turned that fall-through into a hard failure.

Two ways to land in this state, both leave `shard_topology = Some` / `gsfa_router = None`:
- `CLICKHOUSE_GSFA_LOCAL_TABLE` unset (`client.rs:1580` warn)
- local table set but shard schema validation fails (`client.rs:1567` warn)

### Fix

Route shard-local only when the router is actually configured (and, for token-account filters, the token-owner shard-local table too). Otherwise use the distributed query. That restores the pre-#71 fall-through. A configured router whose in-flight shard query fails still surfaces as an error, same as #71 does now.

The decision is a small pure function so the regression is unit-testable without a ClickHouse cluster (there's no test harness for the router/topology state today):

```rust
enum GsfaOwnerRoute<'a> {
    ShardLocal { token_owner_table: &'a str },
    Distributed,
}

fn gsfa_owner_route<'a>(
    use_owner_shard_routing: bool,
    router_configured: bool,
    has_token_account_filter: bool,
    token_owner_shard_local_table: Option<&'a str>,
    token_owner_table: &'a str,
) -> GsfaOwnerRoute<'a>
```

### Tests

4 unit tests on `gsfa_owner_route`:
- router absent -> Distributed (the regression)
- token filter with no shard-local token-owner table -> Distributed
- configured cases -> ShardLocal with the right table
- hot address -> Distributed

`cargo fmt`, `cargo clippy -p superbank-rpc --all-targets --locked -- -D warnings`, and `cargo test -p superbank-rpc` all green (4 new tests, 324 passing).

---
