### PR TITLE
fix: serve progressive inflation rewards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1911,9 +1911,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/crates/superbank-rpc/README.md
+++ b/crates/superbank-rpc/README.md
@@ -30,9 +30,16 @@ Notes:
 - Requests without an `id` are normalized to `id: null` and still return
   JSON-RPC response bodies (compatibility behavior; not strict notification semantics).
 - `processed` commitment is rejected by default; use `confirmed` or `finalized`.
-- `getInflationReward` reads the payout epoch boundary and only the reward partitions selected by
-  the requested addresses. It never expands reward arrays across a complete epoch; dedicated
-  address, concurrency, timeout, thread, memory, and read-byte limits are enabled by default.
+- `getInflationReward` reads the payout epoch boundary, serves boundary vote rewards immediately,
+  and queries only the partition block heights required by unresolved requested addresses. A stake
+  reward becomes available as soon as that address's partition block lands; the method does not
+  wait for later partitions or expand reward arrays across a complete epoch. If the payout boundary
+  does not exist yet, it returns `-32004` (`Block not available`) over HTTP `200`. If a requested
+  partition is still pending, it returns `-32017` (`Epoch rewards period still active`) over HTTP
+  `200`, with `slot`, `currentBlockHeight`, and `rewardsCompleteBlockHeight` in `error.data`.
+  Missing rewards are returned as `null` only after the address's required partition is available.
+  Dedicated address, concurrency, timeout, thread, memory, and read-byte limits are enabled by
+  default.
 - Reward objects expose the optional Agave `commissionBps` field when the ingested source supplied
   it. Legacy rows ingested before the basis-point columns were deployed omit the field; Superbank
   does not infer it from the legacy percentage `commission` value.
@@ -163,6 +170,9 @@ Only internal error (`-32603`), server-generated request timeout (`-32000`), nod
 (`-32005`), and long-term storage unreachable (`-32019`) are promoted to HTTP `503`.
 Client, malformed-request, and data-condition errors remain HTTP `200 OK`. For batches, any
 eligible item promotes the whole HTTP response to `503`.
+For `getInflationReward`, both boundary-unavailable (`-32004`) and rewards-period-active (`-32017`)
+are data-condition errors and remain HTTP `200`; ClickHouse query, metadata, and integrity failures
+continue to use internal error (`-32603`) and are eligible for HTTP `503`.
 
 ## Optional gRPC head cache (`grpc-head-cache`)
 

--- a/crates/superbank-rpc/src/clickhouse/blocks.rs
+++ b/crates/superbank-rpc/src/clickhouse/blocks.rs
@@ -33,8 +33,8 @@ use super::rows::{
 #[cfg(any(feature = "disk-cache", feature = "grpc-streaming"))]
 use super::rows::{TransactionRow, map_transaction_row};
 use super::types::{
-    BlockMetadataRecord, InflationRewardRecord, QueryTimings, StoredAccountsTransactionRecord,
-    StoredTransactionRecord,
+    BlockMetadataRecord, InflationRewardLookupOutcome, InflationRewardRecord, QueryTimings,
+    StoredAccountsTransactionRecord, StoredTransactionRecord,
 };
 use super::util::{annotate_required_query, http_query_with_id};
 
@@ -77,6 +77,7 @@ struct InflationBoundaryRow {
 #[derive(Deserialize, clickhouse::Row)]
 struct InflationSlotRow {
     slot: u64,
+    block_height: Option<u64>,
 }
 
 #[derive(Deserialize, clickhouse::Row)]
@@ -119,20 +120,45 @@ fn build_inflation_partition_slots_query(
     table: &str,
     boundary_slot: u64,
     end_slot_exclusive: u64,
-    num_partitions: usize,
+    required_block_heights: &[u64],
     settings_clause: &str,
 ) -> String {
     let payout_epoch = boundary_slot / SLOT_SHARD_DIVISOR;
+    let block_height_literals = required_block_heights
+        .iter()
+        .map(u64::to_string)
+        .collect::<Vec<_>>()
+        .join(", ");
     format!(
-        "SELECT slot
+        "SELECT slot, block_height
          FROM {table}
          PREWHERE
             intDiv(slot, {slot_shard_divisor}) = {payout_epoch}
             AND slot > {boundary_slot}
             AND slot < {end_slot_exclusive}
-         ORDER BY slot ASC
-         LIMIT 1 BY slot
-         LIMIT {num_partitions}
+         WHERE block_height IN ({block_height_literals})
+         ORDER BY block_height ASC, slot ASC
+         {settings_clause}",
+        slot_shard_divisor = SLOT_SHARD_DIVISOR,
+    )
+}
+
+fn build_inflation_progress_query(
+    table: &str,
+    boundary_slot: u64,
+    end_slot_exclusive: u64,
+    settings_clause: &str,
+) -> String {
+    let payout_epoch = boundary_slot / SLOT_SHARD_DIVISOR;
+    format!(
+        "SELECT slot, block_height
+         FROM {table}
+         PREWHERE
+            intDiv(slot, {slot_shard_divisor}) = {payout_epoch}
+            AND slot >= {boundary_slot}
+            AND slot < {end_slot_exclusive}
+         ORDER BY slot DESC
+         LIMIT 1
          {settings_clause}",
         slot_shard_divisor = SLOT_SHARD_DIVISOR,
     )
@@ -210,6 +236,44 @@ fn build_inflation_rewards_query(
 fn inflation_reward_partition(address: &[u8; 32], num_partitions: usize, seed: &[u8; 32]) -> usize {
     EpochRewardsHasher::new(num_partitions, &Hash::new_from_array(*seed))
         .hash_address_to_partition(&Pubkey::new_from_array(*address))
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct InflationRewardPartitionPlan {
+    block_height_by_pubkey: HashMap<[u8; 32], u64>,
+    required_block_heights: Vec<u64>,
+}
+
+fn plan_inflation_reward_partitions(
+    addresses: &[[u8; 32]],
+    num_partitions: usize,
+    seed: &[u8; 32],
+    boundary_block_height: u64,
+) -> Option<InflationRewardPartitionPlan> {
+    let mut block_height_by_pubkey = HashMap::with_capacity(addresses.len());
+    let mut required_block_height_set = HashSet::with_capacity(addresses.len());
+    for address in addresses {
+        let partition_index = inflation_reward_partition(address, num_partitions, seed);
+        let required_block_height = boundary_block_height
+            .checked_add(partition_index as u64)?
+            .checked_add(1)?;
+        block_height_by_pubkey.insert(*address, required_block_height);
+        required_block_height_set.insert(required_block_height);
+    }
+    let mut required_block_heights = required_block_height_set.into_iter().collect::<Vec<_>>();
+    required_block_heights.sort_unstable();
+
+    Some(InflationRewardPartitionPlan {
+        block_height_by_pubkey,
+        required_block_heights,
+    })
+}
+
+fn inflation_rewards_period_is_active(
+    current_block_height: u64,
+    rewards_complete_block_height: u64,
+) -> bool {
+    current_block_height < rewards_complete_block_height
 }
 
 #[derive(Deserialize, clickhouse::Row)]
@@ -995,11 +1059,14 @@ impl ClickHouseClient {
         &self,
         addresses: &[[u8; 32]],
         epoch: u64,
-    ) -> ProcessingResult<(Vec<InflationRewardRecord>, QueryTimings)> {
+    ) -> ProcessingResult<(InflationRewardLookupOutcome, QueryTimings)> {
         const OPERATION: &str = "get_inflation_rewards_for_epoch";
 
         if addresses.is_empty() {
-            return Ok((Vec::new(), QueryTimings::zero()));
+            return Ok((
+                InflationRewardLookupOutcome::Complete(Vec::new()),
+                QueryTimings::zero(),
+            ));
         }
 
         let (start_slot, end_slot_exclusive) =
@@ -1099,9 +1166,10 @@ impl ClickHouseClient {
 
             let Some(boundary) = boundary else {
                 crate::metrics::inflation_reward_lookup("unknown", "boundary_missing");
-                return Err(ProcessingError::database_msg(format!(
-                    "no confirmed block is available in payout epoch for inflation epoch {epoch}"
-                )));
+                return Ok((
+                    InflationRewardLookupOutcome::BoundaryUnavailable { slot: start_slot },
+                    timings,
+                ));
             };
             if boundary.parent_slot >= start_slot {
                 crate::metrics::inflation_reward_lookup("unknown", "invalid_boundary");
@@ -1111,7 +1179,35 @@ impl ClickHouseClient {
                 )));
             }
 
-            let partitioned = boundary.rewards_num_partitions.is_some();
+            let boundary_block_height = boundary.block_height.ok_or_else(|| {
+                crate::metrics::inflation_reward_lookup("unknown", "invalid_boundary");
+                ProcessingError::database_msg(format!(
+                    "inflation reward boundary slot {} has no block height",
+                    boundary.slot
+                ))
+            })?;
+
+            let num_partitions = match boundary.rewards_num_partitions {
+                Some(num_partitions) => {
+                    let num_partitions = usize::try_from(num_partitions).map_err(|_| {
+                        ProcessingError::database_msg(format!(
+                            "inflation epoch {epoch} declares too many reward partitions"
+                        ))
+                    })?;
+                    if num_partitions == 0 || num_partitions > MAX_INFLATION_REWARD_PARTITIONS {
+                        crate::metrics::inflation_reward_lookup(
+                            "partitioned",
+                            "invalid_partitions",
+                        );
+                        return Err(ProcessingError::database_msg(format!(
+                            "inflation epoch {epoch} declares unsupported reward partition count {num_partitions}"
+                        )));
+                    }
+                    Some(num_partitions)
+                }
+                None => None,
+            };
+            let partitioned = num_partitions.is_some();
             let boundary_selection = if partitioned {
                 InflationRewardSelection::VoteOnly
             } else {
@@ -1154,10 +1250,22 @@ impl ClickHouseClient {
                 let Some(row) = next else {
                     break;
                 };
-                rewards_by_pubkey.insert(
-                    row.pubkey.0,
+                let pubkey = row.pubkey.0;
+                if !seen.contains(&pubkey) {
+                    return Err(ProcessingError::database_msg(
+                        "boundary reward query returned an unrequested address".to_string(),
+                    ));
+                }
+                if row.effective_slot != boundary.slot {
+                    return Err(ProcessingError::database_msg(format!(
+                        "boundary reward for requested address came from slot {}, expected {}",
+                        row.effective_slot, boundary.slot
+                    )));
+                }
+                let previous = rewards_by_pubkey.insert(
+                    pubkey,
                     InflationRewardRecord {
-                        pubkey: row.pubkey.0,
+                        pubkey,
                         effective_slot: row.effective_slot,
                         lamports: row.lamports,
                         post_balance: row.post_balance,
@@ -1165,6 +1273,11 @@ impl ClickHouseClient {
                         commission_bps: row.commission_bps,
                     },
                 );
+                if previous.is_some() {
+                    return Err(ProcessingError::database_msg(
+                        "boundary reward query returned a duplicate address".to_string(),
+                    ));
+                }
             }
             timings.add(QueryTimings {
                 elapsed_ms: boundary_rewards_started.elapsed().as_millis() as u64,
@@ -1190,23 +1303,24 @@ impl ClickHouseClient {
                     query_scope,
                     "Completed targeted getInflationReward lookup"
                 );
-                return Ok((rewards_by_pubkey.into_values().collect(), timings));
+                return Ok((
+                    InflationRewardLookupOutcome::Complete(
+                        rewards_by_pubkey.into_values().collect(),
+                    ),
+                    timings,
+                ));
             }
 
-            let num_partitions_u64 = boundary
-                .rewards_num_partitions
-                .expect("partitioned boundary has a partition count");
-            let num_partitions = usize::try_from(num_partitions_u64).map_err(|_| {
-                ProcessingError::database_msg(format!(
-                    "inflation epoch {epoch} declares too many reward partitions"
-                ))
-            })?;
-            if num_partitions == 0 || num_partitions > MAX_INFLATION_REWARD_PARTITIONS {
-                crate::metrics::inflation_reward_lookup("partitioned", "invalid_partitions");
-                return Err(ProcessingError::database_msg(format!(
-                    "inflation epoch {epoch} declares unsupported reward partition count {num_partitions}"
-                )));
-            }
+            let num_partitions =
+                num_partitions.expect("partitioned boundary has a partition count");
+            let rewards_complete_block_height = boundary_block_height
+                .checked_add(num_partitions as u64)
+                .and_then(|height| height.checked_add(1))
+                .ok_or_else(|| {
+                    ProcessingError::database_msg(format!(
+                        "inflation epoch {epoch} rewards-complete block height overflowed"
+                    ))
+                })?;
 
             let unresolved_addresses = deduped_addresses
                 .iter()
@@ -1228,14 +1342,36 @@ impl ClickHouseClient {
                     query_scope,
                     "Completed targeted getInflationReward lookup"
                 );
-                return Ok((rewards_by_pubkey.into_values().collect(), timings));
+                return Ok((
+                    InflationRewardLookupOutcome::Complete(
+                        rewards_by_pubkey.into_values().collect(),
+                    ),
+                    timings,
+                ));
             }
+
+            let partition_plan = plan_inflation_reward_partitions(
+                &unresolved_addresses,
+                num_partitions,
+                &boundary.parent_blockhash.0,
+                boundary_block_height,
+            )
+            .ok_or_else(|| {
+                ProcessingError::database_msg(format!(
+                    "inflation epoch {epoch} partition block height overflowed"
+                ))
+            })?;
+            let required_block_height_set = partition_plan
+                .required_block_heights
+                .iter()
+                .copied()
+                .collect::<HashSet<_>>();
 
             let partition_slots_query = build_inflation_partition_slots_query(
                 &blocks_metadata_table,
                 boundary.slot,
                 end_slot_exclusive,
-                num_partitions,
+                &partition_plan.required_block_heights,
                 &settings_clause,
             );
             let (partition_slots_query, partition_slots_query_id) = annotate_required_query(
@@ -1256,7 +1392,11 @@ impl ClickHouseClient {
             )
             .fetch::<InflationSlotRow>()
             .map_err(|e| ProcessingError::database(e.to_string(), e))?;
-            let mut partition_slots = Vec::with_capacity(num_partitions);
+            let mut slot_by_block_height =
+                HashMap::with_capacity(partition_plan.required_block_heights.len());
+            let mut block_height_by_slot =
+                HashMap::with_capacity(partition_plan.required_block_heights.len());
+            let mut partition_slot_rows = 0u64;
             loop {
                 let next = match partition_slots_cursor.next().await {
                     Ok(next) => next,
@@ -1268,7 +1408,39 @@ impl ClickHouseClient {
                 let Some(row) = next else {
                     break;
                 };
-                partition_slots.push(row.slot);
+                partition_slot_rows = partition_slot_rows.saturating_add(1);
+                let block_height = row.block_height.ok_or_else(|| {
+                    ProcessingError::database_msg(format!(
+                        "inflation reward partition slot {} has no block height",
+                        row.slot
+                    ))
+                })?;
+                if !required_block_height_set.contains(&block_height) {
+                    return Err(ProcessingError::database_msg(format!(
+                        "partition lookup returned unexpected block height {block_height}"
+                    )));
+                }
+                if row.slot <= boundary.slot || row.slot >= end_slot_exclusive {
+                    return Err(ProcessingError::database_msg(format!(
+                        "partition lookup returned unexpected slot {}",
+                        row.slot
+                    )));
+                }
+                if let Some(previous_slot) = slot_by_block_height.insert(block_height, row.slot)
+                    && previous_slot != row.slot
+                {
+                    return Err(ProcessingError::database_msg(format!(
+                        "partition block height {block_height} maps to multiple slots"
+                    )));
+                }
+                if let Some(previous_height) = block_height_by_slot.insert(row.slot, block_height)
+                    && previous_height != block_height
+                {
+                    return Err(ProcessingError::database_msg(format!(
+                        "partition slot {} maps to multiple block heights",
+                        row.slot
+                    )));
+                }
             }
             timings.add(QueryTimings {
                 elapsed_ms: partition_slots_started.elapsed().as_millis() as u64,
@@ -1276,14 +1448,91 @@ impl ClickHouseClient {
                 decoded_bytes: partition_slots_cursor.decoded_bytes(),
                 rows_read: Some(0),
                 rows_read_unknown: true,
-                rows_returned: partition_slots.len() as u64,
+                rows_returned: partition_slot_rows,
             });
             partition_slots_cleanup.disarm();
-            if partition_slots.len() < num_partitions {
-                crate::metrics::inflation_reward_lookup("partitioned", "incomplete");
+
+            let missing_block_heights = partition_plan
+                .required_block_heights
+                .iter()
+                .copied()
+                .filter(|block_height| !slot_by_block_height.contains_key(block_height))
+                .collect::<Vec<_>>();
+            if !missing_block_heights.is_empty() {
+                let progress_query = build_inflation_progress_query(
+                    &blocks_metadata_table,
+                    boundary.slot,
+                    end_slot_exclusive,
+                    &settings_clause,
+                );
+                let (progress_query, progress_query_id) =
+                    annotate_required_query(progress_query, "get_inflation_reward_payout_progress");
+                let mut progress_cleanup = self.http_query_cleanup_for_client(
+                    query_client.clone(),
+                    cleanup_cluster.clone(),
+                    OPERATION,
+                    progress_query_id.clone(),
+                );
+                let progress_started = Instant::now();
+                let mut progress_cursor =
+                    http_query_with_id(&query_client, &progress_query, Some(progress_query_id))
+                        .fetch::<InflationSlotRow>()
+                        .map_err(|e| ProcessingError::database(e.to_string(), e))?;
+                let progress = match progress_cursor.next().await {
+                    Ok(row) => row,
+                    Err(err) => {
+                        progress_cleanup.spawn_cleanup("error");
+                        return Err(ProcessingError::database(err.to_string(), err));
+                    }
+                };
+                timings.add(QueryTimings {
+                    elapsed_ms: progress_started.elapsed().as_millis() as u64,
+                    received_bytes: progress_cursor.received_bytes(),
+                    decoded_bytes: progress_cursor.decoded_bytes(),
+                    rows_read: Some(0),
+                    rows_read_unknown: true,
+                    rows_returned: u64::from(progress.is_some()),
+                });
+                progress_cleanup.disarm();
+
+                let progress = progress.ok_or_else(|| {
+                    ProcessingError::database_msg(format!(
+                        "payout epoch progress disappeared after boundary slot {} was read",
+                        boundary.slot
+                    ))
+                })?;
+                let current_block_height = progress.block_height.ok_or_else(|| {
+                    ProcessingError::database_msg(format!(
+                        "payout epoch progress slot {} has no block height",
+                        progress.slot
+                    ))
+                })?;
+                if progress.slot < boundary.slot
+                    || progress.slot >= end_slot_exclusive
+                    || current_block_height < boundary_block_height
+                {
+                    return Err(ProcessingError::database_msg(format!(
+                        "payout epoch progress returned unexpected slot {} at block height {}",
+                        progress.slot, current_block_height
+                    )));
+                }
+                if inflation_rewards_period_is_active(
+                    current_block_height,
+                    rewards_complete_block_height,
+                ) {
+                    crate::metrics::inflation_reward_lookup("partitioned", "active");
+                    return Ok((
+                        InflationRewardLookupOutcome::RewardsPeriodActive {
+                            slot: progress.slot,
+                            current_block_height,
+                            rewards_complete_block_height,
+                        },
+                        timings,
+                    ));
+                }
+
                 return Err(ProcessingError::database_msg(format!(
-                    "inflation rewards period for epoch {epoch} is incomplete: expected {num_partitions} partition blocks, found {}",
-                    partition_slots.len()
+                    "inflation rewards for epoch {epoch} reached completion block height {rewards_complete_block_height}, but required partition block heights {missing_block_heights:?} are missing"
                 )));
             }
 
@@ -1291,12 +1540,8 @@ impl ClickHouseClient {
             let mut selected_slots = Vec::with_capacity(unresolved_addresses.len());
             let mut selected_slot_set = HashSet::with_capacity(unresolved_addresses.len());
             for address in &unresolved_addresses {
-                let partition_index = inflation_reward_partition(
-                    address,
-                    num_partitions,
-                    &boundary.parent_blockhash.0,
-                );
-                let expected_slot = partition_slots[partition_index];
+                let required_block_height = partition_plan.block_height_by_pubkey[address];
+                let expected_slot = slot_by_block_height[&required_block_height];
                 expected_slot_by_pubkey.insert(*address, expected_slot);
                 if selected_slot_set.insert(expected_slot) {
                     selected_slots.push(expected_slot);
@@ -1353,7 +1598,7 @@ impl ClickHouseClient {
                         row.effective_slot, expected_slot
                     )));
                 }
-                rewards_by_pubkey.insert(
+                let previous = rewards_by_pubkey.insert(
                     pubkey,
                     InflationRewardRecord {
                         pubkey,
@@ -1364,6 +1609,11 @@ impl ClickHouseClient {
                         commission_bps: row.commission_bps,
                     },
                 );
+                if previous.is_some() {
+                    return Err(ProcessingError::database_msg(
+                        "partition reward query returned a duplicate address".to_string(),
+                    ));
+                }
                 partition_reward_count = partition_reward_count.saturating_add(1);
             }
             timings.add(QueryTimings {
@@ -1392,7 +1642,10 @@ impl ClickHouseClient {
                 "Completed targeted getInflationReward lookup"
             );
 
-            Ok((rewards_by_pubkey.into_values().collect(), timings))
+            Ok((
+                InflationRewardLookupOutcome::Complete(rewards_by_pubkey.into_values().collect()),
+                timings,
+            ))
         };
 
         let execute = Box::pin(execute);
@@ -2193,12 +2446,16 @@ impl ClickHouseClient {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::{
         BlockTransactionProjection, InflationRewardSelection, SLOT_SHARD_DIVISOR,
         build_block_metadata_query, build_block_transactions_query, build_blockhash_valid_query,
         build_inflation_boundary_query, build_inflation_partition_slots_query,
-        build_inflation_rewards_query, build_transaction_count_query, inflation_reward_partition,
-        normalize_slots, shard_indices_for_slot_range,
+        build_inflation_progress_query, build_inflation_rewards_query,
+        build_transaction_count_query, inflation_epoch_slot_bounds, inflation_reward_partition,
+        inflation_rewards_period_is_active, normalize_slots, plan_inflation_reward_partitions,
+        shard_indices_for_slot_range,
     };
     #[cfg(any(feature = "disk-cache", feature = "grpc-streaming"))]
     use super::{
@@ -2302,19 +2559,47 @@ mod tests {
     }
 
     #[test]
-    fn inflation_partition_slots_query_is_ordered_and_bounded() {
+    fn inflation_epoch_1018_payout_starts_at_foundation_error_slot() {
+        assert_eq!(
+            inflation_epoch_slot_bounds(1_018),
+            Some((440_208_000, 440_640_000))
+        );
+    }
+
+    #[test]
+    fn inflation_partition_slots_query_targets_exact_block_heights() {
         let query = build_inflation_partition_slots_query(
             "default.blocks_metadata",
             121_392_000,
             121_824_000,
-            293,
+            &[270_000_001, 270_000_017],
             "",
         );
 
+        assert!(query.contains("SELECT slot, block_height"));
         assert!(query.contains("slot > 121392000"));
         assert!(query.contains("slot < 121824000"));
-        assert!(query.contains("LIMIT 1 BY slot"));
-        assert!(query.contains("LIMIT 293"));
+        assert!(query.contains("WHERE block_height IN (270000001, 270000017)"));
+        assert!(query.contains("ORDER BY block_height ASC, slot ASC"));
+        assert!(!query.contains("LIMIT 1 BY slot"));
+        assert!(!query.contains("LIMIT 293"));
+    }
+
+    #[test]
+    fn inflation_progress_query_reads_latest_landed_payout_block() {
+        let query = build_inflation_progress_query(
+            "default.blocks_metadata",
+            121_392_000,
+            121_824_000,
+            "SETTINGS max_threads=2",
+        );
+
+        assert!(query.contains("SELECT slot, block_height"));
+        assert!(query.contains("slot >= 121392000"));
+        assert!(query.contains("slot < 121824000"));
+        assert!(query.contains("ORDER BY slot DESC"));
+        assert!(query.contains("LIMIT 1"));
+        assert!(query.contains("SETTINGS max_threads=2"));
     }
 
     #[test]
@@ -2350,6 +2635,73 @@ mod tests {
         assert!(first < 293);
         assert!(second < 293);
         assert_ne!(first, second);
+    }
+
+    #[test]
+    fn inflation_partition_plan_deduplicates_shared_partitions_and_targets_distinct_ones() {
+        let seed = [9u8; 32];
+        let num_partitions = 4;
+        let boundary_block_height = 270_000_000;
+        let candidates = (0..=u8::MAX).map(|value| [value; 32]).collect::<Vec<_>>();
+        let mut addresses_by_partition = HashMap::<usize, Vec<[u8; 32]>>::new();
+        for address in candidates {
+            addresses_by_partition
+                .entry(inflation_reward_partition(&address, num_partitions, &seed))
+                .or_default()
+                .push(address);
+        }
+
+        let (shared_partition, shared_addresses) = addresses_by_partition
+            .iter()
+            .find(|(_, addresses)| addresses.len() >= 2)
+            .expect("test inputs should share a partition");
+        let shared_plan = plan_inflation_reward_partitions(
+            &shared_addresses[..2],
+            num_partitions,
+            &seed,
+            boundary_block_height,
+        )
+        .expect("partition heights should not overflow");
+        assert_eq!(
+            shared_plan.required_block_heights,
+            vec![boundary_block_height + *shared_partition as u64 + 1]
+        );
+
+        let mut distinct_partitions = addresses_by_partition.iter();
+        let (first_partition, first_addresses) = distinct_partitions
+            .next()
+            .expect("at least two partitions should be represented");
+        let (second_partition, second_addresses) = distinct_partitions
+            .find(|(partition, _)| partition != &first_partition)
+            .expect("at least two partitions should be represented");
+        let distinct_addresses = [first_addresses[0], second_addresses[0]];
+        let distinct_plan = plan_inflation_reward_partitions(
+            &distinct_addresses,
+            num_partitions,
+            &seed,
+            boundary_block_height,
+        )
+        .expect("partition heights should not overflow");
+        let mut expected_heights = vec![
+            boundary_block_height + *first_partition as u64 + 1,
+            boundary_block_height + *second_partition as u64 + 1,
+        ];
+        expected_heights.sort_unstable();
+        assert_eq!(distinct_plan.required_block_heights, expected_heights);
+    }
+
+    #[test]
+    fn inflation_partition_plan_rejects_block_height_overflow() {
+        assert!(
+            plan_inflation_reward_partitions(&[[1u8; 32]], 293, &[9u8; 32], u64::MAX).is_none()
+        );
+    }
+
+    #[test]
+    fn inflation_reward_period_stays_active_until_completion_height() {
+        assert!(inflation_rewards_period_is_active(1_292, 1_293));
+        assert!(!inflation_rewards_period_is_active(1_293, 1_293));
+        assert!(!inflation_rewards_period_is_active(1_294, 1_293));
     }
 
     #[test]

--- a/crates/superbank-rpc/src/clickhouse/mod.rs
+++ b/crates/superbank-rpc/src/clickhouse/mod.rs
@@ -26,7 +26,10 @@ pub use types::{
     TransactionStatusFilter, TransactionsForAddressQuery,
 };
 
-pub(crate) use types::{ResolvedSignatureFilter, SignatureSlot, SlotBoundary};
+pub(crate) use types::{
+    InflationRewardLookupOutcome, InflationRewardRecord, ResolvedSignatureFilter, SignatureSlot,
+    SlotBoundary,
+};
 
 pub(crate) use sharding::{RoutingPolicy, RoutingScope, RoutingTransport, ShardRoutingConfig};
 pub(crate) use util::{QueryCacheConfig, QueryFreshnessClass};

--- a/crates/superbank-rpc/src/clickhouse/types.rs
+++ b/crates/superbank-rpc/src/clickhouse/types.rs
@@ -268,6 +268,19 @@ pub struct InflationRewardRecord {
 }
 
 #[derive(Debug, Clone)]
+pub enum InflationRewardLookupOutcome {
+    Complete(Vec<InflationRewardRecord>),
+    BoundaryUnavailable {
+        slot: u64,
+    },
+    RewardsPeriodActive {
+        slot: u64,
+        current_block_height: u64,
+        rewards_complete_block_height: u64,
+    },
+}
+
+#[derive(Debug, Clone)]
 pub struct StoredBlockRecord {
     pub metadata: BlockMetadataRecord,
     pub transactions: Vec<StoredTransactionRecord>,

--- a/crates/superbank-rpc/src/handlers/blocks.rs
+++ b/crates/superbank-rpc/src/handlers/blocks.rs
@@ -10,6 +10,7 @@ use serde_json::{Value, json};
 use solana_clock::{DEFAULT_SLOTS_PER_EPOCH, MAX_PROCESSING_AGE};
 use solana_commitment_config::CommitmentConfig;
 use solana_rpc_client_api::custom_error::JSON_RPC_SERVER_ERROR_BLOCK_NOT_AVAILABLE;
+use solana_rpc_client_api::custom_error::JSON_RPC_SERVER_ERROR_EPOCH_REWARDS_PERIOD_ACTIVE;
 use solana_rpc_client_api::custom_error::JSON_RPC_SERVER_ERROR_LONG_TERM_STORAGE_SLOT_SKIPPED;
 use solana_rpc_client_api::custom_error::JSON_RPC_SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED;
 use solana_rpc_client_api::custom_error::JSON_RPC_SERVER_ERROR_UNSUPPORTED_TRANSACTION_VERSION;
@@ -20,7 +21,10 @@ use std::str::FromStr;
 use std::sync::Arc;
 use tracing::{error, warn};
 
-use crate::clickhouse::{QueryTimings, StoredBlockPayload, StoredBlockRecord};
+use crate::clickhouse::{
+    InflationRewardLookupOutcome, InflationRewardRecord, QueryTimings, StoredBlockPayload,
+    StoredBlockRecord,
+};
 use crate::handlers::{
     RouteMetric,
     types::{
@@ -2070,6 +2074,76 @@ fn inflation_reward_address_limit_exceeded(
     max_addresses.is_some_and(|max_addresses| address_count > max_addresses)
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum InflationRewardAvailabilityRoute {
+    NotFound,
+    RpcError,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct InflationRewardAvailabilityError {
+    route: InflationRewardAvailabilityRoute,
+    code: i32,
+    message: String,
+    data: Option<Value>,
+}
+
+fn inflation_reward_availability_error(
+    outcome: &InflationRewardLookupOutcome,
+) -> Option<InflationRewardAvailabilityError> {
+    match outcome {
+        InflationRewardLookupOutcome::Complete(_) => None,
+        InflationRewardLookupOutcome::BoundaryUnavailable { slot } => {
+            Some(InflationRewardAvailabilityError {
+                route: InflationRewardAvailabilityRoute::NotFound,
+                code: JSON_RPC_SERVER_ERROR_BLOCK_NOT_AVAILABLE as i32,
+                message: format!("Block not available for slot {slot}"),
+                data: None,
+            })
+        }
+        InflationRewardLookupOutcome::RewardsPeriodActive {
+            slot,
+            current_block_height,
+            rewards_complete_block_height,
+        } => Some(InflationRewardAvailabilityError {
+            route: InflationRewardAvailabilityRoute::RpcError,
+            code: JSON_RPC_SERVER_ERROR_EPOCH_REWARDS_PERIOD_ACTIVE as i32,
+            message: format!("Epoch rewards period still active at slot {slot}"),
+            data: Some(json!({
+                "slot": slot,
+                "currentBlockHeight": current_block_height,
+                "rewardsCompleteBlockHeight": rewards_complete_block_height,
+            })),
+        }),
+    }
+}
+
+fn inflation_reward_result(
+    requested_pubkeys: &[[u8; 32]],
+    epoch: u64,
+    reward_rows: Vec<InflationRewardRecord>,
+) -> Vec<Option<InflationRewardInfo>> {
+    let mut rewards_by_pubkey = HashMap::with_capacity(reward_rows.len());
+    for row in reward_rows {
+        rewards_by_pubkey.insert(
+            row.pubkey,
+            InflationRewardInfo {
+                epoch,
+                effective_slot: row.effective_slot,
+                amount: row.lamports.unsigned_abs(),
+                post_balance: row.post_balance,
+                commission: row.commission,
+                commission_bps: row.commission_bps,
+            },
+        );
+    }
+
+    requested_pubkeys
+        .iter()
+        .map(|pubkey| rewards_by_pubkey.get(pubkey).cloned())
+        .collect()
+}
+
 pub(crate) async fn handle_get_inflation_reward(
     state: Arc<AppState>,
     id: Value,
@@ -2234,7 +2308,7 @@ pub(crate) async fn handle_get_inflation_reward(
     };
 
     route.source_clickhouse();
-    let (reward_rows, timings) = match state
+    let (lookup_outcome, timings) = match state
         .clickhouse
         .get_inflation_rewards_for_epoch(&requested_pubkeys, epoch)
         .await
@@ -2250,25 +2324,25 @@ pub(crate) async fn handle_get_inflation_reward(
         }
     };
 
-    let mut rewards_by_pubkey = HashMap::with_capacity(reward_rows.len());
-    for row in reward_rows {
-        rewards_by_pubkey.insert(
-            row.pubkey,
-            InflationRewardInfo {
-                epoch,
-                effective_slot: row.effective_slot,
-                amount: row.lamports.unsigned_abs(),
-                post_balance: row.post_balance,
-                commission: row.commission,
-                commission_bps: row.commission_bps,
-            },
+    if let Some(availability_error) = inflation_reward_availability_error(&lookup_outcome) {
+        match availability_error.route {
+            InflationRewardAvailabilityRoute::NotFound => route.not_found(),
+            InflationRewardAvailabilityRoute::RpcError => route.rpc_error(),
+        }
+        let mut resp = json_rpc_error_response(
+            id,
+            availability_error.code,
+            availability_error.message,
+            availability_error.data,
         );
+        add_downstream_header(&mut resp, &timings);
+        return Ok(resp);
     }
+    let InflationRewardLookupOutcome::Complete(reward_rows) = lookup_outcome else {
+        unreachable!("availability outcomes return before reward mapping")
+    };
 
-    let rewards = requested_pubkeys
-        .iter()
-        .map(|pubkey| rewards_by_pubkey.get(pubkey).cloned())
-        .collect::<Vec<_>>();
+    let rewards = inflation_reward_result(&requested_pubkeys, epoch, reward_rows);
 
     route.success();
     let mut resp = json_rpc_success_response(id, json!(rewards));
@@ -2430,9 +2504,14 @@ pub(crate) async fn handle_minimum_ledger_slot(
 #[cfg(test)]
 mod tests {
     use super::{
-        classify_get_block_miss, inflation_reward_address_limit_exceeded, merge_sorted_block_slots,
+        InflationRewardAvailabilityRoute, classify_get_block_miss,
+        inflation_reward_address_limit_exceeded, inflation_reward_availability_error,
+        inflation_reward_result, merge_sorted_block_slots,
     };
+    use crate::clickhouse::InflationRewardLookupOutcome;
+    use crate::clickhouse::InflationRewardRecord;
     use solana_rpc_client_api::custom_error::JSON_RPC_SERVER_ERROR_BLOCK_NOT_AVAILABLE;
+    use solana_rpc_client_api::custom_error::JSON_RPC_SERVER_ERROR_EPOCH_REWARDS_PERIOD_ACTIVE;
     use solana_rpc_client_api::custom_error::JSON_RPC_SERVER_ERROR_LONG_TERM_STORAGE_SLOT_SKIPPED;
 
     #[test]
@@ -2462,6 +2541,78 @@ mod tests {
         assert!(!inflation_reward_address_limit_exceeded(None, usize::MAX));
         assert!(!inflation_reward_address_limit_exceeded(Some(100), 100));
         assert!(inflation_reward_address_limit_exceeded(Some(100), 101));
+    }
+
+    #[test]
+    fn inflation_reward_boundary_unavailable_uses_agave_error_contract() {
+        let error = inflation_reward_availability_error(
+            &InflationRewardLookupOutcome::BoundaryUnavailable { slot: 440_208_000 },
+        )
+        .expect("boundary absence must produce an RPC error");
+
+        assert_eq!(error.route, InflationRewardAvailabilityRoute::NotFound);
+        assert_eq!(error.code, JSON_RPC_SERVER_ERROR_BLOCK_NOT_AVAILABLE as i32);
+        assert_eq!(error.message, "Block not available for slot 440208000");
+        assert_eq!(error.data, None);
+    }
+
+    #[test]
+    fn inflation_reward_active_period_uses_agave_error_contract() {
+        let error = inflation_reward_availability_error(
+            &InflationRewardLookupOutcome::RewardsPeriodActive {
+                slot: 440_208_021,
+                current_block_height: 420_000_020,
+                rewards_complete_block_height: 420_000_294,
+            },
+        )
+        .expect("active reward period must produce an RPC error");
+
+        assert_eq!(error.route, InflationRewardAvailabilityRoute::RpcError);
+        assert_eq!(
+            error.code,
+            JSON_RPC_SERVER_ERROR_EPOCH_REWARDS_PERIOD_ACTIVE as i32
+        );
+        assert_eq!(
+            error.message,
+            "Epoch rewards period still active at slot 440208021"
+        );
+        assert_eq!(
+            error.data,
+            Some(serde_json::json!({
+                "slot": 440_208_021,
+                "currentBlockHeight": 420_000_020,
+                "rewardsCompleteBlockHeight": 420_000_294,
+            }))
+        );
+    }
+
+    #[test]
+    fn inflation_reward_result_preserves_order_duplicates_and_nulls() {
+        let rewarded = [1u8; 32];
+        let missing = [2u8; 32];
+        let result = inflation_reward_result(
+            &[rewarded, missing, rewarded],
+            1_018,
+            vec![InflationRewardRecord {
+                pubkey: rewarded,
+                effective_slot: 440_208_017,
+                lamports: 42,
+                post_balance: 1_000,
+                commission: Some(5),
+                commission_bps: Some(500),
+            }],
+        );
+
+        assert_eq!(result.len(), 3);
+        assert!(result[1].is_none());
+        for index in [0, 2] {
+            let reward = result[index]
+                .as_ref()
+                .expect("rewarded address must be present");
+            assert_eq!(reward.epoch, 1_018);
+            assert_eq!(reward.effective_slot, 440_208_017);
+            assert_eq!(reward.amount, 42);
+        }
     }
 
     #[test]

--- a/crates/superbank-rpc/src/handlers/mod.rs
+++ b/crates/superbank-rpc/src/handlers/mod.rs
@@ -1267,8 +1267,8 @@ mod tests {
     use super::{
         JSON_RPC_INTERNAL_ERROR_CODE, JSON_RPC_REQUEST_TIMEOUT_CODE,
         JSON_RPC_REQUEST_TIMEOUT_MESSAGE, is_http_503_eligible_json_rpc_error,
-        json_rpc_response_value_has_http_503_error, request_header_metric_labels,
-        response_to_json_value, validate_json_rpc_response_value,
+        json_rpc_response_value_has_http_503_error, promote_http_status_for_json_rpc_errors,
+        request_header_metric_labels, response_to_json_value, validate_json_rpc_response_value,
     };
     use axum::{
         Json,
@@ -1278,6 +1278,7 @@ mod tests {
     use serde_json::json;
     use solana_rpc_client_api::custom_error::{
         JSON_RPC_SERVER_ERROR_BLOCK_NOT_AVAILABLE,
+        JSON_RPC_SERVER_ERROR_EPOCH_REWARDS_PERIOD_ACTIVE,
         JSON_RPC_SERVER_ERROR_FILTER_TRANSACTION_NOT_FOUND,
         JSON_RPC_SERVER_ERROR_LONG_TERM_STORAGE_SLOT_SKIPPED,
         JSON_RPC_SERVER_ERROR_LONG_TERM_STORAGE_UNREACHABLE,
@@ -1317,6 +1318,7 @@ mod tests {
             JSON_RPC_SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED,
             JSON_RPC_SERVER_ERROR_UNSUPPORTED_TRANSACTION_VERSION,
             JSON_RPC_SERVER_ERROR_BLOCK_NOT_AVAILABLE,
+            JSON_RPC_SERVER_ERROR_EPOCH_REWARDS_PERIOD_ACTIVE,
             JSON_RPC_SERVER_ERROR_LONG_TERM_STORAGE_SLOT_SKIPPED,
             JSON_RPC_SERVER_ERROR_FILTER_TRANSACTION_NOT_FOUND,
         ] {
@@ -1330,6 +1332,67 @@ mod tests {
             JSON_RPC_REQUEST_TIMEOUT_CODE,
             Some("Upstream returned -32000"),
         ));
+    }
+
+    #[tokio::test]
+    async fn block_not_available_keeps_foundation_http_200_error_contract() {
+        let response = crate::rpc::json_rpc_error_response(
+            json!(1),
+            JSON_RPC_SERVER_ERROR_BLOCK_NOT_AVAILABLE as i32,
+            "Block not available for slot 440208000",
+            None,
+        );
+        let response = promote_http_status_for_json_rpc_errors(response, true).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response_to_json_value(response)
+                .await
+                .expect("response must contain valid JSON-RPC"),
+            json!({
+                "jsonrpc": "2.0",
+                "error": {
+                    "code": -32004,
+                    "message": "Block not available for slot 440208000"
+                },
+                "id": 1
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn active_epoch_rewards_period_keeps_http_200_error_contract() {
+        let response = crate::rpc::json_rpc_error_response(
+            json!(1),
+            JSON_RPC_SERVER_ERROR_EPOCH_REWARDS_PERIOD_ACTIVE as i32,
+            "Epoch rewards period still active at slot 440208021",
+            Some(json!({
+                "slot": 440_208_021,
+                "currentBlockHeight": 420_000_020,
+                "rewardsCompleteBlockHeight": 420_000_294,
+            })),
+        );
+        let response = promote_http_status_for_json_rpc_errors(response, true).await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response_to_json_value(response)
+                .await
+                .expect("response must contain valid JSON-RPC"),
+            json!({
+                "jsonrpc": "2.0",
+                "error": {
+                    "code": -32017,
+                    "message": "Epoch rewards period still active at slot 440208021",
+                    "data": {
+                        "slot": 440_208_021,
+                        "currentBlockHeight": 420_000_020,
+                        "rewardsCompleteBlockHeight": 420_000_294,
+                    }
+                },
+                "id": 1
+            })
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- return Agave-compatible HTTP 200 / `-32004` when the requested epoch's payout boundary is not available
- serve boundary vote rewards immediately and query only the exact partition block heights required by unresolved addresses
- return HTTP 200 / `-32017` while a required partition is still pending, and reserve `-32603` / HTTP 503 for ClickHouse, metadata, or integrity failures
- preserve input ordering, duplicates, and post-partition `null` results
- document progressive availability and both error contracts

## Root cause

`getInflationReward` previously scanned for every declared reward partition and treated an incomplete payout period as a ClickHouse processing failure. The handler converted both a not-yet-created payout boundary and not-yet-landed partitions into `-32603`, which became HTTP 503 when HTTP-error promotion was enabled.

The disk cache does not serve `getInflationReward`, and neither case is cacheable before the relevant boundary or partition block exists.

## Impact

Requests for epoch 1018 now match the Foundation response while its payout boundary is absent:

```json
{
  "jsonrpc": "2.0",
  "error": {
    "code": -32004,
    "message": "Block not available for slot 440208000"
  },
  "id": 1
}
```

During the next epoch's partition rollout, vote-only and landed-partition requests can succeed progressively. A multi-address request returns `-32017` without partial results if any required partition is pending.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p superbank-rpc --all-targets --all-features --locked -- -D warnings`
- `cargo test -p superbank-rpc --all-features --locked` (480 passed, 1 ignored)
- `git diff --check`
- live local replay against Foundation:
  - epoch 1018 boundary-missing request returned HTTP 200 / `-32004` with slot `440208000` on both endpoints
  - epoch 1017 vote reward matched exactly and the local lookup returned only the boundary and vote rows
  - epoch 1017 targeted stake reward matched exactly
  - ordered `[reward, null, reward]` result for a duplicate/missing-address request matched exactly
  - lookup metrics recorded `boundary_missing` and `partitioned/success` with no backend-error samples

k6 is not installed in the development environment. The live `-32017` transition state is not currently reproducible: epoch 1017 is fully distributed, while epoch 1018 has no payout boundary yet. Transition-window comparison remains a deployment validation item.

Linear: [BLO-542](https://linear.app/triton-one/issue/BLO-542/investigate-503s-for-getinflationreward-in-current-epoch)

Base includes Agave 4.2 compatibility from #75.