### PR TITLE
fix(rpc): reject incomplete getBlock payloads

### DIFF
--- a/crates/superbank-rpc/README.md
+++ b/crates/superbank-rpc/README.md
@@ -25,6 +25,11 @@ writer that matches the same schemas).
 - `getTransactionsForAddress` (custom)
 
 Notes:
+- `getBlock` requires the returned transaction count to match block metadata for `full`,
+  `accounts`, and `signatures` responses. Incomplete cache data falls back to storage;
+  inconsistent source data returns internal error (`-32603`) without populating the serialized
+  response cache. A subsequent request can succeed once storage is repaired. Metadata-only
+  (`transactionDetails: "none"`) requests and valid empty blocks remain supported.
 - JSON-RPC batch envelopes are supported. Batch execution is bounded by
   `RPC_MAX_BATCH_SIZE` and `RPC_BATCH_CONCURRENCY_LIMIT`.
 - Requests without an `id` are normalized to `id: null` and still return
@@ -646,3 +651,20 @@ Head cache activation metric:
   - `x_rpc_node="none"`: head cache is disabled.
   - `x_rpc_node="unknown"`: head cache is enabled, but upstream metadata did not include `x-rpc-node`.
   - `x_rpc_node="<value>"`: concrete upstream node identifier reported by DragonsMouth metadata.
+
+
+## getBlock completeness regression
+
+The regular Rust tests cover incomplete payload rejection and response-cache recovery.
+To also exercise real ClickHouse reads, use a local ClickHouse instance with the default
+user and permission to create databases:
+
+```bash
+BLO576_CLICKHOUSE_TEST_URL=http://127.0.0.1:8123 \
+cargo test -p superbank-rpc --all-features --locked \
+  get_block_clickhouse_partial_payload_repair -- --ignored
+```
+
+This test creates uniquely named `blo576_*` databases and drops them on success. A failed
+run can leave those test databases for inspection. With optional cache features compiled,
+it also exercises incomplete head-cache and disk-cache fallback, including disk slot poisoning.

--- a/crates/superbank-rpc/src/handlers/blocks.rs
+++ b/crates/superbank-rpc/src/handlers/blocks.rs
@@ -111,8 +111,23 @@ struct BlockResponseOptions {
     timings: Option<QueryTimings>,
 }
 
-fn block_payload_transaction_count(payload: &StoredBlockPayload) -> Option<usize> {
-    payload.observed_transaction_count()
+/// Metadata-only requests do not fetch transactions and cannot validate their count.
+fn block_payload_has_consistent_transaction_count(payload: &StoredBlockPayload) -> bool {
+    let Some(observed) = payload.observed_transaction_count() else {
+        return true;
+    };
+    let metadata = payload.metadata();
+    if metadata.executed_transaction_count == observed as u64 {
+        return true;
+    }
+    warn!(
+        slot = metadata.slot,
+        expected = metadata.executed_transaction_count,
+        observed,
+        entry_count = metadata.entry_count,
+        "Block transaction count mismatch"
+    );
+    false
 }
 
 fn unsupported_transaction_version_message(version: u8) -> String {
@@ -1353,16 +1368,14 @@ async fn respond_with_hydrated_block(
             "Block metadata slot mismatch"
         );
     }
-    if let Some(observed) = block_payload_transaction_count(&payload)
-        && payload.metadata().executed_transaction_count != observed as u64
-    {
-        warn!(
-            slot,
-            expected = payload.metadata().executed_transaction_count,
-            observed = observed,
-            entry_count = payload.metadata().entry_count,
-            "Block transaction count mismatch"
-        );
+    // Reject before hydration or cache insertion, including when caching is disabled.
+    if !block_payload_has_consistent_transaction_count(&payload) {
+        metrics::backend_error("get_block_transaction_count");
+        let mut resp = json_rpc_internal_error_response(id);
+        if let Some(timings) = timings.as_ref() {
+            add_downstream_header(&mut resp, timings);
+        }
+        return Ok(resp);
     }
 
     let attach_timings = |resp: &mut Response| {
@@ -1570,32 +1583,22 @@ pub(crate) async fn handle_get_block(
                 );
             }
 
-            if let Some(observed) = block_payload_transaction_count(&payload)
-                && payload.metadata().executed_transaction_count != observed as u64
-            {
-                warn!(
+            if block_payload_has_consistent_transaction_count(&payload) {
+                route.source_head_cache();
+                return respond_with_hydrated_block(
+                    state.as_ref(),
+                    id,
+                    &mut route,
                     slot,
-                    expected = payload.metadata().executed_transaction_count,
-                    observed = observed,
-                    entry_count = payload.metadata().entry_count,
-                    "Head-cache block transaction count mismatch"
-                );
+                    payload,
+                    fetch_plan,
+                    BlockResponseOptions {
+                        cache_key: response_cache_key.clone(),
+                        timings: None,
+                    },
+                )
+                .await;
             }
-
-            route.source_head_cache();
-            return respond_with_hydrated_block(
-                state.as_ref(),
-                id,
-                &mut route,
-                slot,
-                payload,
-                fetch_plan,
-                BlockResponseOptions {
-                    cache_key: response_cache_key.clone(),
-                    timings: None,
-                },
-            )
-            .await;
         }
     }
 
@@ -2673,6 +2676,222 @@ mod tests {
     use solana_rpc_client_api::custom_error::JSON_RPC_SERVER_ERROR_BLOCK_NOT_AVAILABLE;
     use solana_rpc_client_api::custom_error::JSON_RPC_SERVER_ERROR_EPOCH_REWARDS_PERIOD_ACTIVE;
     use solana_rpc_client_api::custom_error::JSON_RPC_SERVER_ERROR_LONG_TERM_STORAGE_SLOT_SKIPPED;
+
+    fn count_test_payload(
+        details: solana_transaction_status::TransactionDetails,
+        expected: u64,
+        observed: usize,
+    ) -> crate::clickhouse::StoredBlockPayload {
+        use crate::clickhouse::{StoredAccountsTransactionRecord, StoredBlockPayload};
+        use solana_transaction_status::TransactionDetails;
+
+        let mut block = crate::tests::projection_equivalence_block_record();
+        block.metadata.executed_transaction_count = expected;
+        block.transactions.truncate(observed);
+        assert_eq!(block.transactions.len(), observed);
+        match details {
+            TransactionDetails::None => StoredBlockPayload::Metadata(block.metadata),
+            TransactionDetails::Full => StoredBlockPayload::Full(block),
+            TransactionDetails::Accounts => StoredBlockPayload::Accounts {
+                metadata: block.metadata,
+                transactions: block
+                    .transactions
+                    .into_iter()
+                    .map(StoredAccountsTransactionRecord::from)
+                    .collect(),
+            },
+            TransactionDetails::Signatures => StoredBlockPayload::Signatures {
+                metadata: block.metadata,
+                signatures: block
+                    .transactions
+                    .into_iter()
+                    .map(|tx| bs58::encode(tx.signature).into_string())
+                    .collect(),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn get_block_rejects_count_mismatch_before_caching_and_recovers_after_repair() {
+        use super::*;
+        use crate::block_response_cache::BlockResponseCache;
+
+        for details in [
+            TransactionDetails::Full,
+            TransactionDetails::Accounts,
+            TransactionDetails::Signatures,
+        ] {
+            for cache_bytes in [0, 1024 * 1024] {
+                let mut state = crate::tests::test_state();
+                Arc::get_mut(&mut state).unwrap().block_response_cache =
+                    BlockResponseCache::new(cache_bytes);
+                let plan = GetBlockFetchPlan::new(&RpcBlockConfig {
+                    transaction_details: Some(details),
+                    max_supported_transaction_version: Some(1),
+                    ..Default::default()
+                });
+                let key = plan.cache_key(10, CommitmentLevel::Finalized);
+                // Reject missing, empty, and excess transaction projections.
+                for (expected, observed) in [(2, 1), (2, 0), (1, 2), (0, 1)] {
+                    let response = respond_with_hydrated_block(
+                        &state,
+                        json!("partial"),
+                        &mut RouteMetric::for_state("getBlock", &state),
+                        10,
+                        count_test_payload(details, expected, observed),
+                        plan,
+                        BlockResponseOptions {
+                            cache_key: Some(key.clone()),
+                            timings: Some(QueryTimings {
+                                elapsed_ms: 1,
+                                received_bytes: 2,
+                                decoded_bytes: 3,
+                                rows_read: Some(4),
+                                rows_read_unknown: false,
+                                rows_returned: 2,
+                            }),
+                        },
+                    )
+                    .await
+                    .unwrap();
+                    assert_eq!(
+                        crate::util::extract_downstream_timings(&response)
+                            .unwrap()
+                            .rows_returned,
+                        2
+                    );
+                    let body: Value = serde_json::from_slice(
+                        &axum::body::to_bytes(response.into_body(), usize::MAX)
+                            .await
+                            .unwrap(),
+                    )
+                    .unwrap();
+                    assert_eq!(body["id"], "partial");
+                    assert_eq!(
+                        body["error"]["code"], -32603,
+                        "{details:?}, cache={cache_bytes}"
+                    );
+                    assert!(body.get("result").is_none());
+                    assert!(state.block_response_cache.get(&key).await.is_none());
+                }
+                let response = respond_with_hydrated_block(
+                    &state,
+                    json!("repaired"),
+                    &mut RouteMetric::for_state("getBlock", &state),
+                    10,
+                    count_test_payload(details, 2, 2),
+                    plan,
+                    BlockResponseOptions {
+                        cache_key: Some(key.clone()),
+                        timings: None,
+                    },
+                )
+                .await
+                .unwrap();
+                let body: Value = serde_json::from_slice(
+                    &axum::body::to_bytes(response.into_body(), usize::MAX)
+                        .await
+                        .unwrap(),
+                )
+                .unwrap();
+                let field = if details == TransactionDetails::Signatures {
+                    "signatures"
+                } else {
+                    "transactions"
+                };
+                assert_eq!(body["id"], "repaired");
+                assert!(body.get("error").is_none(), "{body}");
+                assert_eq!(body["result"][field].as_array().unwrap().len(), 2);
+                assert_eq!(
+                    state.block_response_cache.get(&key).await.is_some(),
+                    cache_bytes > 0
+                );
+                if cache_bytes > 0 {
+                    // Exercise the handler's early cache hit, with no reachable storage needed.
+                    let cached = handle_get_block(
+                        state.clone(),
+                        json!("cached"),
+                        Some(vec![
+                            json!(10),
+                            json!({
+                                "transactionDetails": details, "maxSupportedTransactionVersion": 1
+                            }),
+                        ]),
+                    )
+                    .await
+                    .unwrap();
+                    let cached: Value = serde_json::from_slice(
+                        &axum::body::to_bytes(cached.into_body(), usize::MAX)
+                            .await
+                            .unwrap(),
+                    )
+                    .unwrap();
+                    assert_eq!(cached["id"], "cached");
+                    assert_eq!(cached["result"], body["result"]);
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn get_block_count_validation_preserves_empty_and_metadata_only_responses() {
+        use super::*;
+        use crate::block_response_cache::BlockResponseCache;
+
+        for (details, expected) in [
+            (TransactionDetails::Full, 0),
+            (TransactionDetails::Accounts, 0),
+            (TransactionDetails::Signatures, 0),
+            (TransactionDetails::None, 0),
+            (TransactionDetails::None, 2),
+        ] {
+            for cache_bytes in [0, 1024 * 1024] {
+                let mut state = crate::tests::test_state();
+                Arc::get_mut(&mut state).unwrap().block_response_cache =
+                    BlockResponseCache::new(cache_bytes);
+                let plan = GetBlockFetchPlan::new(&RpcBlockConfig {
+                    transaction_details: Some(details),
+                    ..Default::default()
+                });
+                let key = plan.cache_key(10, CommitmentLevel::Finalized);
+                let response = respond_with_hydrated_block(
+                    &state,
+                    json!(1),
+                    &mut RouteMetric::for_state("getBlock", &state),
+                    10,
+                    count_test_payload(details, expected, 0),
+                    plan,
+                    BlockResponseOptions {
+                        cache_key: Some(key.clone()),
+                        timings: None,
+                    },
+                )
+                .await
+                .unwrap();
+                let body: Value = serde_json::from_slice(
+                    &axum::body::to_bytes(response.into_body(), usize::MAX)
+                        .await
+                        .unwrap(),
+                )
+                .unwrap();
+                assert!(body.get("error").is_none(), "{body}");
+                match details {
+                    TransactionDetails::None => {
+                        assert!(body["result"].get("transactions").is_none());
+                        assert!(body["result"].get("signatures").is_none());
+                    }
+                    TransactionDetails::Signatures => {
+                        assert_eq!(body["result"]["signatures"], json!([]))
+                    }
+                    _ => assert_eq!(body["result"]["transactions"], json!([])),
+                }
+                assert_eq!(
+                    state.block_response_cache.get(&key).await.is_some(),
+                    cache_bytes > 0
+                );
+            }
+        }
+    }
 
     #[test]
     fn merge_sorted_block_slots_handles_empty_inputs() {

--- a/crates/superbank-rpc/src/tests/mod.rs
+++ b/crates/superbank-rpc/src/tests/mod.rs
@@ -179,7 +179,7 @@ fn test_state_with_token_owner_activity_available(available: bool) -> Arc<AppSta
     })
 }
 
-fn test_state() -> Arc<AppState> {
+pub(crate) fn test_state() -> Arc<AppState> {
     test_state_with_token_owner_activity_available(true)
 }
 
@@ -710,7 +710,7 @@ fn head_cache_metadata(
     metadata
 }
 
-fn projection_equivalence_block_record() -> StoredBlockRecord {
+pub(crate) fn projection_equivalence_block_record() -> StoredBlockRecord {
     let mut block = base_block_record(10);
     block.metadata.block_time = Some(1_700_000_000);
     block.metadata.block_height = Some(123);
@@ -7090,4 +7090,196 @@ async fn handle_json_rpc_batch_response_aggregates_clickhouse_metrics_header() {
     let value: Value = serde_json::from_slice(&body_bytes).expect("valid JSON body");
     let items = value.as_array().expect("batch response array");
     assert_eq!(items.len(), 2);
+}
+
+/// Uses a dedicated database on an explicitly supplied local ClickHouse instance.
+#[tokio::test]
+#[ignore = "requires BLO576_CLICKHOUSE_TEST_URL pointing to local ClickHouse"]
+async fn get_block_clickhouse_partial_payload_repair() {
+    let url = std::env::var("BLO576_CLICKHOUSE_TEST_URL").expect("set BLO576_CLICKHOUSE_TEST_URL");
+    let http = reqwest::Client::new();
+    let database = format!("blo576_{}_{}", std::process::id(), current_time_millis());
+    async fn execute(http: &reqwest::Client, url: &str, sql: String) {
+        let response = http
+            .post(url)
+            .body(sql)
+            .send()
+            .await
+            .expect("ClickHouse request");
+        let status = response.status();
+        let body = response.text().await.unwrap();
+        assert!(status.is_success(), "ClickHouse {status}: {body}");
+    }
+    execute(&http, &url, format!("CREATE DATABASE {database}")).await;
+    for ddl in [
+        include_str!("../../../../ddl/local/transactions.sql"),
+        include_str!("../../../../ddl/local/blocks_metadata.sql"),
+        include_str!("../../../../ddl/local/signatures.sql"),
+        // Use the initial view definition: the migration's projection of the materialized
+        // addr_bucket column cannot be cloned by the disk cache on ClickHouse 26.8.
+        include_str!("../../../../ddl/local/gsfa.sql")
+            .split_once("-- Update the query")
+            .expect("GSFA migration marker")
+            .0,
+    ] {
+        for statement in ddl
+            .replace("default.", &format!("{database}."))
+            .split(";\n")
+        {
+            if !statement.trim().is_empty() {
+                execute(&http, &url, statement.to_string()).await;
+            }
+        }
+    }
+    let mut slot = 600;
+    for details in ["full", "accounts", "signatures"] {
+        for cache_bytes in [0, 1024 * 1024] {
+            slot += 1;
+            execute(&http, &url, format!(
+                "INSERT INTO {database}.blocks_metadata (slot, parent_slot, blockhash, parent_blockhash, executed_transaction_count) VALUES ({slot}, {}, repeat('b', 32), repeat('p', 32), 2)", slot - 1
+            )).await;
+            let insert_transaction = |index| {
+                format!(
+                    "INSERT INTO {database}.transactions (signature, slot, slot_idx, tx_signatures, tx_num_required_signatures, tx_account_keys, tx_recent_blockhash, meta_status_ok, meta_pre_balances, meta_post_balances) VALUES (repeat('{}', 64), {slot}, {index}, [repeat('{}', 64)], 1, [repeat('k', 32)], repeat('h', 32), 1, [10], [10])",
+                    if index == 0 { 'a' } else { 'z' },
+                    if index == 0 { 'a' } else { 'z' }
+                )
+            };
+            execute(&http, &url, insert_transaction(0)).await;
+            let mut state = test_state_with_clickhouse_url(&url);
+            let mutable = Arc::get_mut(&mut state).unwrap();
+            mutable.clickhouse.transaction_table = format!("{database}.transactions");
+            mutable.clickhouse.blocks_metadata_table = format!("{database}.blocks_metadata");
+            mutable.block_response_cache = BlockResponseCache::new(cache_bytes);
+            mutable.emit_http_errors = cache_bytes > 0;
+            #[cfg(feature = "grpc-head-cache")]
+            {
+                let head = Arc::new(HeadCache::new(32, TEST_MAX_LIMIT as usize));
+                let mut metadata = base_block_record(slot).metadata;
+                metadata.executed_transaction_count = 2;
+                head.note_block_metadata(metadata);
+                let signature = Signature::new_unique();
+                let address = Pubkey::new_unique();
+                let mut record = base_transaction_record();
+                record.slot = slot;
+                record.signature = *signature.as_array();
+                head.insert_for_tests(signature, record, 0, &[address], CommitmentLevel::Finalized);
+                head.note_slot_commitment(slot, CommitmentLevel::Finalized);
+                mutable.head_cache = Some(head);
+            }
+            #[cfg(feature = "disk-cache")]
+            let disk = {
+                use crate::disk_cache::{DiskCache, DiskCacheConfig, SlotStatus};
+                mutable.clickhouse.use_table_names(
+                    crate::clickhouse::ClickHouseTableNames::in_database(&database),
+                );
+                mutable
+                    .clickhouse
+                    .set_token_owner_activity_available_for_tests(false);
+                let cache_database = format!("{database}_cache_{slot}");
+                let disk = Arc::new(
+                    DiskCache::open(
+                        DiskCacheConfig {
+                            url: url.clone(),
+                            database: cache_database.clone(),
+                            username: "default".to_string(),
+                            password: String::new(),
+                            required: false,
+                            retain_slots: 1000,
+                            max_bytes: 0,
+                            partition_slots: 100,
+                            query_timeout: Duration::from_secs(10),
+                            schema_check_interval: Duration::from_secs(60),
+                            memory_blocks_metadata: false,
+                            memory_retain_slots: None,
+                            memory_max_bytes: None,
+                            block_index: None,
+                        },
+                        &mutable.clickhouse,
+                    )
+                    .await
+                    .unwrap(),
+                );
+                for table in ["transactions", "blocks_metadata"] {
+                    execute(&http, &url, format!("INSERT INTO {cache_database}.{table} SELECT * FROM {database}.{table} WHERE slot = {slot}")).await;
+                }
+                // Simulate a previously covered cache slot whose transaction data is incomplete.
+                disk.publish_range_coverage(vec![(slot, SlotStatus::Covered { tx_count: 2 })])
+                    .await
+                    .unwrap();
+                mutable.disk_cache = Some(Arc::new(tokio::sync::OnceCell::new_with(Some(
+                    disk.clone(),
+                ))));
+                disk
+            };
+
+            let params = vec![
+                json!(slot),
+                json!({ "transactionDetails": details, "maxSupportedTransactionVersion": 1 }),
+            ];
+            let partial = handle_json_rpc_value(
+                state.clone(),
+                &json!({
+                    "jsonrpc": "2.0", "id": 1, "method": "getBlock", "params": params.clone()
+                }),
+            )
+            .await;
+            assert_eq!(
+                partial.status(),
+                if cache_bytes > 0 {
+                    StatusCode::SERVICE_UNAVAILABLE
+                } else {
+                    StatusCode::OK
+                }
+            );
+            assert!(partial.headers().contains_key("X-Superbank-Metrics"));
+            let partial = parse_json_rpc_response(partial).await;
+            assert_eq!(partial.error.expect("partial must fail").code, -32603);
+            assert!(partial.result.is_none());
+            assert_eq!(state.block_response_cache.entry_count(), 0);
+            #[cfg(feature = "disk-cache")]
+            assert!(
+                !disk.covers_slot(slot),
+                "incomplete cache slot must be poisoned"
+            );
+            execute(&http, &url, insert_transaction(1)).await;
+            #[cfg(feature = "disk-cache")]
+            disk.publish_range_coverage(vec![(
+                slot,
+                crate::disk_cache::SlotStatus::Covered { tx_count: 2 },
+            )])
+            .await
+            .unwrap();
+
+            for id in [2, 3] {
+                let repaired = handle_get_block(state.clone(), json!(id), Some(params.clone()))
+                    .await
+                    .unwrap();
+                let repaired = parse_json_rpc_response(repaired).await;
+                assert!(repaired.error.is_none(), "{:?}", repaired.error);
+                assert_eq!(repaired.id, json!(id));
+                let field = if details == "signatures" {
+                    "signatures"
+                } else {
+                    "transactions"
+                };
+                assert_eq!(repaired.result.unwrap()[field].as_array().unwrap().len(), 2);
+            }
+            assert_eq!(
+                state.block_response_cache.entry_count(),
+                u64::from(cache_bytes > 0)
+            );
+            #[cfg(feature = "disk-cache")]
+            {
+                assert!(!disk.covers_slot(slot));
+                execute(
+                    &http,
+                    &url,
+                    format!("DROP DATABASE {database}_cache_{slot}"),
+                )
+                .await;
+            }
+        }
+    }
+    execute(&http, &url, format!("DROP DATABASE {database}")).await;
 }


### PR DESCRIPTION
When block metadata reports two transactions but storage returns only one, `getBlock` currently returns success and can retain that incomplete finalized response in the serialized cache. Reject transaction-count mismatches for `full`, `accounts`, and `signatures` before hydration, serialization, or cache insertion, returning the existing internal error (`-32603`). A subsequent request succeeds after storage is repaired.

Preserve head/disk cache fallback, valid empty blocks, metadata-only responses, request IDs, downstream timings, and existing HTTP error mapping. Add regression tests with response caching enabled and disabled, plus a documented opt-in ClickHouse integration test covering partial storage, repair, cache fallback, and disk slot poisoning. Runtime configuration and schemas are unchanged.

Fixes [BLO-576](https://linear.app/triton-one/issue/BLO-576/reject-incomplete-getblock-payloads-before-returning-or-caching-them).

## Validation

- `cargo fmt --all -- --check` and `git diff --check` passed.
- `cargo clippy --workspace --all-targets --locked -- -D warnings` passed.
- `cargo clippy -p superbank-rpc --all-targets --all-features --locked -- -D warnings` passed.
- `cargo test -p superbank-rpc --locked get_block -- --include-ignored`: 37 passed, including real ClickHouse repair, using `BLO576_CLICKHOUSE_TEST_URL` for the isolated instance.
- The same getBlock test selection with `--all-features`: 61 passed, including head/disk fallback and disk slot poisoning.
- Basic k6 signatures smoke: 905 iterations passed. Existing getBlock validation scenario against an explicit local metadata-only reference fixture: 4,350 iterations passed. Both used one VU for five seconds; transaction-bearing repair is covered by the Rust/ClickHouse integration tests.

## Validation limitations

`cargo test --workspace --locked` and `cargo test -p superbank-rpc --all-features --locked` both encounter the unchanged `tests::parameter_filter_requires_complete_param_equality` failure: that test expects a backend error, but the pre-existing localhost ClickHouse service allows the request to succeed. RPC suites otherwise passed 385/default and 491/all-feature tests; remaining workspace packages were run separately and passed.

The disk integration fixture uses the initial repository GSFA view definition. The later GSFA migration projects the materialized `addr_bucket` column, which the disk-cache schema cloning path cannot recreate on the installed ClickHouse 26.8. This separate schema issue is outside this fix.

Builds used `RUSTC_WRAPPER=` and `CARGO_BUILD_JOBS=2` after an initial sccache build was killed.