### PR TITLE
fix: add transactionIndex to gSFA

### DIFF
--- a/crates/superbank-rpc/README.md
+++ b/crates/superbank-rpc/README.md
@@ -75,6 +75,8 @@ Notes:
   - `slot`: optional `u64`; when supplied, ClickHouse is queried directly for that exact slot and
     the response is `null` if the signature is not present in that slot.
 - `getSignaturesForAddress` accepts standard Solana config fields plus optional Superbank extensions:
+  - Each returned entry includes `transactionIndex`, the transaction's zero-based position in the
+    block's flattened transaction list.
   - `beforeSlot`: optional `u64`; exclusive whole-slot upper bound (`slot < beforeSlot`).
   - `untilSlot`: optional `u64`; exclusive whole-slot lower bound (`slot > untilSlot`).
     These are whole-slot cursors, not signature-position cursors; `beforeSlot` cannot be combined

--- a/crates/superbank-rpc/src/handlers/signatures.rs
+++ b/crates/superbank-rpc/src/handlers/signatures.rs
@@ -737,6 +737,7 @@ pub(crate) async fn handle_get_signatures_for_address(
                 .map(|meta| SignatureInfo {
                     signature: meta.signature_str.to_string(),
                     slot: meta.pos.slot,
+                    transaction_index: Some(meta.pos.idx),
                     err: meta.err.clone(),
                     memo: meta.memo.clone(),
                     block_time: meta.block_time,
@@ -897,6 +898,7 @@ pub(crate) async fn handle_get_signatures_for_address(
             .map(|sig| SignatureInfo {
                 signature: sig.signature,
                 slot: sig.slot,
+                transaction_index: Some(sig.slot_idx),
                 err: sig.err,
                 memo: sig.memo,
                 block_time: sig.block_time,
@@ -1067,6 +1069,7 @@ pub(crate) async fn handle_get_signatures_for_address(
         .map(|sig: SignatureRecord| SignatureInfo {
             signature: sig.signature,
             slot: sig.slot,
+            transaction_index: Some(sig.slot_idx),
             err: sig.err,
             memo: sig.memo,
             block_time: sig.block_time,

--- a/crates/superbank-rpc/src/handlers/types.rs
+++ b/crates/superbank-rpc/src/handlers/types.rs
@@ -161,6 +161,12 @@ pub(crate) struct GetSignatureStatusesConfig {
 pub(crate) struct SignatureInfo {
     pub(crate) signature: String,
     pub(crate) slot: u64,
+    #[serde(
+        rename = "transactionIndex",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub(crate) transaction_index: Option<u32>,
     pub(crate) err: Option<Value>,
     pub(crate) memo: Option<String>,
     #[serde(rename = "blockTime")]

--- a/crates/superbank-rpc/src/tests/mod.rs
+++ b/crates/superbank-rpc/src/tests/mod.rs
@@ -5631,6 +5631,10 @@ async fn get_signatures_for_address_processed_served_from_head_cache() {
     );
     assert_eq!(arr[0].get("slot").and_then(|v| v.as_u64()), Some(11));
     assert_eq!(
+        arr[0].get("transactionIndex").and_then(|v| v.as_u64()),
+        Some(2)
+    );
+    assert_eq!(
         arr[0].get("confirmationStatus").and_then(|v| v.as_str()),
         Some("processed")
     );
@@ -5640,6 +5644,10 @@ async fn get_signatures_for_address_processed_served_from_head_cache() {
         Some(sig1_str.as_str())
     );
     assert_eq!(arr[1].get("slot").and_then(|v| v.as_u64()), Some(10));
+    assert_eq!(
+        arr[1].get("transactionIndex").and_then(|v| v.as_u64()),
+        Some(7)
+    );
     assert_eq!(
         arr[1].get("confirmationStatus").and_then(|v| v.as_str()),
         Some("processed")


### PR DESCRIPTION
This pull request adds support for including the transaction's zero-based index within a block (`transactionIndex`) in the results returned by the `getSignaturesForAddress` RPC method. This enhancement is reflected in both the API response and the documentation, and is covered by new tests to ensure correctness.

**API Enhancements:**

* The `SignatureInfo` struct now includes an optional `transactionIndex` field, which is serialized as `transactionIndex` in the API response when present.
* The `getSignaturesForAddress` handler populates the `transaction_index` field for all code paths where signature information is returned. [[1]](diffhunk://#diff-4d5a479df8cebee347e862952038fee1356425a880855277d917a6c12b7cc9efR740) [[2]](diffhunk://#diff-4d5a479df8cebee347e862952038fee1356425a880855277d917a6c12b7cc9efR901) [[3]](diffhunk://#diff-4d5a479df8cebee347e862952038fee1356425a880855277d917a6c12b7cc9efR1072)

**Documentation Updates:**

* The README for `superbank-rpc` has been updated to document the new `transactionIndex` field in the `getSignaturesForAddress` response.

**Testing:**

* Unit tests have been updated to validate that the `transactionIndex` field is present and has the expected value in the API response. [[1]](diffhunk://#diff-06ff0b330b8e38bb605d92cebe067005586b454768b3aa5024986cfad730ffaeR5633-R5636) [[2]](diffhunk://#diff-06ff0b330b8e38bb605d92cebe067005586b454768b3aa5024986cfad730ffaeR5647-R5650)