### PR TITLE
fix: make latest-slot and block-height refreshes cancellation-safe

### DIFF
--- a/crates/superbank-rpc/src/state.rs
+++ b/crates/superbank-rpc/src/state.rs
@@ -102,15 +102,72 @@ fn commitment_label(commitment: CommitmentLevel) -> &'static str {
 }
 
 enum CacheRefreshRole {
-    Leader(Arc<Notify>),
+    Leader(CacheRefreshLeader),
     Waiter(OwnedNotified),
+}
+
+// Owns one refresh notification, including while the backend or completion lock is pending.
+// Follow SignatureSlotCacheLeader's cancellation cleanup without retaining the whole cache.
+struct CacheRefreshLeader {
+    refresh_lock: Arc<Mutex<Option<Arc<Notify>>>>,
+    notify: Arc<Notify>,
+    armed: bool,
+}
+
+impl CacheRefreshLeader {
+    async fn finish(mut self) {
+        Self::remove_in_flight(&self.refresh_lock, &self.notify).await;
+        self.armed = false;
+    }
+
+    async fn remove_in_flight(refresh_lock: &Mutex<Option<Arc<Notify>>>, notify: &Arc<Notify>) {
+        let mut guard = refresh_lock.lock().await;
+        Self::remove_matching_entry(&mut guard, notify);
+        drop(guard);
+        notify.notify_waiters();
+    }
+
+    fn remove_matching_entry(guard: &mut Option<Arc<Notify>>, notify: &Arc<Notify>) {
+        if guard
+            .as_ref()
+            .is_some_and(|current| Arc::ptr_eq(current, notify))
+        {
+            *guard = None;
+        }
+    }
+}
+
+impl Drop for CacheRefreshLeader {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+
+        let refresh_lock = self.refresh_lock.clone();
+        let notify = self.notify.clone();
+        if let Ok(mut guard) = refresh_lock.try_lock() {
+            Self::remove_matching_entry(&mut guard, &notify);
+            drop(guard);
+            notify.notify_waiters();
+            return;
+        }
+
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                Self::remove_in_flight(&refresh_lock, &notify).await;
+            });
+        } else {
+            // Match the signature cache's runtime-teardown fallback for retained waiters.
+            notify.notify_waiters();
+        }
+    }
 }
 
 pub(crate) struct LatestSlotCache {
     ttl: Duration,
     pub(crate) value: AtomicU64,
     pub(crate) last_updated_ms: AtomicU64,
-    refresh_lock: Mutex<Option<Arc<Notify>>>,
+    refresh_lock: Arc<Mutex<Option<Arc<Notify>>>>,
 }
 
 impl LatestSlotCache {
@@ -119,7 +176,7 @@ impl LatestSlotCache {
             ttl,
             value: AtomicU64::new(0),
             last_updated_ms: AtomicU64::new(0),
-            refresh_lock: Mutex::new(None),
+            refresh_lock: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -150,12 +207,16 @@ impl LatestSlotCache {
                 } else {
                     let inflight = Arc::new(Notify::new());
                     *guard = Some(inflight.clone());
-                    CacheRefreshRole::Leader(inflight)
+                    CacheRefreshRole::Leader(CacheRefreshLeader {
+                        refresh_lock: self.refresh_lock.clone(),
+                        notify: inflight,
+                        armed: true,
+                    })
                 }
             };
 
             match role {
-                CacheRefreshRole::Leader(notify) => {
+                CacheRefreshRole::Leader(leader) => {
                     let fetch_result = async {
                         let slot_opt = clickhouse.get_latest_finalized_slot().await?;
                         slot_opt.ok_or_else(|| {
@@ -171,15 +232,11 @@ impl LatestSlotCache {
                             self.value.store(latest, Ordering::Relaxed);
                             self.last_updated_ms
                                 .store(current_time_millis(), Ordering::Relaxed);
-                            let mut guard = self.refresh_lock.lock().await;
-                            *guard = None;
-                            notify.notify_waiters();
+                            leader.finish().await;
                             return Ok(latest);
                         }
                         Err(err) => {
-                            let mut guard = self.refresh_lock.lock().await;
-                            *guard = None;
-                            notify.notify_waiters();
+                            leader.finish().await;
                             return Err(err);
                         }
                     }
@@ -199,7 +256,7 @@ pub(crate) struct LatestBlockHeightCache {
     // u64::MAX means cache seeded without a slot (tests/back-compat).
     pub(crate) slot: AtomicU64,
     pub(crate) last_updated_ms: AtomicU64,
-    refresh_lock: Mutex<Option<Arc<Notify>>>,
+    refresh_lock: Arc<Mutex<Option<Arc<Notify>>>>,
 }
 
 impl LatestBlockHeightCache {
@@ -212,7 +269,7 @@ impl LatestBlockHeightCache {
             value: AtomicU64::new(Self::NONE_SENTINEL),
             slot: AtomicU64::new(Self::UNKNOWN_SLOT_SENTINEL),
             last_updated_ms: AtomicU64::new(0),
-            refresh_lock: Mutex::new(None),
+            refresh_lock: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -252,43 +309,111 @@ impl LatestBlockHeightCache {
                 } else {
                     let inflight = Arc::new(Notify::new());
                     *guard = Some(inflight.clone());
-                    CacheRefreshRole::Leader(inflight)
+                    CacheRefreshRole::Leader(CacheRefreshLeader {
+                        refresh_lock: self.refresh_lock.clone(),
+                        notify: inflight,
+                        armed: true,
+                    })
                 }
             };
 
             match role {
-                CacheRefreshRole::Leader(notify) => {
+                CacheRefreshRole::Leader(leader) => {
                     let result = clickhouse.get_blockhash_height_by_slot(slot).await.map(
                         |(row_opt, timings)| {
                             (row_opt.and_then(|(_blockhash, height)| height), timings)
                         },
                     );
-                    match result {
+                    let height = match result {
                         Ok((height_opt, _timings)) => {
                             let stored = height_opt.unwrap_or(Self::NONE_SENTINEL);
                             self.value.store(stored, Ordering::Relaxed);
                             self.slot.store(slot, Ordering::Relaxed);
                             self.last_updated_ms
                                 .store(current_time_millis(), Ordering::Release);
+                            height_opt
                         }
                         Err(err) => {
-                            let mut guard = self.refresh_lock.lock().await;
-                            *guard = None;
-                            notify.notify_waiters();
+                            leader.finish().await;
                             return Err(err);
                         }
-                    }
+                    };
 
-                    let mut guard = self.refresh_lock.lock().await;
-                    *guard = None;
-                    notify.notify_waiters();
-                    let cached = self.value.load(Ordering::Relaxed);
-                    return Ok((cached != Self::NONE_SENTINEL).then_some(cached));
+                    leader.finish().await;
+                    return Ok(height);
                 }
                 CacheRefreshRole::Waiter(notified) => {
                     notified.await;
                 }
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn leader() -> CacheRefreshLeader {
+        let notify = Arc::new(Notify::new());
+        CacheRefreshLeader {
+            refresh_lock: Arc::new(Mutex::new(Some(notify.clone()))),
+            notify,
+            armed: true,
+        }
+    }
+
+    #[tokio::test]
+    async fn refresh_leader_drop_wakes_unpolled_waiter() {
+        let leader = leader();
+        let lock = leader.refresh_lock.clone();
+        let waiter = leader.notify.clone().notified_owned();
+        drop(leader);
+        assert!(lock.lock().await.is_none());
+        tokio::time::timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("notification before first poll must not be lost");
+    }
+
+    #[tokio::test]
+    async fn refresh_leader_cancelled_during_finish_cleans_up_contended_lock() {
+        let leader = leader();
+        let lock = leader.refresh_lock.clone();
+        let waiter = leader.notify.clone().notified_owned();
+        let locked = lock.lock().await;
+        let mut finish = Box::pin(leader.finish());
+        assert!(futures_util::poll!(finish.as_mut()).is_pending());
+        drop(finish);
+        drop(locked);
+        tokio::time::timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("contended cancellation must wake waiters");
+        assert!(lock.lock().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn refresh_leader_cleanup_preserves_replacement() {
+        for contended in [false, true] {
+            let leader = leader();
+            let lock = leader.refresh_lock.clone();
+            let waiter = leader.notify.clone().notified_owned();
+            let replacement = Arc::new(Notify::new());
+            let mut locked = lock.lock().await;
+            *locked = Some(replacement.clone());
+            if contended {
+                drop(leader);
+                drop(locked);
+            } else {
+                drop(locked);
+                drop(leader);
+            }
+            tokio::time::timeout(Duration::from_secs(1), waiter)
+                .await
+                .expect("old waiters must still wake");
+            assert!(Arc::ptr_eq(
+                lock.lock().await.as_ref().unwrap(),
+                &replacement
+            ));
         }
     }
 }

--- a/crates/superbank-rpc/src/tests/cache_refresh.rs
+++ b/crates/superbank-rpc/src/tests/cache_refresh.rs
@@ -1,0 +1,358 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+/*
+ * Copyright 2025-2026 Triton One Limited. All rights reserved.
+ */
+
+use super::*;
+use crate::processing::ProcessingError;
+use axum::{Router, routing::post};
+use std::sync::atomic::AtomicUsize;
+use tokio::sync::{mpsc, oneshot};
+
+const SLOT: u64 = 123;
+const HEIGHT: u64 = 100;
+const TEST_TIMEOUT: Duration = Duration::from_secs(3);
+
+type BackendReply = (StatusCode, Vec<u8>);
+
+struct PendingQuery {
+    sql: String,
+    reply: oneshot::Sender<BackendReply>,
+}
+
+struct Backend {
+    url: String,
+    requests: mpsc::UnboundedReceiver<PendingQuery>,
+    calls: Arc<AtomicUsize>,
+    server: tokio::task::JoinHandle<()>,
+}
+
+impl Backend {
+    async fn start() -> Self {
+        let (send, requests) = mpsc::unbounded_channel();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let handler_calls = calls.clone();
+        let app = Router::new().route(
+            "/",
+            post(move |body: Bytes| {
+                let send = send.clone();
+                let calls = handler_calls.clone();
+                async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    let (reply, response) = oneshot::channel();
+                    send.send(PendingQuery {
+                        sql: String::from_utf8(body.to_vec()).expect("SQL body"),
+                        reply,
+                    })
+                    .expect("test receiver");
+                    response
+                        .await
+                        .unwrap_or((StatusCode::SERVICE_UNAVAILABLE, Vec::new()))
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        Self {
+            url,
+            requests,
+            calls,
+            server,
+        }
+    }
+
+    async fn next(&mut self, kind: CacheKind) -> PendingQuery {
+        let query = tokio::time::timeout(TEST_TIMEOUT, self.requests.recv())
+            .await
+            .expect("backend query must start")
+            .expect("backend request");
+        assert!(
+            query.sql.contains(match kind {
+                CacheKind::Slot => "maxOrNull(slot)",
+                CacheKind::Height => "block_height",
+            }),
+            "unexpected query: {}",
+            query.sql
+        );
+        query
+    }
+
+    fn call_count(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+
+    fn state(&self) -> Arc<AppState> {
+        let mut state = test_state_with_clickhouse_url(&self.url);
+        let state_mut = Arc::get_mut(&mut state).unwrap();
+        state_mut.latest_slot_cache = LatestSlotCache::new(Duration::from_secs(60));
+        state_mut.latest_block_height_cache = LatestBlockHeightCache::new(Duration::from_secs(60));
+        // The fixture returns plain RowBinary; exercise real queries and decoding without
+        // duplicating ClickHouse's compression and schema-header protocols in the mock.
+        state_mut.clickhouse.client = state_mut
+            .clickhouse
+            .client
+            .clone()
+            .with_compression(clickhouse::Compression::None)
+            .with_validation(false);
+        state
+    }
+}
+
+impl Drop for Backend {
+    fn drop(&mut self) {
+        self.server.abort();
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum CacheKind {
+    Slot,
+    Height,
+}
+
+impl CacheKind {
+    async fn refresh(self, state: Arc<AppState>) -> Result<Option<u64>, ProcessingError> {
+        match self {
+            Self::Slot => state
+                .latest_slot_cache
+                .get_or_refresh(&state.clickhouse)
+                .await
+                .map(Some),
+            Self::Height => {
+                state
+                    .latest_block_height_cache
+                    .get_or_refresh(SLOT, &state.clickhouse)
+                    .await
+            }
+        }
+    }
+
+    fn value(self) -> u64 {
+        match self {
+            Self::Slot => SLOT,
+            Self::Height => HEIGHT,
+        }
+    }
+
+    fn method(self) -> &'static str {
+        match self {
+            Self::Slot => "getSlot",
+            Self::Height => "getBlockHeight",
+        }
+    }
+
+    fn respond(self, query: PendingQuery, value: Option<u64>) {
+        // FixedString(32) blockhash followed by Nullable(UInt64), or just Nullable(UInt64).
+        let mut bytes = if matches!(self, Self::Height) {
+            vec![7; 32]
+        } else {
+            Vec::new()
+        };
+        bytes.push(u8::from(value.is_none()));
+        if let Some(value) = value {
+            bytes.extend_from_slice(&value.to_le_bytes());
+        }
+        query
+            .reply
+            .send((StatusCode::OK, bytes))
+            .expect("live backend request");
+    }
+}
+
+async fn assert_recovered(
+    waiters: Vec<tokio::task::JoinHandle<Result<Option<u64>, ProcessingError>>>,
+    kind: CacheKind,
+) {
+    let results = tokio::time::timeout(TEST_TIMEOUT, futures_util::future::join_all(waiters))
+        .await
+        .expect("all cache callers must complete");
+    for result in results {
+        assert_eq!(
+            result.expect("caller task").expect("refresh success"),
+            Some(kind.value())
+        );
+    }
+}
+
+#[tokio::test]
+async fn cache_refresh_cancelled_leader_releases_existing_waiters() {
+    for kind in [CacheKind::Slot, CacheKind::Height] {
+        let mut backend = Backend::start().await;
+        let state = backend.state();
+        let leader = tokio::spawn(kind.refresh(state.clone()));
+        let pending = backend.next(kind).await;
+        let mut waiters = Vec::new();
+        for _ in 0..3 {
+            let mut waiter = Box::pin(kind.refresh(state.clone()));
+            assert!(futures_util::poll!(waiter.as_mut()).is_pending());
+            waiters.push(waiter);
+        }
+        assert_eq!(backend.call_count(), 1);
+        leader.abort();
+        assert!(leader.await.unwrap_err().is_cancelled());
+        drop(pending);
+        let mut tasks: Vec<_> = waiters.into_iter().map(tokio::spawn).collect();
+        tasks.push(tokio::spawn(kind.refresh(state.clone())));
+        kind.respond(backend.next(kind).await, Some(kind.value()));
+        assert_recovered(tasks, kind).await;
+        assert_eq!(kind.refresh(state).await.unwrap(), Some(kind.value()));
+        assert_eq!(
+            backend.call_count(),
+            2,
+            "one replacement leader for {kind:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn cache_refresh_singleflight_and_error_recovery() {
+    for kind in [CacheKind::Slot, CacheKind::Height] {
+        for fail in [false, true] {
+            let mut backend = Backend::start().await;
+            let state = backend.state();
+            let leader = tokio::spawn(kind.refresh(state.clone()));
+            let pending = backend.next(kind).await;
+            let mut waiters = Vec::new();
+            for _ in 0..3 {
+                let mut waiter = Box::pin(kind.refresh(state.clone()));
+                assert!(futures_util::poll!(waiter.as_mut()).is_pending());
+                waiters.push(waiter);
+            }
+            assert_eq!(backend.call_count(), 1);
+            if fail {
+                pending
+                    .reply
+                    .send((
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        b"backend unavailable".to_vec(),
+                    ))
+                    .unwrap();
+                assert!(
+                    tokio::time::timeout(TEST_TIMEOUT, leader)
+                        .await
+                        .unwrap()
+                        .unwrap()
+                        .is_err()
+                );
+            } else {
+                kind.respond(pending, Some(kind.value()));
+                assert_recovered(vec![leader], kind).await;
+            }
+            let tasks = waiters.into_iter().map(tokio::spawn).collect();
+            if fail {
+                kind.respond(backend.next(kind).await, Some(kind.value()));
+            }
+            assert_recovered(tasks, kind).await;
+            assert_eq!(kind.refresh(state).await.unwrap(), Some(kind.value()));
+            assert_eq!(backend.call_count(), if fail { 2 } else { 1 });
+        }
+    }
+}
+
+#[tokio::test]
+async fn cache_refresh_empty_slot_retries_and_missing_height_is_cached_by_slot() {
+    let mut backend = Backend::start().await;
+    let state = backend.state();
+    let leader = tokio::spawn(CacheKind::Slot.refresh(state.clone()));
+    CacheKind::Slot.respond(backend.next(CacheKind::Slot).await, None);
+    let error = tokio::time::timeout(TEST_TIMEOUT, leader)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("no finalized slot in ClickHouse")
+    );
+    let retry = tokio::spawn(CacheKind::Slot.refresh(state.clone()));
+    CacheKind::Slot.respond(backend.next(CacheKind::Slot).await, Some(SLOT));
+    assert_recovered(vec![retry], CacheKind::Slot).await;
+
+    let leader = tokio::spawn(CacheKind::Height.refresh(state.clone()));
+    CacheKind::Height.respond(backend.next(CacheKind::Height).await, None);
+    assert_eq!(
+        tokio::time::timeout(TEST_TIMEOUT, leader)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap(),
+        None
+    );
+    assert_eq!(
+        CacheKind::Height.refresh(state.clone()).await.unwrap(),
+        None
+    );
+    assert_eq!(backend.call_count(), 3);
+    let other_slot = tokio::spawn(async move {
+        state
+            .latest_block_height_cache
+            .get_or_refresh(SLOT + 1, &state.clickhouse)
+            .await
+    });
+    let query = backend.next(CacheKind::Height).await;
+    assert!(query.sql.contains("slot = 124"));
+    CacheKind::Height.respond(query, Some(HEIGHT));
+    assert_recovered(vec![other_slot], CacheKind::Height).await;
+    assert_eq!(backend.call_count(), 4);
+}
+
+#[tokio::test]
+async fn cache_refresh_recovers_after_batch_envelope_deadline() {
+    for kind in [CacheKind::Slot, CacheKind::Height] {
+        let mut backend = Backend::start().await;
+        let mut state = backend.state();
+        let state_mut = Arc::get_mut(&mut state).unwrap();
+        // Shorter than the client's 8s query budget: cancellation must come from the batch.
+        state_mut.rpc_request_timeout = Duration::from_millis(250);
+        if matches!(kind, CacheKind::Height) {
+            state_mut
+                .latest_slot_cache
+                .value
+                .store(SLOT, Ordering::Relaxed);
+            state_mut
+                .latest_slot_cache
+                .last_updated_ms
+                .store(current_time_millis(), Ordering::Relaxed);
+        }
+        let batch_state = state.clone();
+        let batch = tokio::spawn(async move {
+            handle_json_rpc_value(
+                batch_state,
+                &json!([
+                    {"jsonrpc": "2.0", "id": 1, "method": kind.method()},
+                    {"jsonrpc": "2.0", "id": 2, "method": kind.method()}
+                ]),
+            )
+            .await
+        });
+        let pending = backend.next(kind).await;
+        let mut external_waiter = Box::pin(kind.refresh(state.clone()));
+        assert!(futures_util::poll!(external_waiter.as_mut()).is_pending());
+        let response = tokio::time::timeout(TEST_TIMEOUT, batch)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let response = parse_json_value_response(response).await;
+        assert_eq!(response["id"], Value::Null);
+        assert_eq!(response["error"]["code"], -32000);
+        assert_eq!(response["error"]["message"], "Request timeout");
+        assert_eq!(response["error"]["data"]["timeoutMs"], 250);
+        drop(pending);
+        let waiter = tokio::spawn(external_waiter);
+        kind.respond(backend.next(kind).await, Some(kind.value()));
+        assert_recovered(vec![waiter], kind).await;
+        let response = handle_json_rpc_value(
+            state,
+            &json!({
+                "jsonrpc": "2.0", "id": 3, "method": kind.method()
+            }),
+        )
+        .await;
+        let response = parse_json_value_response(response).await;
+        assert_eq!(response["result"], kind.value());
+        assert_eq!(backend.call_count(), 2);
+    }
+}

--- a/crates/superbank-rpc/src/tests/mod.rs
+++ b/crates/superbank-rpc/src/tests/mod.rs
@@ -3,6 +3,8 @@
  * Copyright 2025-2026 Triton One Limited. All rights reserved.
  */
 
+mod cache_refresh;
+
 use crate::solana_sdk;
 use crate::solana_sdk::{
     hash::Hash,


### PR DESCRIPTION
Cancelling a latest-slot or block-height refresh previously left its in-flight marker installed, making subsequent callers wait indefinitely. A batch envelope deadline could therefore turn a transient backend delay into a persistent availability failure.

Add a shared refresh-leader guard following the existing signature-cache pattern. Cancellation removes only the leader's own marker and wakes waiters, with asynchronous cleanup when the lock is contended. Block-height leaders return their fetched value directly after releasing ownership. Cache TTLs, public interfaces, SQL, configuration, and dependencies are unchanged.

Fixes [BLO-575](https://linear.app/triton-one/issue/BLO-575/make-latest-slot-and-block-height-cache-refreshes-cancellation-safe).

## Validation

Updated against `main` at `7415861`. Both test modules are retained; the cache regression fixture now supports ClickHouse cancellation preflight and the latest-slot UInt64/empty-result query format. The production refresh guard is unchanged by the merge.

All checks passed after resolving conflicts:

```bash
cargo fmt --all -- --check
cargo clippy --workspace --all-targets --locked -- -D warnings
cargo clippy -p superbank-rpc --all-targets --all-features --locked -- -D warnings
cargo test --workspace --locked
cargo test -p superbank-rpc --all-features --locked
```

Default RPC: 447 passed, 3 ignored. All-feature RPC: 584 passed, 7 ignored. All other workspace targets passed. Seven cache regression tests cover cancellation with existing waiters and new callers, singleflight, backend errors, missing values, slot matching, real batch envelope deadlines, contended completion cleanup, and replacement-marker protection. The earlier environment-dependent parameter-filter failure no longer occurs with the merged code.

### Earlier k6 validation

Both k6 scenarios passed against the original PR revision and local ClickHouse, using k6 v1.0.0:

```bash
k6 run tests/k6/scenarios/basic/superbank-rpc-get-signatures.js -e RPC_URL=http://127.0.0.1:18899 -e ADDRESS_FILE=./tests/k6/data/pools/addresses.txt -e VUS=1 -e DURATION=10s
k6 run tests/k6/scenarios/validation/superbank-rpc-validate-batch.js -e RPC_URL=http://127.0.0.1:18899
```

Basic: 3,075 successful requests, zero HTTP/RPC/timeout errors, p95 3.51 ms. Batch: 27/27 checks passed with zero HTTP failures. These are local smoke results.

