### PR TITLE
chore(release): prepare v0.6.0-rc1

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,7 +14,9 @@ Dockerfile
 *~
 artifacts/
 deploy/
-dist/
+dist/*
+!dist/superbank
+!dist/superbank-rpc
 docker-compose.yaml
 scripts/
 superbank.yaml

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -116,6 +116,7 @@ checksum:
 
 release:
   name_template: "Release {{ .Tag }}"
+  prerelease: auto
   header: |
     rust {{ .Env.RUST_VERSION }}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -211,19 +211,16 @@ CI enforces PR titles via the `Lint PR title` GitHub Actions check.
 Releases are tag-driven and published by GoReleaser:
 
 1. Update the shared package version under `[workspace.package]` in the root `Cargo.toml`.
-2. Create and push an annotated `vX.Y.Z` tag.
+2. Create and push a signed annotated `vX.Y.Z` or `vX.Y.Z-<prerelease>` tag.
 3. The release workflow verifies that the tag version matches the Cargo package versions.
-4. The release workflow runs a Tilt-backed E2E gate that starts ClickHouse, applies local DDL,
-   runs `superbank` ingestion, starts `superbank-rpc`, and runs the k6 release suite before assets are
-   published.
-5. After E2E passes, GoReleaser builds both binaries for Linux amd64 and Linux arm64,
-   then publishes a GitHub Release with `.tar.gz` archives, release notes, and `SHA256SUMS.txt`.
+4. The release workflow runs a Tilt-backed E2E gate that starts ClickHouse, applies local DDL, runs `superbank` ingestion, starts `superbank-rpc`, and runs the k6 release suite before assets are published.
+5. After E2E passes, GoReleaser builds `superbank`, `superbank-rpc`, `superbank-solparq`, `superbank-solparq-read`, and `superbank-verify` for Linux amd64 and Linux arm64, then publishes a GitHub Release with `.tar.gz` archives, release notes, and `SHA256SUMS.txt`.
 
 Example:
 
 ```bash
-git tag -a v0.5.0 -m "Release v0.5.0"
-git push origin v0.5.0
+git tag -s v0.6.0-rc1 -m "Release v0.6.0-rc1"
+git push origin v0.6.0-rc1
 ```
 
 Repository settings required (GitHub UI):

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7771,7 +7771,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "superbank"
-version = "0.5.0-solparq.18"
+version = "0.6.0-rc1"
 dependencies = [
  "anyhow",
  "axum",
@@ -7824,7 +7824,7 @@ dependencies = [
 
 [[package]]
 name = "superbank-rpc"
-version = "0.5.0-solparq.18"
+version = "0.6.0-rc1"
 dependencies = [
  "async-stream",
  "axum",
@@ -7895,7 +7895,7 @@ dependencies = [
 
 [[package]]
 name = "superbank-solparq"
-version = "0.5.0-solparq.18"
+version = "0.6.0-rc1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -7927,7 +7927,7 @@ dependencies = [
 
 [[package]]
 name = "superbank-verify"
-version = "0.5.0-solparq.18"
+version = "0.6.0-rc1"
 dependencies = [
  "anyhow",
  "axum",
@@ -7959,7 +7959,7 @@ dependencies = [
 
 [[package]]
 name = "superbank-workspace"
-version = "0.5.0-solparq.18"
+version = "0.6.0-rc1"
 
 [[package]]
 name = "symbolic-common"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors.workspace = true
 publish = false
 
 [workspace.package]
-version = "0.5.0-solparq.18"
+version = "0.6.0-rc1"
 edition = "2024"
 license = "AGPL-3.0-only"
 authors = [

--- a/ddl/cluster/gsfa.sql
+++ b/ddl/cluster/gsfa.sql
@@ -109,6 +109,7 @@ WITH
         CAST(base58Decode('SysvarS1otHashes111111111111111111111111111') AS FixedString(32))
     ] AS gsfa_ignored_addresses
 SELECT
+    cityHash64(address) % 32 AS addr_bucket,
     address,
     signature,
     slot,

--- a/ddl/cluster/gsfa_hot.sql
+++ b/ddl/cluster/gsfa_hot.sql
@@ -117,6 +117,7 @@ WITH
         CAST(base58Decode('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v') AS FixedString(32))
     ] AS gsfa_hot_addresses
 SELECT
+    cityHash64(address) % 32 AS addr_bucket,
     address,
     signature,
     slot,

--- a/ddl/cluster/gsfa_nohot.sql
+++ b/ddl/cluster/gsfa_nohot.sql
@@ -119,6 +119,7 @@ WITH
         CAST(base58Decode('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v') AS FixedString(32))
     ] AS gsfa_hot_addresses
 SELECT
+    cityHash64(address) % 32 AS addr_bucket,
     address,
     signature,
     slot,

--- a/ddl/cluster/token_owner_activity.sql
+++ b/ddl/cluster/token_owner_activity.sql
@@ -128,6 +128,7 @@ WITH
         CAST(base58Decode('Memo4c2pN8afCj432Lb7RMVKi9PbQnnW7ewFFaV3oAH') AS FixedString(32))
     ] AS memo_program_ids
 SELECT
+    cityHash64(owner) % 32 AS owner_bucket,
     assumeNotNull(entry.1) AS owner,
     entry.2 AS token_account,
     signature,

--- a/ddl/local/gsfa.sql
+++ b/ddl/local/gsfa.sql
@@ -94,6 +94,7 @@ WITH
         CAST(base58Decode('SysvarS1otHashes111111111111111111111111111') AS FixedString(32))
     ] AS gsfa_ignored_addresses
 SELECT
+    cityHash64(address) % 32 AS addr_bucket,
     address,
     signature,
     slot,

--- a/ddl/local/gsfa_hot.sql
+++ b/ddl/local/gsfa_hot.sql
@@ -102,6 +102,7 @@ WITH
         CAST(base58Decode('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v') AS FixedString(32))
     ] AS gsfa_hot_addresses
 SELECT
+    cityHash64(address) % 32 AS addr_bucket,
     address,
     signature,
     slot,

--- a/ddl/local/gsfa_nohot.sql
+++ b/ddl/local/gsfa_nohot.sql
@@ -104,6 +104,7 @@ WITH
         CAST(base58Decode('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v') AS FixedString(32))
     ] AS gsfa_hot_addresses
 SELECT
+    cityHash64(address) % 32 AS addr_bucket,
     address,
     signature,
     slot,

--- a/ddl/local/token_owner_activity.sql
+++ b/ddl/local/token_owner_activity.sql
@@ -113,6 +113,7 @@ WITH
         CAST(base58Decode('Memo4c2pN8afCj432Lb7RMVKi9PbQnnW7ewFFaV3oAH') AS FixedString(32))
     ] AS memo_program_ids
 SELECT
+    cityHash64(owner) % 32 AS owner_bucket,
     assumeNotNull(entry.1) AS owner,
     entry.2 AS token_account,
     signature,

--- a/ddl/replicated/gsfa.sql
+++ b/ddl/replicated/gsfa.sql
@@ -109,6 +109,7 @@ WITH
         CAST(base58Decode('SysvarS1otHashes111111111111111111111111111') AS FixedString(32))
     ] AS gsfa_ignored_addresses
 SELECT
+    cityHash64(address) % 32 AS addr_bucket,
     address,
     signature,
     slot,

--- a/ddl/replicated/gsfa_hot.sql
+++ b/ddl/replicated/gsfa_hot.sql
@@ -117,6 +117,7 @@ WITH
         CAST(base58Decode('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v') AS FixedString(32))
     ] AS gsfa_hot_addresses
 SELECT
+    cityHash64(address) % 32 AS addr_bucket,
     address,
     signature,
     slot,

--- a/ddl/replicated/gsfa_nohot.sql
+++ b/ddl/replicated/gsfa_nohot.sql
@@ -119,6 +119,7 @@ WITH
         CAST(base58Decode('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v') AS FixedString(32))
     ] AS gsfa_hot_addresses
 SELECT
+    cityHash64(address) % 32 AS addr_bucket,
     address,
     signature,
     slot,

--- a/ddl/replicated/token_owner_activity.sql
+++ b/ddl/replicated/token_owner_activity.sql
@@ -128,6 +128,7 @@ WITH
         CAST(base58Decode('Memo4c2pN8afCj432Lb7RMVKi9PbQnnW7ewFFaV3oAH') AS FixedString(32))
     ] AS memo_program_ids
 SELECT
+    cityHash64(owner) % 32 AS owner_bucket,
     assumeNotNull(entry.1) AS owner,
     entry.2 AS token_account,
     signature,

--- a/scripts/test/run-k6.sh
+++ b/scripts/test/run-k6.sh
@@ -36,6 +36,7 @@ Suite defaults (override as needed):
 Notes:
   - Validation tests are skipped unless REFERENCE_RPC_URL is set.
   - Head-cache WS scenario runs only if RPC supports `commitment=processed` and SOLANA_WS_URL is set.
+  - The getInflationReward stress scenario is skipped unless INFLATION_REWARD_EPOCH is set.
   - Stress/soak/spike scenarios are long-running; enable them explicitly via flags.
 EOF
 }
@@ -287,6 +288,11 @@ run_replay_suite() {
 run_long_suite() {
   if [[ "${include_stress}" == "true" ]]; then
     for script in tests/k6/scenarios/stress/*.js; do
+      if [[ "${script}" == "tests/k6/scenarios/stress/stress-test-get-inflation-reward.js" \
+        && -z "${INFLATION_REWARD_EPOCH:-}" ]]; then
+        skip "stress:$(basename "${script}")" "INFLATION_REWARD_EPOCH not set"
+        continue
+      fi
       run_k6 "stress:$(basename "${script}")" "${script}"
     done
   fi


### PR DESCRIPTION
This pull request updates the release process to support prerelease versions and updates documentation and configuration to match. The most significant changes include enabling prerelease tagging with GoReleaser, updating the release instructions in the documentation, and bumping the workspace package version.

Release process updates:

* Enabled automatic prerelease detection in GoReleaser by adding `prerelease: auto` to `.goreleaser.yaml`, allowing releases with tags like `vX.Y.Z-rc1`.
* Updated release instructions in `CONTRIBUTING.md` to clarify that signed annotated tags with prerelease identifiers (e.g., `v0.6.0-rc1`) are now supported, and expanded the list of binaries built and published during release.

Version bump:

* Updated the workspace package version in `Cargo.toml` from `0.5.0-solparq.18` to `0.6.0-rc1` to reflect the new prerelease versioning.