### PR TITLE
fix(rpc): isolate distributed query routing

### DIFF
--- a/crates/superbank-rpc/README.md
+++ b/crates/superbank-rpc/README.md
@@ -402,21 +402,21 @@ CLI flags and environment variables (see `crates/superbank-rpc/src/config.rs`):
 | `--clickhouse-query-cache-share-between-users` | `CLICKHOUSE_QUERY_CACHE_SHARE_BETWEEN_USERS` | `false` | Controls `query_cache_share_between_users` for historical read queries. |
 | `--clickhouse-query-condition-cache-enabled` | `CLICKHOUSE_QUERY_CONDITION_CACHE_ENABLED` | `false` | Enables `use_query_condition_cache=1` for selected historical address-filtered read queries. |
 | `--clickhouse-transport` | `CLICKHOUSE_TRANSPORT` | `http` | `tcp` or `http` (`tcp` requires `CLICKHOUSE_SCOPE=shard-direct`). |
-| `--clickhouse-scope` | `CLICKHOUSE_SCOPE` | `distributed` | `distributed` or `shard-direct`. |
-| `--clickhouse-tcp-access-check-timeout-ms` | `CLICKHOUSE_TCP_ACCESS_CHECK_TIMEOUT_MS` | `2000` | Startup TCP access-check timeout (ms). |
-| `--clickhouse-tcp-pool-min` | `CLICKHOUSE_TCP_POOL_MIN` | `10` | Minimum connections retained per shard in each ClickHouse native (TCP) connection pool. |
-| `--clickhouse-tcp-pool-max` | `CLICKHOUSE_TCP_POOL_MAX` | `20` | Maximum connections per shard in each ClickHouse native (TCP) connection pool. Total native connections per instance are bounded by this value times the number of shards, so size it against the ClickHouse connection budget. |
-| `--clickhouse-cluster` | `CLICKHOUSE_CLUSTER` | `{cluster}` | — |
-| `--clickhouse-topology-config` | `CLICKHOUSE_TOPOLOGY_CONFIG` | — | Optional authoritative YAML shard topology. When set, superbank-rpc skips `system.clusters` discovery, uses the YAML shard/IP/port mapping for shard-local connections, and routes `getTransactionsForAddress` to the address-owner shard. |
-| `--clickhouse-gsfa-local-table` | `CLICKHOUSE_GSFA_LOCAL_TABLE` | — | Local GSFA table used by shard-direct reads and owner-shard `getTransactionsForAddress` routing. |
+| `--clickhouse-scope` | `CLICKHOUSE_SCOPE` | `distributed` | `distributed` sends all queries through `CLICKHOUSE_URL`; `shard-direct` enables local-table routing. |
+| `--clickhouse-tcp-access-check-timeout-ms` | `CLICKHOUSE_TCP_ACCESS_CHECK_TIMEOUT_MS` | `2000` | Shard-direct only. Startup TCP access-check timeout (ms). |
+| `--clickhouse-tcp-pool-min` | `CLICKHOUSE_TCP_POOL_MIN` | `10` | Shard-direct only. Minimum connections retained per shard in each ClickHouse native (TCP) connection pool. |
+| `--clickhouse-tcp-pool-max` | `CLICKHOUSE_TCP_POOL_MAX` | `20` | Shard-direct only. Maximum connections per shard in each ClickHouse native (TCP) connection pool. Total native connections per instance are bounded by this value times the number of shards, so size it against the ClickHouse connection budget. |
+| `--clickhouse-cluster` | `CLICKHOUSE_CLUSTER` | `{cluster}` | Shard-direct only. Cluster used for topology discovery. |
+| `--clickhouse-topology-config` | `CLICKHOUSE_TOPOLOGY_CONFIG` | — | Shard-direct only. Optional authoritative YAML shard topology that replaces `system.clusters` discovery. |
+| `--clickhouse-gsfa-local-table` | `CLICKHOUSE_GSFA_LOCAL_TABLE` | — | Shard-direct only. Local GSFA table used by address queries. |
 | `--clickhouse-hot-address` | `CLICKHOUSE_GSFA_HOT_ADDRESSES` | empty | Repeatable; env accepts comma-separated values. |
 | `--clickhouse-gsfa-hot-table` | `CLICKHOUSE_GSFA_HOT_TABLE` | `default.gsfa_hot` | Distributed hot table used for active hot-address reads. |
-| `--clickhouse-gsfa-hot-local-table` | `CLICKHOUSE_GSFA_HOT_LOCAL_TABLE` | `default.gsfa_hot_local` | Shard-local backing table behind `CLICKHOUSE_GSFA_HOT_TABLE`. |
-| `--clickhouse-signatures-local-table` | `CLICKHOUSE_SIGNATURES_LOCAL_TABLE` | — | — |
-| `--clickhouse-token-owner-activity-local-table` | `CLICKHOUSE_TOKEN_OWNER_ACTIVITY_LOCAL_TABLE` | — | — |
-| `--clickhouse-transactions-local-table` | `CLICKHOUSE_TRANSACTIONS_LOCAL_TABLE` | — | — |
-| `--clickhouse-blocks-metadata-local-table` | `CLICKHOUSE_BLOCKS_METADATA_LOCAL_TABLE` | — | — |
-| `--clickhouse-shard-http-port` | `CLICKHOUSE_SHARD_HTTP_PORT` | — | — |
+| `--clickhouse-gsfa-hot-local-table` | `CLICKHOUSE_GSFA_HOT_LOCAL_TABLE` | `default.gsfa_hot_local` | Shard-direct only. Local hot table queried by hot-address fanout. |
+| `--clickhouse-signatures-local-table` | `CLICKHOUSE_SIGNATURES_LOCAL_TABLE` | — | Shard-direct only. |
+| `--clickhouse-token-owner-activity-local-table` | `CLICKHOUSE_TOKEN_OWNER_ACTIVITY_LOCAL_TABLE` | — | Shard-direct only. |
+| `--clickhouse-transactions-local-table` | `CLICKHOUSE_TRANSACTIONS_LOCAL_TABLE` | — | Shard-direct only. |
+| `--clickhouse-blocks-metadata-local-table` | `CLICKHOUSE_BLOCKS_METADATA_LOCAL_TABLE` | — | Shard-direct only. |
+| `--clickhouse-shard-http-port` | `CLICKHOUSE_SHARD_HTTP_PORT` | — | Shard-direct only. |
 
 Table selection (environment variables, read at startup):
 
@@ -431,20 +431,11 @@ Table selection (environment variables, read at startup):
 | `CLICKHOUSE_TOKEN_OWNER_ACTIVITY_TABLE` | `default.token_owner_activity` | — |
 
 Shard routing:
-When `CLICKHOUSE_SCOPE=shard-direct`, superbank-rpc discovers shards from `system.clusters` and
-validates local table schemas. Local tables default to `{table}_local` when not provided
-explicitly. `CLICKHOUSE_TRANSPORT` selects the shard-direct transport (`tcp` or `http`). When a
-topology is available in distributed scope, `getTransactionsForAddress` also uses the address
-hash to query the owner shard's local GSFA table; a failed owner-shard query is returned as an
-error instead of being retried against the distributed table.
-Set `CLICKHOUSE_TOPOLOGY_CONFIG` (or `--clickhouse-topology-config`) to make a YAML topology file
-authoritative for shard-local connection targets and skip `system.clusters` discovery at startup.
-When multiple YAML nodes are listed for the same shard, the first node listed for that shard is
-used as the shard-local TCP/HTTP connection target, and the remaining nodes are ignored.
-The YAML `ip-address` field is the authoritative connection address and does not need to match
-ClickHouse `host_address`. Shard-local TCP uses YAML `ip-address` and `tcp-port`; shard-local HTTP
-uses the same YAML `ip-address` plus `CLICKHOUSE_SHARD_HTTP_PORT` or the port from
-`CLICKHOUSE_URL`.
+When `CLICKHOUSE_SCOPE=distributed`, superbank-rpc sends every ClickHouse query through `CLICKHOUSE_URL`. It does not read `CLICKHOUSE_TOPOLOGY_CONFIG`, discover `system.clusters`, connect to shard endpoints, query local tables, or validate local schemas. Explicit shard-local settings are ignored with a startup warning.
+
+When `CLICKHOUSE_SCOPE=shard-direct`, superbank-rpc discovers shards from `system.clusters` and validates local table schemas. Local tables default to `{table}_local` when not provided explicitly. `CLICKHOUSE_TRANSPORT` selects the shard-direct transport (`tcp` or `http`).
+
+In shard-direct scope, set `CLICKHOUSE_TOPOLOGY_CONFIG` (or `--clickhouse-topology-config`) to make a YAML topology file authoritative for shard-local connection targets and skip `system.clusters` discovery at startup. When multiple YAML nodes are listed for the same shard, the first node listed for that shard is used as the shard-local TCP/HTTP connection target, and the remaining nodes are ignored. The YAML `ip-address` field is the authoritative connection address and does not need to match ClickHouse `host_address`. Shard-local TCP uses YAML `ip-address` and `tcp-port`; shard-local HTTP uses the same YAML `ip-address` plus `CLICKHOUSE_SHARD_HTTP_PORT` or the port from `CLICKHOUSE_URL`.
 YAML keys support both kebab-case and snake_case:
 
 ```yaml
@@ -522,18 +513,16 @@ routing by themselves.
 | --- | --- | --- | --- |
 | `--clickhouse-hot-address` | `CLICKHOUSE_GSFA_HOT_ADDRESSES` | empty | Repeatable; env accepts comma-separated values. |
 | `--clickhouse-gsfa-hot-table` | `CLICKHOUSE_GSFA_HOT_TABLE` | `default.gsfa_hot` | Distributed hot table used for active hot-address reads. |
-| `--clickhouse-gsfa-hot-local-table` | `CLICKHOUSE_GSFA_HOT_LOCAL_TABLE` | `default.gsfa_hot_local` | Shard-local backing table behind `CLICKHOUSE_GSFA_HOT_TABLE`. |
+| `--clickhouse-gsfa-hot-local-table` | `CLICKHOUSE_GSFA_HOT_LOCAL_TABLE` | `default.gsfa_hot_local` | Shard-direct local table queried by hot-address fanout. |
 
 Startup checks:
 - The hot distributed table must exist and contain rows for each configured address.
-- If a hot address has no rows (or the hot table is unavailable), that address falls back to
-  the standard GSFA table and a warning is logged.
+- If a hot address has no rows (or the hot table is unavailable), that address falls back to the standard GSFA table and a warning is logged.
+- Shard-direct scope also validates the local hot table schema and verifies that its bucket modulus matches the distributed hot table.
 
 Routing behavior:
-- Active hot addresses always query `CLICKHOUSE_GSFA_HOT_TABLE`, even when
-  `CLICKHOUSE_SCOPE=shard-direct` and `CLICKHOUSE_TRANSPORT=tcp`.
-- `CLICKHOUSE_GSFA_HOT_LOCAL_TABLE` remains the shard-local backing table for the distributed hot
-  table, but superbank-rpc no longer queries it directly.
+- In distributed scope, active hot addresses query `CLICKHOUSE_GSFA_HOT_TABLE` through `CLICKHOUSE_URL` and do not require shard topology.
+- In shard-direct scope, active hot addresses fan out across `CLICKHOUSE_GSFA_HOT_LOCAL_TABLE` using the configured or discovered topology.
 
 Hot table schema expectations:
 - Same columns as `default.gsfa_local` (`addr_bucket`, `address`, `signature`, `slot`,

--- a/crates/superbank-rpc/src/clickhouse/client.rs
+++ b/crates/superbank-rpc/src/clickhouse/client.rs
@@ -647,6 +647,14 @@ impl ClickHouseClient {
         let client =
             build_clickhouse_http_client(url, database, username, password, http_connect_timeout);
 
+        // Distributed scope is coordinator-only. Ignore any injected shard routing so all
+        // startup checks, cleanup queries, and reads stay on the configured HTTP endpoint.
+        let shard_routing = if routing_policy.scope == RoutingScope::ShardDirect {
+            shard_routing
+        } else {
+            None
+        };
+
         let transaction_table = std::env::var("CLICKHOUSE_TRANSACTION_TABLE")
             .or_else(|_| std::env::var("CLICKHOUSE_SIGNATURE_TABLE"))
             .unwrap_or_else(|_| "default.transactions".to_string());
@@ -659,27 +667,37 @@ impl ClickHouseClient {
         let token_owner_activity_table = std::env::var("CLICKHOUSE_TOKEN_OWNER_ACTIVITY_TABLE")
             .unwrap_or_else(|_| "default.token_owner_activity".to_string());
 
-        let signatures_local_table = shard_routing
-            .as_ref()
-            .and_then(|config| config.signatures_local_table.clone())
-            .or_else(|| derive_local_table_name(&signature_statuses_table, None));
-        let token_owner_activity_local_table = shard_routing
-            .as_ref()
-            .and_then(|config| config.token_owner_activity_local_table.clone())
-            .or_else(|| derive_local_table_name(&token_owner_activity_table, None));
-        let transactions_local_table = shard_routing
-            .as_ref()
-            .and_then(|config| config.transactions_local_table.clone())
-            .or_else(|| derive_local_table_name(&transaction_table, None));
-        let blocks_metadata_local_table = shard_routing
-            .as_ref()
-            .and_then(|config| config.blocks_metadata_local_table.clone())
-            .or_else(|| derive_local_table_name(&blocks_metadata_table, None));
+        let signatures_local_table = shard_routing.as_ref().and_then(|config| {
+            config
+                .signatures_local_table
+                .clone()
+                .or_else(|| derive_local_table_name(&signature_statuses_table, None))
+        });
+        let token_owner_activity_local_table = shard_routing.as_ref().and_then(|config| {
+            config
+                .token_owner_activity_local_table
+                .clone()
+                .or_else(|| derive_local_table_name(&token_owner_activity_table, None))
+        });
+        let transactions_local_table = shard_routing.as_ref().and_then(|config| {
+            config
+                .transactions_local_table
+                .clone()
+                .or_else(|| derive_local_table_name(&transaction_table, None))
+        });
+        let blocks_metadata_local_table = shard_routing.as_ref().and_then(|config| {
+            config
+                .blocks_metadata_local_table
+                .clone()
+                .or_else(|| derive_local_table_name(&blocks_metadata_table, None))
+        });
 
-        let gsfa_local_table = shard_routing
-            .as_ref()
-            .and_then(|config| config.gsfa_local_table.clone())
-            .or_else(|| derive_local_table_name(&gsfa_table, None));
+        let gsfa_local_table = shard_routing.as_ref().and_then(|config| {
+            config
+                .gsfa_local_table
+                .clone()
+                .or_else(|| derive_local_table_name(&gsfa_table, None))
+        });
 
         let shard_routing = shard_routing.map(|mut config| {
             if config.gsfa_local_table.is_none() {
@@ -1139,7 +1157,9 @@ impl ClickHouseClient {
             None
         };
 
-        if let Some(topology) = &self.shard_topology {
+        if self.scope_shard_direct()
+            && let Some(topology) = &self.shard_topology
+        {
             if let Some(router) = &self.gsfa_router {
                 let local_modulus = detect_bucket_modulus_on_shards(
                     topology,
@@ -1157,9 +1177,7 @@ impl ClickHouseClient {
                 )?;
             }
 
-            if self.scope_shard_direct()
-                && let Some(local_table) = &self.signatures_local_table
-            {
+            if let Some(local_table) = &self.signatures_local_table {
                 let local_modulus = detect_bucket_modulus_on_shards(
                     topology,
                     local_table,
@@ -1196,7 +1214,9 @@ impl ClickHouseClient {
             }
         }
 
-        if let (Some(topology), Some(distributed_modulus)) = (&self.shard_topology, hot_modulus) {
+        if self.scope_shard_direct()
+            && let (Some(topology), Some(distributed_modulus)) = (&self.shard_topology, hot_modulus)
+        {
             let local_modulus = detect_bucket_modulus_on_shards(
                 topology,
                 &self.gsfa_hot_local_table,
@@ -1545,7 +1565,9 @@ impl ClickHouseClient {
 
         let hot_routing_configured = self.gsfa_hot_routing_configured();
 
-        if let Some(config) = self.shard_routing.clone() {
+        if self.scope_shard_direct()
+            && let Some(config) = self.shard_routing.clone()
+        {
             match self.build_shard_topology(&config).await {
                 Ok(topology) => {
                     if self.transport_tcp() {
@@ -1580,8 +1602,7 @@ impl ClickHouseClient {
                         tracing::warn!("GSFA shard routing disabled; local table not configured");
                     }
 
-                    if self.scope_shard_direct()
-                        && let Some(local_table) = config.signatures_local_table.clone()
+                    if let Some(local_table) = config.signatures_local_table.clone()
                         && let Err(e) = validate_table_schema_on_shards(
                             topology.as_ref(),
                             &local_table,
@@ -1630,15 +1651,10 @@ impl ClickHouseClient {
                     }
                 }
                 Err(e) => {
-                    if self.scope_shard_direct()
-                        || hot_routing_configured
-                        || config.topology_config_path.is_some()
-                    {
-                        return Err(ProcessingError::database_msg(format!(
-                            "ClickHouse shard routing is required but topology initialization failed: {}",
-                            e
-                        )));
-                    }
+                    return Err(ProcessingError::database_msg(format!(
+                        "ClickHouse shard routing is required but topology initialization failed: {}",
+                        e
+                    )));
                 }
             }
         }
@@ -1646,10 +1662,15 @@ impl ClickHouseClient {
         self.discover_bucket_moduli().await?;
         self.initialize_gsfa_hot_addresses().await;
 
-        if !self.gsfa_hot_pubkeys.is_empty() {
+        if !self.gsfa_hot_pubkeys.is_empty() && self.scope_shard_direct() {
             tracing::info!(
                 "GSFA hot addresses use shard-local fanout over '{}' while '{}' remains the distributed hot table",
                 self.gsfa_hot_local_table,
+                self.gsfa_hot_table,
+            );
+        } else if !self.gsfa_hot_pubkeys.is_empty() {
+            tracing::info!(
+                "GSFA hot addresses use distributed table '{}' through the configured ClickHouse endpoint",
                 self.gsfa_hot_table,
             );
         }
@@ -2113,6 +2134,100 @@ mod tests {
                 "default.gsfa_hot_local".to_string(),
             ),
         )
+    }
+
+    #[test]
+    fn distributed_scope_discards_injected_shard_routing() {
+        let client = ClickHouseClient::new(
+            "http://localhost:8123",
+            "default",
+            "default",
+            "",
+            ClickHouseClientOptions::new(
+                RoutingPolicy {
+                    transport: RoutingTransport::Http,
+                    scope: RoutingScope::Distributed,
+                },
+                Some(ShardRoutingConfig {
+                    cluster: "production".to_string(),
+                    topology_config_path: Some("/unreachable/topology.yaml".to_string()),
+                    shard_http_port: Some(8124),
+                    gsfa_local_table: Some("default.gsfa_local".to_string()),
+                    signatures_local_table: Some("default.signatures_local".to_string()),
+                    token_owner_activity_local_table: Some(
+                        "default.token_owner_activity_local".to_string(),
+                    ),
+                    transactions_local_table: Some("default.transactions_local".to_string()),
+                    blocks_metadata_local_table: Some("default.blocks_metadata_local".to_string()),
+                }),
+                Vec::new(),
+                "default.gsfa_hot".to_string(),
+                "default.gsfa_hot_local".to_string(),
+            ),
+        );
+
+        let mut cleanup = client.http_query_cleanup("test", "query-id".to_string());
+        assert!(cleanup.cluster.is_none());
+        cleanup.disarm();
+
+        assert!(client.shard_routing.is_none());
+        assert!(client.shard_topology.is_none());
+        assert!(client.gsfa_router.is_none());
+        assert!(client.signatures_local_table.is_none());
+        assert!(client.token_owner_activity_local_table.is_none());
+        assert!(client.transactions_local_table.is_none());
+        assert!(client.blocks_metadata_local_table.is_none());
+    }
+
+    #[test]
+    fn shard_direct_scope_keeps_injected_shard_routing() {
+        let client = ClickHouseClient::new(
+            "http://localhost:8123",
+            "default",
+            "default",
+            "",
+            ClickHouseClientOptions::new(
+                RoutingPolicy {
+                    transport: RoutingTransport::Http,
+                    scope: RoutingScope::ShardDirect,
+                },
+                Some(ShardRoutingConfig {
+                    cluster: "production".to_string(),
+                    topology_config_path: None,
+                    shard_http_port: None,
+                    gsfa_local_table: None,
+                    signatures_local_table: None,
+                    token_owner_activity_local_table: None,
+                    transactions_local_table: None,
+                    blocks_metadata_local_table: None,
+                }),
+                Vec::new(),
+                "default.gsfa_hot".to_string(),
+                "default.gsfa_hot_local".to_string(),
+            ),
+        );
+
+        let mut cleanup = client.http_query_cleanup("test", "query-id".to_string());
+        assert_eq!(cleanup.cluster.as_deref(), Some("production"));
+        cleanup.disarm();
+
+        assert!(client.shard_routing.is_some());
+        assert_eq!(
+            client.signatures_local_table.as_deref(),
+            Some("default.signatures_local")
+        );
+        assert_eq!(
+            client.token_owner_activity_local_table.as_deref(),
+            Some("default.token_owner_activity_local")
+        );
+        assert_eq!(
+            client.transactions_local_table.as_deref(),
+            Some("default.transactions_local")
+        );
+        assert_eq!(
+            client.blocks_metadata_local_table.as_deref(),
+            Some("default.blocks_metadata_local")
+        );
     }
 
     fn test_client_with_query_cache() -> ClickHouseClient {

--- a/crates/superbank-rpc/src/clickhouse/gsfa.rs
+++ b/crates/superbank-rpc/src/clickhouse/gsfa.rs
@@ -146,11 +146,13 @@ impl ClickHouseClient {
     }
 
     pub(crate) fn should_use_gsfa_hot_fanout(&self, pubkey: &Pubkey) -> bool {
-        self.is_gsfa_hot_address(pubkey) && self.shard_topology.is_some()
+        self.scope_shard_direct()
+            && self.is_gsfa_hot_address(pubkey)
+            && self.shard_topology.is_some()
     }
 
     pub(crate) fn should_use_gsfa_shard_routing(&self, pubkey: &Pubkey) -> bool {
-        !self.is_gsfa_hot_address(pubkey)
+        self.scope_shard_direct() && !self.is_gsfa_hot_address(pubkey)
     }
 
     pub(crate) fn gsfa_table_for_address<'a>(&'a self, pubkey: &Pubkey) -> &'a str {
@@ -1042,14 +1044,15 @@ impl GsfaShardRouter {
 mod tests {
     use super::*;
     use crate::clickhouse::{
-        ClickHouseClientOptions, RoutingPolicy, RoutingScope, RoutingTransport, SignatureSlot,
+        ClickHouseClientOptions, QueryCacheConfig, RoutingPolicy, RoutingScope, RoutingTransport,
+        SignatureSlot,
     };
 
     fn normalize_sql(sql: &str) -> String {
         sql.split_whitespace().collect::<Vec<_>>().join(" ")
     }
 
-    fn test_client() -> ClickHouseClient {
+    fn test_client_with_scope(scope: RoutingScope) -> ClickHouseClient {
         ClickHouseClient::new(
             "http://localhost:8123",
             "default",
@@ -1058,7 +1061,7 @@ mod tests {
             ClickHouseClientOptions::new(
                 RoutingPolicy {
                     transport: RoutingTransport::Http,
-                    scope: RoutingScope::ShardDirect,
+                    scope,
                 },
                 None,
                 Vec::new(),
@@ -1066,6 +1069,21 @@ mod tests {
                 "default.gsfa_hot_local".to_string(),
             ),
         )
+    }
+
+    fn test_client() -> ClickHouseClient {
+        test_client_with_scope(RoutingScope::ShardDirect)
+    }
+
+    fn empty_test_topology() -> Arc<ShardTopology> {
+        Arc::new(ShardTopology {
+            total_weight: 1,
+            shards: Vec::new(),
+            weights: vec![1],
+            allow_query_settings: true,
+            query_cache: QueryCacheConfig::default(),
+            query_timeout: Duration::from_secs(8),
+        })
     }
 
     #[test]
@@ -1253,6 +1271,36 @@ mod tests {
         );
         assert!(!client.should_use_gsfa_hot_fanout(&hot_pubkey));
         assert!(!client.should_use_gsfa_shard_routing(&hot_pubkey));
+    }
+
+    #[test]
+    fn distributed_scope_never_uses_gsfa_shard_routing_with_topology() {
+        let mut client = test_client_with_scope(RoutingScope::Distributed);
+        let hot_pubkey = Pubkey::new_from_array([7; 32]);
+        let cold_pubkey = Pubkey::new_from_array([9; 32]);
+        client.gsfa_hot_pubkeys.insert(hot_pubkey);
+        client.shard_topology = Some(empty_test_topology());
+
+        assert_eq!(
+            client.gsfa_table_for_address(&hot_pubkey),
+            "default.gsfa_hot"
+        );
+        assert!(!client.should_use_gsfa_hot_fanout(&hot_pubkey));
+        assert!(!client.should_use_gsfa_shard_routing(&hot_pubkey));
+        assert!(!client.should_use_gsfa_shard_routing(&cold_pubkey));
+    }
+
+    #[test]
+    fn shard_direct_scope_uses_gsfa_shard_routing_with_topology() {
+        let mut client = test_client();
+        let hot_pubkey = Pubkey::new_from_array([7; 32]);
+        let cold_pubkey = Pubkey::new_from_array([9; 32]);
+        client.gsfa_hot_pubkeys.insert(hot_pubkey);
+        client.shard_topology = Some(empty_test_topology());
+
+        assert!(client.should_use_gsfa_hot_fanout(&hot_pubkey));
+        assert!(!client.should_use_gsfa_shard_routing(&hot_pubkey));
+        assert!(client.should_use_gsfa_shard_routing(&cold_pubkey));
     }
 
     #[test]

--- a/crates/superbank-rpc/src/config.rs
+++ b/crates/superbank-rpc/src/config.rs
@@ -344,36 +344,43 @@ pub struct RpcConfig {
     )]
     pub(crate) clickhouse_tcp_access_check_timeout_ms: u64,
 
-    /// ClickHouse cluster name used to discover shard topology (supports macros like {cluster}).
+    /// ClickHouse cluster name used to discover shard topology in shard-direct scope.
+    /// Supports macros such as {cluster}.
     #[arg(long, env = "CLICKHOUSE_CLUSTER", default_value = "{cluster}")]
     pub(crate) clickhouse_cluster: String,
 
     /// Optional authoritative YAML topology file for shard-local ClickHouse connections.
-    /// When set, superbank-rpc skips system.clusters discovery and uses the YAML mapping directly.
+    /// In shard-direct scope, this skips system.clusters discovery and uses the YAML mapping.
+    /// Distributed scope ignores this setting.
     #[arg(long, env = "CLICKHOUSE_TOPOLOGY_CONFIG")]
     pub(crate) clickhouse_topology_config: Option<String>,
 
-    /// Local gsfa table used by shard-direct and owner-shard address queries.
+    /// Local gsfa table used by shard-direct address queries.
     #[arg(long, env = "CLICKHOUSE_GSFA_LOCAL_TABLE")]
     pub(crate) clickhouse_gsfa_local_table: Option<String>,
 
-    /// Local signatures table name on each shard (defaults to CLICKHOUSE_SIGNATURE_STATUSES_TABLE + _local).
+    /// Local signatures table used in shard-direct scope.
+    /// Defaults to CLICKHOUSE_SIGNATURE_STATUSES_TABLE + _local.
     #[arg(long, env = "CLICKHOUSE_SIGNATURES_LOCAL_TABLE")]
     pub(crate) clickhouse_signatures_local_table: Option<String>,
 
-    /// Local token owner activity table name on each shard (defaults to CLICKHOUSE_TOKEN_OWNER_ACTIVITY_TABLE + _local).
+    /// Local token owner activity table used in shard-direct scope.
+    /// Defaults to CLICKHOUSE_TOKEN_OWNER_ACTIVITY_TABLE + _local.
     #[arg(long, env = "CLICKHOUSE_TOKEN_OWNER_ACTIVITY_LOCAL_TABLE")]
     pub(crate) clickhouse_token_owner_activity_local_table: Option<String>,
 
-    /// Local transactions table name on each shard (defaults to CLICKHOUSE_TRANSACTION_TABLE + _local).
+    /// Local transactions table used in shard-direct scope.
+    /// Defaults to CLICKHOUSE_TRANSACTION_TABLE + _local.
     #[arg(long, env = "CLICKHOUSE_TRANSACTIONS_LOCAL_TABLE")]
     pub(crate) clickhouse_transactions_local_table: Option<String>,
 
-    /// Local blocks metadata table name on each shard (defaults to CLICKHOUSE_BLOCKS_METADATA_TABLE + _local).
+    /// Local blocks metadata table used in shard-direct scope.
+    /// Defaults to CLICKHOUSE_BLOCKS_METADATA_TABLE + _local.
     #[arg(long, env = "CLICKHOUSE_BLOCKS_METADATA_LOCAL_TABLE")]
     pub(crate) clickhouse_blocks_metadata_local_table: Option<String>,
 
-    /// Override shard HTTP port for shard-local HTTP queries (defaults to port in CLICKHOUSE_URL).
+    /// Override the shard HTTP port in shard-direct scope.
+    /// Defaults to the port in CLICKHOUSE_URL.
     #[arg(long, env = "CLICKHOUSE_SHARD_HTTP_PORT")]
     pub(crate) clickhouse_shard_http_port: Option<u16>,
 
@@ -394,7 +401,7 @@ pub struct RpcConfig {
     )]
     pub(crate) clickhouse_gsfa_hot_table: String,
 
-    /// Local GSFA hot table backing CLICKHOUSE_GSFA_HOT_TABLE on each shard.
+    /// Local GSFA hot table used by shard-direct hot-address fanout.
     #[arg(
         long,
         env = "CLICKHOUSE_GSFA_HOT_LOCAL_TABLE",

--- a/crates/superbank-rpc/src/server.rs
+++ b/crates/superbank-rpc/src/server.rs
@@ -20,9 +20,7 @@ use crate::clickhouse::{
     ClickHouseClient, ClickHouseClientOptions, InflationRewardQueryLimits, QueryCacheConfig,
     RoutingPolicy, RoutingScope, RoutingTransport, ShardRoutingConfig,
 };
-use crate::config::{
-    ClickHouseScope, ClickHouseTransport, RpcConfig, has_usable_gsfa_hot_addresses,
-};
+use crate::config::{ClickHouseScope, ClickHouseTransport, RpcConfig};
 use crate::handlers::handle_json_rpc_with_headers;
 use crate::metrics;
 use crate::metrics::metrics_handler;
@@ -47,6 +45,10 @@ use solana_commitment_config::CommitmentLevel;
 pub type RpcResult<T> = Result<T, RpcError>;
 
 fn build_shard_routing_config(args: &RpcConfig) -> Option<ShardRoutingConfig> {
+    if args.clickhouse_scope != ClickHouseScope::ShardDirect {
+        return None;
+    }
+
     let topology_config_path = args
         .clickhouse_topology_config
         .as_deref()
@@ -54,25 +56,69 @@ fn build_shard_routing_config(args: &RpcConfig) -> Option<ShardRoutingConfig> {
         .filter(|path| !path.is_empty())
         .map(str::to_string);
 
-    if args.clickhouse_scope == ClickHouseScope::ShardDirect
-        || has_usable_gsfa_hot_addresses(&args.clickhouse_hot_addresses)
-        || topology_config_path.is_some()
-    {
-        Some(ShardRoutingConfig {
-            cluster: args.clickhouse_cluster.clone(),
-            topology_config_path,
-            shard_http_port: args.clickhouse_shard_http_port,
-            gsfa_local_table: args.clickhouse_gsfa_local_table.clone(),
-            signatures_local_table: args.clickhouse_signatures_local_table.clone(),
-            token_owner_activity_local_table: args
-                .clickhouse_token_owner_activity_local_table
-                .clone(),
-            transactions_local_table: args.clickhouse_transactions_local_table.clone(),
-            blocks_metadata_local_table: args.clickhouse_blocks_metadata_local_table.clone(),
-        })
-    } else {
-        None
+    Some(ShardRoutingConfig {
+        cluster: args.clickhouse_cluster.clone(),
+        topology_config_path,
+        shard_http_port: args.clickhouse_shard_http_port,
+        gsfa_local_table: args.clickhouse_gsfa_local_table.clone(),
+        signatures_local_table: args.clickhouse_signatures_local_table.clone(),
+        token_owner_activity_local_table: args.clickhouse_token_owner_activity_local_table.clone(),
+        transactions_local_table: args.clickhouse_transactions_local_table.clone(),
+        blocks_metadata_local_table: args.clickhouse_blocks_metadata_local_table.clone(),
+    })
+}
+
+fn has_nonempty_setting(value: Option<&str>) -> bool {
+    value.is_some_and(|value| !value.trim().is_empty())
+}
+
+fn ignored_distributed_shard_settings(args: &RpcConfig) -> Vec<&'static str> {
+    if args.clickhouse_scope != ClickHouseScope::Distributed {
+        return Vec::new();
     }
+
+    let mut ignored = Vec::new();
+    if args.clickhouse_cluster.trim() != "{cluster}" {
+        ignored.push("CLICKHOUSE_CLUSTER");
+    }
+    if has_nonempty_setting(args.clickhouse_topology_config.as_deref()) {
+        ignored.push("CLICKHOUSE_TOPOLOGY_CONFIG");
+    }
+    if has_nonempty_setting(args.clickhouse_gsfa_local_table.as_deref()) {
+        ignored.push("CLICKHOUSE_GSFA_LOCAL_TABLE");
+    }
+    if has_nonempty_setting(args.clickhouse_signatures_local_table.as_deref()) {
+        ignored.push("CLICKHOUSE_SIGNATURES_LOCAL_TABLE");
+    }
+    if has_nonempty_setting(args.clickhouse_token_owner_activity_local_table.as_deref()) {
+        ignored.push("CLICKHOUSE_TOKEN_OWNER_ACTIVITY_LOCAL_TABLE");
+    }
+    if has_nonempty_setting(args.clickhouse_transactions_local_table.as_deref()) {
+        ignored.push("CLICKHOUSE_TRANSACTIONS_LOCAL_TABLE");
+    }
+    if has_nonempty_setting(args.clickhouse_blocks_metadata_local_table.as_deref()) {
+        ignored.push("CLICKHOUSE_BLOCKS_METADATA_LOCAL_TABLE");
+    }
+    if args.clickhouse_shard_http_port.is_some() {
+        ignored.push("CLICKHOUSE_SHARD_HTTP_PORT");
+    }
+    if args.clickhouse_gsfa_hot_local_table.trim() != "default.gsfa_hot_local" {
+        ignored.push("CLICKHOUSE_GSFA_HOT_LOCAL_TABLE");
+    }
+    if args.clickhouse_tcp_access_check_timeout_ms != 2_000 {
+        ignored.push("CLICKHOUSE_TCP_ACCESS_CHECK_TIMEOUT_MS");
+    }
+    if args.clickhouse_tcp_pool_min != 10 {
+        ignored.push("CLICKHOUSE_TCP_POOL_MIN");
+    }
+    if args.clickhouse_tcp_pool_max != 20 {
+        ignored.push("CLICKHOUSE_TCP_POOL_MAX");
+    }
+    if args.clickhouse_shard_fanout_concurrency != 8 {
+        ignored.push("CLICKHOUSE_SHARD_FANOUT_CONCURRENCY");
+    }
+
+    ignored
 }
 
 fn build_routing_policy(args: &RpcConfig) -> Result<RoutingPolicy, ProcessingError> {
@@ -160,8 +206,15 @@ pub async fn run_server(args: RpcConfig) -> RpcResult<()> {
     }
 
     // Initialize ClickHouse client
-    let shard_routing = build_shard_routing_config(&args);
     let routing_policy = build_routing_policy(&args)?;
+    let ignored_shard_settings = ignored_distributed_shard_settings(&args);
+    if !ignored_shard_settings.is_empty() {
+        warn!(
+            settings = %ignored_shard_settings.join(", "),
+            "Shard-local ClickHouse settings are ignored because CLICKHOUSE_SCOPE=distributed"
+        );
+    }
+    let shard_routing = build_shard_routing_config(&args);
 
     let mut clickhouse = ClickHouseClient::new(
         &args.clickhouse_url,
@@ -601,7 +654,9 @@ fn parse_commitment_level(value: &str) -> CommitmentLevel {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_routing_policy, build_shard_routing_config};
+    use super::{
+        build_routing_policy, build_shard_routing_config, ignored_distributed_shard_settings,
+    };
     use crate::clickhouse::{RoutingScope, RoutingTransport};
     use crate::config::{ClickHouseScope, ClickHouseTransport, RpcConfig};
 
@@ -630,7 +685,7 @@ mod tests {
     }
 
     #[test]
-    fn shard_routing_enabled_for_hot_routing_in_distributed_scope() {
+    fn shard_routing_disabled_for_hot_routing_in_distributed_scope() {
         use clap::Parser;
 
         let _env_lock = crate::config::ENV_TEST_LOCK.lock().expect("env lock");
@@ -639,12 +694,11 @@ mod tests {
         cfg.clickhouse_hot_addresses =
             vec!["EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string()];
 
-        let routing = build_shard_routing_config(&cfg).expect("routing config");
-        assert_eq!(routing.cluster, "{cluster}");
+        assert!(build_shard_routing_config(&cfg).is_none());
     }
 
     #[test]
-    fn shard_routing_enabled_for_topology_config_in_distributed_scope() {
+    fn shard_routing_disabled_for_topology_config_in_distributed_scope() {
         use clap::Parser;
 
         let _env_lock = crate::config::ENV_TEST_LOCK.lock().expect("env lock");
@@ -652,11 +706,90 @@ mod tests {
         cfg.clickhouse_scope = ClickHouseScope::Distributed;
         cfg.clickhouse_topology_config = Some(" /etc/superbank/topology.yaml ".to_string());
 
+        assert!(build_shard_routing_config(&cfg).is_none());
+    }
+
+    #[test]
+    fn shard_routing_normalizes_topology_config_in_shard_direct_scope() {
+        use clap::Parser;
+
+        let _env_lock = crate::config::ENV_TEST_LOCK.lock().expect("env lock");
+        let mut cfg = RpcConfig::parse_from(["superbank-rpc"]);
+        cfg.clickhouse_scope = ClickHouseScope::ShardDirect;
+        cfg.clickhouse_topology_config = Some(" /etc/superbank/topology.yaml ".to_string());
+
         let routing = build_shard_routing_config(&cfg).expect("routing config");
         assert_eq!(
             routing.topology_config_path.as_deref(),
             Some("/etc/superbank/topology.yaml")
         );
+    }
+
+    #[test]
+    fn distributed_scope_reports_explicit_shard_settings_as_ignored() {
+        use clap::Parser;
+
+        let _env_lock = crate::config::ENV_TEST_LOCK.lock().expect("env lock");
+        let mut cfg = RpcConfig::parse_from(["superbank-rpc"]);
+        cfg.clickhouse_scope = ClickHouseScope::Distributed;
+        cfg.clickhouse_cluster = "production".to_string();
+        cfg.clickhouse_topology_config = Some("/etc/superbank/topology.yaml".to_string());
+        cfg.clickhouse_gsfa_local_table = Some("default.gsfa_local".to_string());
+        cfg.clickhouse_signatures_local_table = Some("default.signatures_local".to_string());
+        cfg.clickhouse_token_owner_activity_local_table =
+            Some("default.token_owner_activity_local".to_string());
+        cfg.clickhouse_transactions_local_table = Some("default.transactions_local".to_string());
+        cfg.clickhouse_blocks_metadata_local_table =
+            Some("default.blocks_metadata_local".to_string());
+        cfg.clickhouse_shard_http_port = Some(8124);
+        cfg.clickhouse_gsfa_hot_local_table = "default.custom_hot_local".to_string();
+        cfg.clickhouse_tcp_access_check_timeout_ms = 3_000;
+        cfg.clickhouse_tcp_pool_min = 11;
+        cfg.clickhouse_tcp_pool_max = 21;
+        cfg.clickhouse_shard_fanout_concurrency = 9;
+
+        assert_eq!(
+            ignored_distributed_shard_settings(&cfg),
+            vec![
+                "CLICKHOUSE_CLUSTER",
+                "CLICKHOUSE_TOPOLOGY_CONFIG",
+                "CLICKHOUSE_GSFA_LOCAL_TABLE",
+                "CLICKHOUSE_SIGNATURES_LOCAL_TABLE",
+                "CLICKHOUSE_TOKEN_OWNER_ACTIVITY_LOCAL_TABLE",
+                "CLICKHOUSE_TRANSACTIONS_LOCAL_TABLE",
+                "CLICKHOUSE_BLOCKS_METADATA_LOCAL_TABLE",
+                "CLICKHOUSE_SHARD_HTTP_PORT",
+                "CLICKHOUSE_GSFA_HOT_LOCAL_TABLE",
+                "CLICKHOUSE_TCP_ACCESS_CHECK_TIMEOUT_MS",
+                "CLICKHOUSE_TCP_POOL_MIN",
+                "CLICKHOUSE_TCP_POOL_MAX",
+                "CLICKHOUSE_SHARD_FANOUT_CONCURRENCY",
+            ]
+        );
+    }
+
+    #[test]
+    fn distributed_scope_has_no_ignored_shard_settings_at_defaults() {
+        use clap::Parser;
+
+        let _env_lock = crate::config::ENV_TEST_LOCK.lock().expect("env lock");
+        let mut cfg = RpcConfig::parse_from(["superbank-rpc"]);
+        cfg.clickhouse_scope = ClickHouseScope::Distributed;
+
+        assert!(ignored_distributed_shard_settings(&cfg).is_empty());
+    }
+
+    #[test]
+    fn shard_direct_scope_does_not_report_shard_settings_as_ignored() {
+        use clap::Parser;
+
+        let _env_lock = crate::config::ENV_TEST_LOCK.lock().expect("env lock");
+        let mut cfg = RpcConfig::parse_from(["superbank-rpc"]);
+        cfg.clickhouse_scope = ClickHouseScope::ShardDirect;
+        cfg.clickhouse_topology_config = Some("/etc/superbank/topology.yaml".to_string());
+        cfg.clickhouse_gsfa_local_table = Some("default.gsfa_local".to_string());
+
+        assert!(ignored_distributed_shard_settings(&cfg).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
This pull request refines the distinction between "distributed" and "shard-direct" ClickHouse routing scopes in both the implementation and documentation of `superbank-rpc`. It clarifies the behavior of configuration flags, ensures that shard-local routing is only enabled in the appropriate scope, and adds tests to verify correct behavior. The changes improve reliability and developer understanding of how routing and table selection work in different deployment modes.

**Documentation and configuration clarity:**

- Updated the `README.md` to clearly distinguish which CLI flags and environment variables apply only to `shard-direct` scope, and clarified the routing and table selection behavior for both `distributed` and `shard-direct` modes. [[1]](diffhunk://#diff-d520a39c230a8012b22bb2c0279fd36de1c852c94bc29b5bd5f6281a451ad56eL405-R419) [[2]](diffhunk://#diff-d520a39c230a8012b22bb2c0279fd36de1c852c94bc29b5bd5f6281a451ad56eL434-R438) [[3]](diffhunk://#diff-d520a39c230a8012b22bb2c0279fd36de1c852c94bc29b5bd5f6281a451ad56eL525-R525)
- Improved documentation for hot address routing, making it explicit how hot tables are used in each scope and what startup checks are performed.

**Code logic improvements:**

- Modified `ClickHouseClient` initialization so that injected shard routing configuration is ignored in `distributed` scope, ensuring all queries and checks go through the configured HTTP endpoint only.
- Refactored local table resolution logic to only derive or use local tables when shard routing is present, further restricting it to `shard-direct` scope.
- Updated schema validation and bucket modulus checks to only run in `shard-direct` scope, preventing unnecessary or invalid checks in `distributed` mode. [[1]](diffhunk://#diff-7943caddf960631c545ec9e98742b9a09045c65438baaef2bcd480921f025496L1142-R1162) [[2]](diffhunk://#diff-7943caddf960631c545ec9e98742b9a09045c65438baaef2bcd480921f025496L1160-R1180) [[3]](diffhunk://#diff-7943caddf960631c545ec9e98742b9a09045c65438baaef2bcd480921f025496L1199-R1219) [[4]](diffhunk://#diff-7943caddf960631c545ec9e98742b9a09045c65438baaef2bcd480921f025496L1548-R1570) [[5]](diffhunk://#diff-7943caddf960631c545ec9e98742b9a09045c65438baaef2bcd480921f025496L1583-R1605) [[6]](diffhunk://#diff-7943caddf960631c545ec9e98742b9a09045c65438baaef2bcd480921f025496L1633-R1675)

**Testing:**

- Added comprehensive tests to verify that shard routing is discarded in `distributed` scope and retained in `shard-direct` scope, including validation of table selection and cleanup logic.

**Routing logic:**

- Updated GSFA hot address and shard routing logic to only use fanout and local tables when in `shard-direct` scope, ensuring correct routing behavior based on deployment mode.

**Test utility improvements:**

- Improved test utilities to allow explicit selection of routing scope for more robust and targeted testing.