### PR TITLE
fix(rpc): serve signature statuses from disk cache

### DIFF
--- a/crates/superbank-rpc/README.md
+++ b/crates/superbank-rpc/README.md
@@ -59,11 +59,11 @@ Notes:
 - Methods that need a latest finalized context return a backend/internal JSON-RPC error when
   ClickHouse has no finalized slot available. This includes `getSlot`, `getBlockHeight`,
   `getTransactionCount`, `getLatestBlockhash`, `getSignatureStatuses`, and min-context checks.
-- `getSignatureStatuses` only looks up historical (ClickHouse-backed) statuses when the second
-  param sets `searchTransactionHistory: true`. Without it, only the short-lived head-cache tier
-  (when compiled with `--features grpc-head-cache` and enabled) is checked, so a signature that is
-  known to exist and is already indexed can still return `null`. This matches standard Solana
-  JSON-RPC semantics, not a Superbank-specific limitation.
+- `getSignatureStatuses` looks up recent statuses in the enabled cache tiers: the short-lived head
+  cache and, when compiled with `--features disk-cache` and enabled, the finalized disk cache. The
+  ClickHouse-backed history tier is searched only when the second param sets
+  `searchTransactionHistory: true`; without it, a signature outside the enabled cache retention
+  still returns `null`.
 - `getTransaction` accepts the standard Solana config fields plus an optional Superbank extension:
   - `slot`: optional `u64`; when supplied, ClickHouse is queried directly for that exact slot and
     the response is `null` if the signature is not present in that slot.

--- a/crates/superbank-rpc/src/handlers/signatures.rs
+++ b/crates/superbank-rpc/src/handlers/signatures.rs
@@ -196,11 +196,11 @@ pub(crate) async fn handle_get_signature_statuses(
         }
     };
 
-    // Disk tier: finalized statuses for signatures the head cache does not hold.
-    // Per getSignatureStatuses semantics, historical tiers are searched only
-    // when searchTransactionHistory is set.
+    // Disk tier: finalized recent statuses for signatures the head cache does not hold.
+    // This is part of the default status-cache lookup; searchTransactionHistory
+    // only controls the ClickHouse fallback below.
     #[cfg(feature = "disk-cache")]
-    let disk_statuses: HashMap<String, (u64, Option<Value>)> = if search_transaction_history {
+    let disk_statuses: HashMap<String, (u64, Option<Value>)> =
         if let Some(disk) = state.disk_cache.as_ref() {
             let pending: Vec<(String, Signature)> = unique_valid
                 .iter()
@@ -232,10 +232,7 @@ pub(crate) async fn handle_get_signature_statuses(
             }
         } else {
             HashMap::new()
-        }
-    } else {
-        HashMap::new()
-    };
+        };
 
     #[cfg(feature = "disk-cache")]
     let in_disk = |sig: &String| disk_statuses.contains_key(sig);

--- a/crates/superbank-rpc/src/tests/mod.rs
+++ b/crates/superbank-rpc/src/tests/mod.rs
@@ -7033,7 +7033,7 @@ mod disk_cache_tier {
     }
 
     #[tokio::test]
-    async fn get_signature_statuses_skips_disk_without_search_history() {
+    async fn get_signature_statuses_served_from_disk_without_search_history() {
         let dir = tempfile::tempdir().expect("tempdir");
         let disk = open_disk_cache(&dir);
         let signatures = write_block(&disk, 100, 99, 2);
@@ -7059,10 +7059,18 @@ mod disk_cache_tier {
                 .expect("statuses");
             let statuses = value.as_array().expect("array");
             assert_eq!(statuses.len(), 2);
-            assert!(
-                statuses.iter().all(Value::is_null),
-                "{case}: expected no historical lookup, got {statuses:?}"
-            );
+            for status in statuses {
+                assert_eq!(
+                    status.get("confirmationStatus").and_then(Value::as_str),
+                    Some("finalized"),
+                    "{case}: {status:?}"
+                );
+                assert_eq!(
+                    status.get("slot").and_then(Value::as_u64),
+                    Some(100),
+                    "{case}: {status:?}"
+                );
+            }
         }
     }
 
@@ -7106,6 +7114,57 @@ mod disk_cache_tier {
 
     fn empty_head_cache() -> Arc<HeadCache> {
         Arc::new(HeadCache::new(64, TEST_MAX_LIMIT as usize))
+    }
+
+    fn head_cache_with_finalized_tip(slot: u64) -> Arc<HeadCache> {
+        let cache = empty_head_cache();
+        let address = Pubkey::new_from_array([91u8; 32]);
+        let signature_bytes = [92u8; 64];
+        let signature = Signature::from(signature_bytes);
+        let mut record = base_transaction_record();
+        record.slot = slot;
+        record.signature = signature_bytes;
+        record.tx_signatures = vec![signature_bytes];
+        record.tx_account_keys = vec![address.to_bytes()];
+        cache.insert_for_tests(signature, record, 0, &[address], CommitmentLevel::Finalized);
+        cache
+    }
+
+    #[tokio::test]
+    async fn get_signature_statuses_disk_hit_marks_response_source_without_history_search() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let disk = open_disk_cache(&dir);
+        let signatures = write_block(&disk, 100, 99, 1);
+        let state = state_with_head_and_disk(head_cache_with_finalized_tip(101), disk);
+        let request = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "getSignatureStatuses",
+            "params": [[signatures[0].clone()]]
+        });
+
+        let response = handle_json_rpc_value(state, &request).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get("X-Superbank-Sources")
+                .and_then(|value| value.to_str().ok()),
+            Some("head-cache,disk-cache")
+        );
+
+        let parsed = parse_json_rpc_response(response).await;
+        assert!(parsed.error.is_none(), "{:?}", parsed.error);
+        let status = parsed
+            .result
+            .as_ref()
+            .and_then(|result| result.pointer("/value/0"))
+            .expect("disk status");
+        assert_eq!(status.get("slot").and_then(Value::as_u64), Some(100));
+        assert_eq!(
+            status.get("confirmationStatus").and_then(Value::as_str),
+            Some("finalized")
+        );
     }
 
     #[tokio::test]

--- a/tests/k6/scenarios/validation/superbank-rpc-disk-cache-parity.js
+++ b/tests/k6/scenarios/validation/superbank-rpc-disk-cache-parity.js
@@ -169,6 +169,7 @@ export default function (data) {
   if (harvestedSignatures.length > 0) {
     compareCall('getSignatureStatuses', 'getSignatureStatuses', [
       harvestedSignatures.slice(0, 50),
+      { searchTransactionHistory: true },
     ]);
   }
 


### PR DESCRIPTION
This pull request updates the behavior and documentation of the `getSignatureStatuses` RPC method to clarify and improve how recent signature statuses are served from cache tiers, and adjusts related tests to match the new logic. The most important changes are:

**Behavior and Documentation Updates:**

* Updated the documentation in `README.md` to clarify that `getSignatureStatuses` now looks up recent statuses in both the head cache and, if enabled, the disk cache by default. The ClickHouse history tier is only searched if `searchTransactionHistory: true` is specified.
* Changed the implementation so that the disk cache is always checked for finalized recent statuses, regardless of the `searchTransactionHistory` parameter; this parameter now only controls fallback to ClickHouse. [[1]](diffhunk://#diff-4d5a479df8cebee347e862952038fee1356425a880855277d917a6c12b7cc9efL199-R203) [[2]](diffhunk://#diff-4d5a479df8cebee347e862952038fee1356425a880855277d917a6c12b7cc9efL235-L237)

**Test Updates:**

* Renamed and updated the test to verify that `getSignatureStatuses` serves results from the disk cache even without `searchTransactionHistory`, and checks that the returned status is marked as finalized and from the correct slot. [[1]](diffhunk://#diff-06ff0b330b8e38bb605d92cebe067005586b454768b3aa5024986cfad730ffaeL7036-R7036) [[2]](diffhunk://#diff-06ff0b330b8e38bb605d92cebe067005586b454768b3aa5024986cfad730ffaeL7062-R7075)
* Added a new test to ensure the response source header (`X-Superbank-Sources`) correctly indicates both head-cache and disk-cache when disk cache is hit without history search.
* Updated the K6 validation scenario to explicitly set `{ searchTransactionHistory: true }` when comparing `getSignatureStatuses` calls, ensuring test coverage for the ClickHouse fallback path.