### PR TITLE
fix(disk-cache): bound key lookup partition fanout

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Solana-compatible JSON-RPC endpoints backed by that data.
 
 > [!NOTE]
 > Superbank is licensed under **AGPL-3.0-only** (see `LICENSE`).
-> `superbank-rpc` supports an optional in-memory gRPC "head cache" (`--features grpc-head-cache`) to reduce perceived ingestion lag and (optionally) expose `processed` commitment for a subset of methods. It also supports an independent localhost ClickHouse forward cache (`--features disk-cache`) for recent finalized slots. See `crates/superbank-rpc/README.md` for details.
+> `superbank-rpc` supports an optional in-memory gRPC "head cache" (`--features grpc-head-cache`) to reduce perceived ingestion lag and (optionally) expose `processed` commitment for a subset of methods. It also supports an independent localhost ClickHouse forward cache (`--features disk-cache`) for recent finalized slots, with bounded in-process signature/address partition routing (`DISK_CACHE_KEY_INDEX_MAX_MEMORY_BYTES`, default 4 GiB). See `crates/superbank-rpc/README.md` for details.
 
 ## Features
 

--- a/crates/superbank-rpc/README.md
+++ b/crates/superbank-rpc/README.md
@@ -304,6 +304,41 @@ The configured cache database is exclusively owned by this feature. A nonempty d
 
 By default, local initialization failures do not block RPC startup. Reads continue against the source cluster while a background supervisor retries local initialization. `DISK_CACHE_REQUIRED=true` makes initialization a startup requirement and makes `/health` return HTTP 503 when the local cache is not ready or cannot answer a health query.
 
+Signature and address reads use an in-process Bloom membership index to exclude unrelated slot
+partitions before querying ClickHouse. This preserves whole-partition eviction without making
+key lookups search every retained partition. Signature status batches, pagination-bound signature
+lookups, regular/hot address history, and token-owner history use the same routing mechanism.
+Candidate partitions are queried in result order, one at a time, until the answer is complete or
+the shared `DISK_CACHE_QUERY_TIMEOUT_MS` deadline expires. Admission waiting and transaction
+hydration count against that deadline. Incomplete address pages use source fallback.
+
+The routing index rebuilds asynchronously from actual materialized-table keys, newest complete
+historical partitions first. The actively filled partition, unbuilt filters, and invalidated
+filters remain query candidates. Fill/repair, poisoning, eviction, and schema rebuild invalidate
+filters before changing data. A stale build cannot publish, and a read whose exclusions became
+invalid falls back. This assumes the owned cache has no independent external writers.
+
+The memory budget reserves 64 MiB for buffers/metadata and allocates the remaining space across
+the retention window. Filters target roughly 1% false positives; limited memory reduces
+selectivity rather than correctness. A single builder uses one ClickHouse execution thread and a
+separate 64 MiB server query-memory limit. Initialization and index failures preserve source
+fallback; a cold index can have higher latency than a fully built index.
+
+Cache format **5** preserves the source's portable MergeTree index/mark settings and reverse
+sort directions from canonical DDL. Forwarding views project only insertable columns so the
+cache recomputes materialized bucket columns. Upgrading uses
+the existing ownership-checked cache rebuild and temporarily refills through source fallback.
+The separately owned full-history block index is preserved. Before deployment, run the full-size
+key-routing workload described in `tests/k6/README.md`; small-fixture tests do not establish its
+latency targets.
+
+The `superbank_disk_cache_reads_total` outcomes distinguish misses, query errors, and timeouts.
+`superbank_disk_cache_key_seconds` records complete attempts, admission waits, and index builds;
+`superbank_disk_cache_key_index_bytes` reports reserved index memory, and
+`superbank_disk_cache_key_index_partitions` / `superbank_disk_cache_key_index_unknown_partitions`
+show index coverage. Partition probe/skip counters use `operation="key_partition"` with bounded
+labels; no keys or partition IDs are metric labels.
+
 Query-facing tables use `ReplacingMergeTree` by default. `blocks_metadata` can opt into the ClickHouse `Memory` engine with `DISK_CACHE_MEMORY_TABLES=blocks_metadata`. This mode requires explicit row and byte caps. Memory-engine coverage is reset after a local ClickHouse restart because those rows are not durable. No other query-facing table is accepted in the Memory allowlist in this release.
 
 Run example:
@@ -330,6 +365,9 @@ Configuration:
 | `--disk-cache-max-bytes` | `DISK_CACHE_MAX_BYTES` | `0` | Enforced active-part byte budget for the primary cache database; `0` means unlimited. May purge the newest partition and mark the cache unready when one partition cannot fit. |
 | `--disk-cache-partition-slots` | `DISK_CACHE_PARTITION_SLOTS` | automatic | Width of local slot partitions. The automatic value targets at most 128 active partitions. |
 | `--disk-cache-query-timeout-ms` | `DISK_CACHE_QUERY_TIMEOUT_MS` | `2000` | Timeout for one local cache read. |
+| `--disk-cache-key-index-max-memory-bytes` | `DISK_CACHE_KEY_INDEX_MAX_MEMORY_BYTES` | `4294967296` | In-process partition membership budget, including builder buffers and metadata; minimum 64 MiB. Separate from ClickHouse and the historical block index. |
+| `--disk-cache-query-concurrency` | `DISK_CACHE_QUERY_CONCURRENCY` | `8` | Concurrent local interactive queries, range 1–64. |
+| `--disk-cache-query-max-threads` | `DISK_CACHE_QUERY_MAX_THREADS` | `2` | ClickHouse execution threads per local interactive query, range 1–16. |
 | `--disk-cache-schema-check-interval-secs` | `DISK_CACHE_SCHEMA_CHECK_INTERVAL_SECS` | `300` | Source schema fingerprint check interval. |
 | `--disk-cache-memory-tables` | `DISK_CACHE_MEMORY_TABLES` | empty | Comma-separated Memory-engine allowlist. Only `blocks_metadata` is accepted. |
 | `--disk-cache-memory-retain-slots` | `DISK_CACHE_MEMORY_RETAIN_SLOTS` | — | Required row cap when `blocks_metadata` uses Memory; must not exceed the main retention window. |

--- a/crates/superbank-rpc/README.md
+++ b/crates/superbank-rpc/README.md
@@ -327,10 +327,19 @@ fallback; a cold index can have higher latency than a fully built index.
 Cache format **5** preserves the source's portable MergeTree index/mark settings and reverse
 sort directions from canonical DDL. Forwarding views project only insertable columns so the
 cache recomputes materialized bucket columns. Upgrading uses
-the existing ownership-checked cache rebuild and temporarily refills through source fallback.
-The separately owned full-history block index is preserved. Before deployment, run the full-size
+an ownership-checked table rebuild and temporarily refills through source fallback.
+The rebuild preserves `_cache_meta` until replacement DDL succeeds, so interrupted rebuilds
+can retry. Drops of verified owned tables set `max_table_size_to_drop=0` for that query only;
+server-wide drop protection remains unchanged. The separately owned full-history block index is preserved. Before deployment, run the full-size
 key-routing workload described in `tests/k6/README.md`; small-fixture tests do not establish its
 latency targets.
+
+If an older build partially dropped the cache database and removed `_cache_meta`, startup
+continues to reject the remaining tables. After confirming the target is the disposable cache
+ClickHouse instance and pausing its RPC task, an operator can remove the remaining cache with
+`DROP DATABASE IF EXISTS superbank_disk_cache SYNC SETTINGS max_table_size_to_drop=0`
+(substitute the configured cache database). This deletes the remaining cache data; restart RPC
+to recreate and refill it. Do not recreate an ownership marker over unidentified tables.
 
 The `superbank_disk_cache_reads_total` outcomes distinguish misses, query errors, and timeouts.
 `superbank_disk_cache_key_seconds` records complete attempts, admission waits, and index builds;

--- a/crates/superbank-rpc/src/clickhouse/client.rs
+++ b/crates/superbank-rpc/src/clickhouse/client.rs
@@ -157,6 +157,12 @@ impl HttpQueryCleanup {
         }
     }
 
+    pub(crate) fn disarm_optional(cleanup: &mut Option<Self>) {
+        if let Some(cleanup) = cleanup {
+            cleanup.disarm();
+        }
+    }
+
     pub(crate) fn disarm(&mut self) {
         self.query_id = None;
     }
@@ -409,6 +415,7 @@ pub struct ClickHouseClient {
     pub(crate) username: String,
     pub(crate) password: String,
     pub(crate) signature_slot_cache: Arc<SignatureSlotCache>,
+    pub(crate) cache_partition: Option<(u64, u64)>,
     pub(crate) transaction_table: String,
     pub(crate) blocks_metadata_table: String,
     pub(crate) gsfa_table: String,
@@ -765,6 +772,7 @@ impl ClickHouseClient {
             username: username.to_string(),
             password: password.to_string(),
             signature_slot_cache: Arc::new(SignatureSlotCache::from_env()),
+            cache_partition: None,
             transaction_table,
             blocks_metadata_table,
             gsfa_table,
@@ -920,6 +928,50 @@ impl ClickHouseClient {
         })
     }
 
+    pub(crate) fn annotate_lookup_query(
+        &self,
+        query: String,
+        operation: &'static str,
+    ) -> (String, Option<String>, Option<HttpQueryCleanup>) {
+        if self.cache_partition.is_some() {
+            let (query, id) = super::util::annotate_required_query(query, operation);
+            let cleanup = self.http_query_cleanup(operation, id.clone());
+            (query, Some(id), Some(cleanup))
+        } else {
+            let (query, id) = super::util::annotate_query(query, operation);
+            (query, id, None)
+        }
+    }
+
+    fn cache_settings_or(&self, settings: String, timeout: Duration) -> String {
+        if self.cache_partition.is_some() {
+            format!(
+                "SETTINGS max_execution_time={}, timeout_overflow_mode='throw', use_query_cache=0",
+                timeout.as_secs_f64().max(0.001)
+            )
+        } else {
+            settings
+        }
+    }
+
+    #[cfg(feature = "disk-cache")]
+    fn record_cache_admission(&self, started: std::time::Instant) {
+        if self.cache_partition.is_some() {
+            crate::metrics::disk_cache_key_seconds(
+                "admission",
+                "acquired",
+                started.elapsed().as_secs_f64(),
+            );
+        }
+    }
+
+    pub(crate) fn cache_slot_predicate(&self) -> String {
+        self.cache_partition
+            .map_or_else(String::new, |(width, partition)| {
+                format!(" AND intDiv(slot, {width}) = {partition}")
+            })
+    }
+
     pub(crate) fn select_settings_clause(
         &self,
         operation: &'static str,
@@ -936,7 +988,7 @@ impl ClickHouseClient {
     ) -> String {
         // Bound the server-side query lifetime so a query ClickHouse keeps running after
         // `with_http_query_timeout` drops the HTTP future does not linger and hold a connection.
-        append_max_execution_time_setting(
+        let settings = append_max_execution_time_setting(
             &build_select_settings_clause(
                 self.allow_query_settings,
                 freshness,
@@ -945,7 +997,8 @@ impl ClickHouseClient {
                 operation,
             ),
             timeout,
-        )
+        );
+        self.cache_settings_or(settings, timeout)
     }
 
     pub(crate) fn select_settings_clause_with_condition_cache(
@@ -970,7 +1023,7 @@ impl ClickHouseClient {
         operation: &'static str,
         freshness: QueryFreshnessClass,
     ) -> String {
-        append_max_execution_time_setting(
+        let settings = append_max_execution_time_setting(
             &build_select_settings_clause_with_overrides(
                 self.allow_query_settings,
                 freshness,
@@ -980,7 +1033,8 @@ impl ClickHouseClient {
                 operation,
             ),
             self.query_timeout,
-        )
+        );
+        self.cache_settings_or(settings, self.query_timeout)
     }
 
     pub(crate) fn inflation_reward_settings_clause(&self, operation: &'static str) -> String {
@@ -1070,10 +1124,15 @@ impl ClickHouseClient {
     pub(crate) async fn acquire_http_query_permit(
         &self,
     ) -> ProcessingResult<tokio::sync::SemaphorePermit<'_>> {
-        self.http_query_sem
-            .acquire()
-            .await
-            .map_err(|_| ProcessingError::database_msg("ClickHouse HTTP query semaphore closed"))
+        #[cfg(feature = "disk-cache")]
+        let started = std::time::Instant::now();
+        let permit =
+            self.http_query_sem.acquire().await.map_err(|_| {
+                ProcessingError::database_msg("ClickHouse HTTP query semaphore closed")
+            });
+        #[cfg(feature = "disk-cache")]
+        self.record_cache_admission(started);
+        permit
     }
 
     async fn describe_table_http(&self, table: &str) -> ProcessingResult<Vec<DescribeTableRow>> {

--- a/crates/superbank-rpc/src/clickhouse/gsfa.rs
+++ b/crates/superbank-rpc/src/clickhouse/gsfa.rs
@@ -276,7 +276,9 @@ impl ClickHouseClient {
         records: Vec<SignatureRecord>,
         timings: QueryTimings,
     ) -> ProcessingResult<(Vec<SignatureRecord>, QueryTimings)> {
-        let mode = gsfa_fallback_mode();
+        let mode = self
+            .cache_partition
+            .map_or_else(gsfa_fallback_mode, |_| GsfaFallbackMode::Disabled);
         let should_fallback = match mode {
             GsfaFallbackMode::Disabled => false,
             GsfaFallbackMode::EmptyOnly => records.is_empty(),
@@ -711,6 +713,7 @@ impl ClickHouseClient {
             let addr_bucket =
                 cityhash64(pubkey.as_ref()) % self.gsfa_bucket_modulus_for_address(&pubkey);
             let (with_clause, where_clause) = build_pagination_clauses(before_pos, until_pos);
+            let where_clause = format!("({where_clause}){}", self.cache_slot_predicate());
 
             let settings_clause = self.select_settings_clause(
                 "get_signatures_for_address_with_positions",
@@ -725,7 +728,7 @@ impl ClickHouseClient {
                 limit,
                 &settings_clause,
             );
-            let (query, query_id) = annotate_query(query, "gsfa_signatures");
+            let (query, query_id, mut cleanup) = self.annotate_lookup_query(query, "gsfa_signatures");
 
             let start = Instant::now();
 
@@ -747,6 +750,7 @@ impl ClickHouseClient {
                 .map(map_gsfa_signature_row)
                 .collect::<Vec<_>>();
 
+            super::client::HttpQueryCleanup::disarm_optional(&mut cleanup);
             let timings = QueryTimings {
                 elapsed_ms: start.elapsed().as_millis() as u64,
                 received_bytes: cursor.received_bytes(),

--- a/crates/superbank-rpc/src/clickhouse/queries.rs
+++ b/crates/superbank-rpc/src/clickhouse/queries.rs
@@ -247,6 +247,7 @@ pub(crate) const TOKEN_OWNER_REQUIRED_COLUMNS: [&str; 9] = [
 ];
 
 pub(crate) struct TransactionsForAddressTables<'a> {
+    pub(crate) cache_partition: Option<(u64, u64)>,
     pub(crate) gsfa_table: &'a str,
     pub(crate) gsfa_bucket_modulus: u64,
     pub(crate) token_owner_table: &'a str,
@@ -720,10 +721,16 @@ pub(crate) fn build_transactions_for_address_query(
         conditions.join(" AND ")
     };
 
+    let slot_scope = tables
+        .cache_partition
+        .map_or_else(String::new, |(width, partition)| {
+            format!(" AND intDiv(slot, {width}) = {partition}")
+        });
+
     let gsfa_subquery = format!(
         "SELECT signature, slot, slot_idx, err, memo, block_time
          FROM {gsfa_table}
-         PREWHERE addr_bucket = {addr_bucket} AND address = {address_literal}",
+         PREWHERE addr_bucket = {addr_bucket} AND address = {address_literal}{slot_scope}",
         gsfa_table = tables.gsfa_table,
         addr_bucket = gsfa_addr_bucket,
         address_literal = address_literal
@@ -739,7 +746,7 @@ pub(crate) fn build_transactions_for_address_query(
         let token_subquery = format!(
             "SELECT signature, slot, slot_idx, err, memo, block_time
              FROM {token_owner_table}
-             PREWHERE owner_bucket = {addr_bucket} AND owner = {address_literal}{balance_clause}",
+             PREWHERE owner_bucket = {addr_bucket} AND owner = {address_literal}{slot_scope}{balance_clause}",
             token_owner_table = tables.token_owner_table,
             addr_bucket = token_owner_bucket,
             address_literal = address_literal,
@@ -763,7 +770,7 @@ pub(crate) fn build_transactions_for_address_query(
             memo,
             block_time
          FROM {gsfa_table}
-         PREWHERE addr_bucket = {addr_bucket} AND address = {address_literal}
+         PREWHERE addr_bucket = {addr_bucket} AND address = {address_literal}{slot_scope}
          WHERE {where_clause}",
             with_clause = with_clause,
             gsfa_table = tables.gsfa_table,
@@ -993,6 +1000,7 @@ mod tests {
         };
 
         let tables = TransactionsForAddressTables {
+            cache_partition: None,
             gsfa_table: "default.gsfa",
             gsfa_bucket_modulus: 128,
             token_owner_table: "default.token_owner_activity",
@@ -1058,6 +1066,7 @@ mod tests {
         };
 
         let tables = TransactionsForAddressTables {
+            cache_partition: None,
             gsfa_table: "default.gsfa",
             gsfa_bucket_modulus: 32,
             token_owner_table: "default.token_owner_activity",
@@ -1098,6 +1107,7 @@ mod tests {
             token_accounts: TokenAccountsFilter::None,
         };
         let tables = TransactionsForAddressTables {
+            cache_partition: None,
             gsfa_table: "default.gsfa_local",
             gsfa_bucket_modulus: 32,
             token_owner_table: "default.token_owner_activity_local",
@@ -1139,6 +1149,7 @@ mod tests {
             token_accounts: TokenAccountsFilter::None,
         };
         let tables = TransactionsForAddressTables {
+            cache_partition: None,
             gsfa_table: "cache.gsfa",
             gsfa_bucket_modulus: 32,
             token_owner_table: "cache.token_owner_activity",
@@ -1179,6 +1190,7 @@ mod tests {
             token_accounts: TokenAccountsFilter::None,
         };
         let tables = TransactionsForAddressTables {
+            cache_partition: None,
             gsfa_table: "default.gsfa_local",
             gsfa_bucket_modulus: 32,
             token_owner_table: "default.token_owner_activity_local",

--- a/crates/superbank-rpc/src/clickhouse/signatures.rs
+++ b/crates/superbank-rpc/src/clickhouse/signatures.rs
@@ -18,7 +18,7 @@ use super::client::{ClickHouseClient, execute_shard_tcp_query_block};
 use super::sharding::ShardTopology;
 use super::types::{QueryTimings, SignatureSlot, SignatureStatusRecord};
 use super::util::{
-    annotate_query, append_max_execution_time_setting, http_query_with_id, parse_err_json,
+    append_max_execution_time_setting, http_query_with_id, parse_err_json,
     transient_shard_local_error_reason,
 };
 
@@ -87,6 +87,32 @@ impl ClickHouseClient {
         let signature_hex = hex::encode(signature_bytes.as_ref()).to_uppercase();
         let signature_literal = format!("toFixedString(unhex('{signature_hex}'), 64)");
 
+        if self.cache_partition.is_some() {
+            return self
+                .get_signature_slot_by_signature_uncached(
+                    signature_hash,
+                    sig_bucket,
+                    &signature_literal,
+                )
+                .await;
+        }
+
+        self.get_signature_slot_cached(
+            signature_bytes,
+            signature_hash,
+            sig_bucket,
+            &signature_literal,
+        )
+        .await
+    }
+
+    async fn get_signature_slot_cached(
+        &self,
+        signature_bytes: SignatureBytes,
+        signature_hash: u64,
+        sig_bucket: u64,
+        signature_literal: &str,
+    ) -> ProcessingResult<(Option<SignatureSlot>, QueryTimings)> {
         let call_start = Instant::now();
         let mut waited = false;
 
@@ -120,7 +146,7 @@ impl ClickHouseClient {
                         .get_signature_slot_by_signature_uncached(
                             signature_hash,
                             sig_bucket,
-                            &signature_literal,
+                            signature_literal,
                         )
                         .await;
 
@@ -197,16 +223,18 @@ impl ClickHouseClient {
                     slot,
                     slot_idx
                  FROM {signature_statuses_table}
-                 PREWHERE sig_bucket = {sig_bucket} AND signature = {signature_literal}
+                 PREWHERE sig_bucket = {sig_bucket} AND signature = {signature_literal}{cache_scope}
                  ORDER BY slot DESC, slot_idx DESC, signature
                  LIMIT 1
                  {settings_clause}",
+                cache_scope = self.cache_slot_predicate(),
                 signature_statuses_table = signature_statuses_table,
                 sig_bucket = sig_bucket,
                 signature_literal = signature_literal,
                 settings_clause = settings_clause
             );
-            let (query, query_id) = annotate_query(query, "signature_slot");
+            let (query, query_id, mut cleanup) =
+                self.annotate_lookup_query(query, "signature_slot");
 
             let start = Instant::now();
             let mut cursor = http_query_with_id(&self.client, &query, query_id)
@@ -218,6 +246,7 @@ impl ClickHouseClient {
                 .await
                 .map_err(|e| ProcessingError::database(e.to_string(), e))?;
 
+            super::client::HttpQueryCleanup::disarm_optional(&mut cleanup);
             let timings = QueryTimings {
                 elapsed_ms: start.elapsed().as_millis() as u64,
                 received_bytes: cursor.received_bytes(),
@@ -320,15 +349,17 @@ impl ClickHouseClient {
                         signature,
                         argMax(tuple(slot, err), tuple(slot, slot_idx)) AS latest
                     FROM {signature_statuses_table}
-                    PREWHERE {signature_filter}
+                    PREWHERE ({signature_filter}){cache_scope}
                     GROUP BY signature
                  )
                  {settings_clause}",
+                cache_scope = self.cache_slot_predicate(),
                 signature_statuses_table = signature_statuses_table,
                 signature_filter = signature_filter,
                 settings_clause = settings_clause
             );
-            let (query, query_id) = annotate_query(query, "signature_statuses");
+            let (query, query_id, mut cleanup) =
+                self.annotate_lookup_query(query, "signature_statuses");
 
             #[derive(Deserialize, clickhouse::Row)]
             struct StatusRow {
@@ -359,6 +390,7 @@ impl ClickHouseClient {
                 });
             }
 
+            super::client::HttpQueryCleanup::disarm_optional(&mut cleanup);
             let timings = QueryTimings {
                 elapsed_ms: start.elapsed().as_millis() as u64,
                 received_bytes: cursor.received_bytes(),

--- a/crates/superbank-rpc/src/clickhouse/transactions.rs
+++ b/crates/superbank-rpc/src/clickhouse/transactions.rs
@@ -333,6 +333,7 @@ impl ClickHouseClient {
         let gsfa_table = self.gsfa_table_for_address(pubkey);
         let gsfa_bucket_modulus = self.gsfa_bucket_modulus_for_address(pubkey);
         let tables = TransactionsForAddressTables {
+            cache_partition: self.cache_partition,
             gsfa_table,
             gsfa_bucket_modulus,
             token_owner_table: &self.token_owner_activity_table,
@@ -342,10 +343,10 @@ impl ClickHouseClient {
         };
         let query = build_transactions_for_address_query(&tables, query, &settings_clause)?;
 
+        let (query, query_id, mut cleanup) =
+            self.annotate_lookup_query(query, "cache_address_transactions");
         let start = Instant::now();
-        let mut cursor = self
-            .client
-            .query(&query)
+        let mut cursor = super::util::http_query_with_id(&self.client, &query, query_id)
             .fetch::<TransactionsForAddressQueryRow>()
             .map_err(|e| ProcessingError::database(e.to_string(), e))?;
 
@@ -358,6 +359,7 @@ impl ClickHouseClient {
             results.push(row);
         }
 
+        super::client::HttpQueryCleanup::disarm_optional(&mut cleanup);
         let records = results
             .into_iter()
             .map(map_transactions_for_address_row)
@@ -517,6 +519,21 @@ impl ClickHouseClient {
         .await
     }
 
+    async fn fetch_transaction_lookup(
+        &self,
+        query: &str,
+    ) -> ProcessingResult<(Option<TransactionRow>, QueryTimings)> {
+        let (query, query_id, mut cleanup) =
+            self.annotate_lookup_query(query.to_string(), "transaction_lookup");
+        let client = query_id.map_or_else(
+            || self.client.clone(),
+            |id| self.client.clone().with_setting("query_id", id),
+        );
+        let result = fetch_single_transaction_row(&client, &query).await?;
+        super::client::HttpQueryCleanup::disarm_optional(&mut cleanup);
+        Ok(result)
+    }
+
     pub async fn get_transaction_by_signature(
         &self,
         signature: &str,
@@ -574,7 +591,7 @@ impl ClickHouseClient {
                         );
                         let query =
                             build_query(&self.transaction_table, Some(slot_idx), &settings_clause);
-                        let result = fetch_single_transaction_row(&self.client, &query).await?;
+                        let result = self.fetch_transaction_lookup(&query).await?;
                         (result.0, result.1, false)
                     }
                 }
@@ -584,7 +601,7 @@ impl ClickHouseClient {
                     QueryFreshnessClass::Historical,
                 );
                 let query = build_query(&self.transaction_table, Some(slot_idx), &settings_clause);
-                let result = fetch_single_transaction_row(&self.client, &query).await?;
+                let result = self.fetch_transaction_lookup(&query).await?;
                 (result.0, result.1, false)
             };
             timings.add(query_timings);
@@ -599,7 +616,7 @@ impl ClickHouseClient {
                 );
                 let query = build_query(&self.transaction_table, Some(slot_idx), &settings_clause);
                 let (fallback_opt, fallback_timings) =
-                    fetch_single_transaction_row(&self.client, &query).await?;
+                    self.fetch_transaction_lookup(&query).await?;
                 timings.add(fallback_timings);
                 row_opt = fallback_opt;
             }
@@ -612,7 +629,7 @@ impl ClickHouseClient {
                 );
                 let query = build_query(&self.transaction_table, None, &settings_clause);
                 let (fallback_opt, fallback_timings) =
-                    fetch_single_transaction_row(&self.client, &query).await?;
+                    self.fetch_transaction_lookup(&query).await?;
                 timings.add(fallback_timings);
                 row_opt = fallback_opt;
             }
@@ -672,7 +689,7 @@ impl ClickHouseClient {
                             QueryFreshnessClass::Historical,
                         );
                         let query = build_query(&self.transaction_table, &settings_clause);
-                        let result = fetch_single_transaction_row(&self.client, &query).await?;
+                        let result = self.fetch_transaction_lookup(&query).await?;
                         (result.0, result.1, false)
                     }
                 }
@@ -682,7 +699,7 @@ impl ClickHouseClient {
                     QueryFreshnessClass::Historical,
                 );
                 let query = build_query(&self.transaction_table, &settings_clause);
-                let result = fetch_single_transaction_row(&self.client, &query).await?;
+                let result = self.fetch_transaction_lookup(&query).await?;
                 (result.0, result.1, false)
             };
 
@@ -693,7 +710,7 @@ impl ClickHouseClient {
                 );
                 let query = build_query(&self.transaction_table, &settings_clause);
                 let (fallback_opt, fallback_timings) =
-                    fetch_single_transaction_row(&self.client, &query).await?;
+                    self.fetch_transaction_lookup(&query).await?;
                 timings.add(fallback_timings);
                 row_opt = fallback_opt;
             }
@@ -732,6 +749,7 @@ impl ClickHouseClient {
         let gsfa_table = self.gsfa_local_table(router);
         let gsfa_bucket_modulus = self.gsfa_bucket_modulus_for_address(pubkey);
         let tables = TransactionsForAddressTables {
+            cache_partition: self.cache_partition,
             gsfa_table,
             gsfa_bucket_modulus,
             token_owner_table,
@@ -964,6 +982,7 @@ impl ClickHouseClient {
         let gsfa_table = self.gsfa_local_table(router);
         let gsfa_bucket_modulus = self.gsfa_bucket_modulus_for_address(pubkey);
         let tables = TransactionsForAddressTables {
+            cache_partition: self.cache_partition,
             gsfa_table,
             gsfa_bucket_modulus,
             token_owner_table,

--- a/crates/superbank-rpc/src/config.rs
+++ b/crates/superbank-rpc/src/config.rs
@@ -526,6 +526,21 @@ pub struct RpcConfig {
     pub(crate) disk_cache_query_timeout_ms: u64,
 
     #[cfg(feature = "disk-cache")]
+    /// Total partition routing index budget, including build buffers.
+    #[arg(long, env = "DISK_CACHE_KEY_INDEX_MAX_MEMORY_BYTES", default_value_t = 4_294_967_296, value_parser = clap::value_parser!(u64).range(67_108_864..))]
+    pub(crate) disk_cache_key_index_max_memory_bytes: u64,
+
+    #[cfg(feature = "disk-cache")]
+    /// Concurrent local interactive queries.
+    #[arg(long, env = "DISK_CACHE_QUERY_CONCURRENCY", default_value_t = 8, value_parser = clap::value_parser!(u64).range(1..=64))]
+    pub(crate) disk_cache_query_concurrency: u64,
+
+    #[cfg(feature = "disk-cache")]
+    /// Execution threads per local interactive query.
+    #[arg(long, env = "DISK_CACHE_QUERY_MAX_THREADS", default_value_t = 2, value_parser = clap::value_parser!(u64).range(1..=16))]
+    pub(crate) disk_cache_query_max_threads: u64,
+
+    #[cfg(feature = "disk-cache")]
     /// Interval for checking the source schema fingerprint.
     #[arg(long, env = "DISK_CACHE_SCHEMA_CHECK_INTERVAL_SECS", default_value_t = 300, value_parser = clap::value_parser!(u64).range(1..))]
     pub(crate) disk_cache_schema_check_interval_secs: u64,

--- a/crates/superbank-rpc/src/disk_cache/coverage.rs
+++ b/crates/superbank-rpc/src/disk_cache/coverage.rs
@@ -99,6 +99,13 @@ impl CoverageMap {
             .is_some_and(|(_, &end)| slot <= end)
     }
 
+    pub(crate) fn intersects(&self, start: u64, end: u64) -> bool {
+        self.ranges
+            .range(..=end)
+            .next_back()
+            .is_some_and(|(_, range_end)| *range_end >= start)
+    }
+
     /// `(min covered, max covered)` across all ranges.
     pub(crate) fn covered_span(&self) -> Option<(u64, u64)> {
         let (&first_start, _) = self.ranges.first_key_value()?;

--- a/crates/superbank-rpc/src/disk_cache/filler.rs
+++ b/crates/superbank-rpc/src/disk_cache/filler.rs
@@ -435,7 +435,7 @@ pub(crate) fn plan_ranges(
     chunked
 }
 
-async fn fill_range(
+pub(super) async fn fill_range(
     cache: &DiskCache,
     source: &ClickHouseClient,
     range: SlotRange,
@@ -462,6 +462,7 @@ async fn fill_range(
         .ok_or_else(|| DiskCacheError::Config("transactions schema missing".to_string()))?;
     // Forward the durable fact table first. The block table can use Memory,
     // which cannot deduplicate a retry after a later stage fails.
+    let _mutation = cache.begin_fill(range.start, range.end);
     native_forward(cache, source, transactions, range, cfg.query_timeout).await?;
     cache
         .validate_transaction_counts(range.start, range.end, &expected)

--- a/crates/superbank-rpc/src/disk_cache/key_index.rs
+++ b/crates/superbank-rpc/src/disk_cache/key_index.rs
@@ -1,0 +1,537 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Ephemeral partition membership. Missing or changing filters always admit a query.
+
+use super::{DiskCache, DiskCacheConfig, DiskCacheError, schema::CacheTableKind};
+use clickhouse::Row;
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+const RESERVE: u64 = 64 * 1024 * 1024;
+const ENTRY_OVERHEAD: u64 = 1024;
+
+#[derive(Clone, Copy, Debug)]
+pub(super) enum Family {
+    Signature,
+    Address,
+    HotAddress,
+    Owner,
+}
+impl Family {
+    fn table(self) -> (CacheTableKind, &'static str) {
+        match self {
+            Self::Signature => (CacheTableKind::Signatures, "signature"),
+            Self::Address => (CacheTableKind::Gsfa, "address"),
+            Self::HotAddress => (CacheTableKind::GsfaHot, "address"),
+            Self::Owner => (CacheTableKind::TokenOwnerActivity, "owner"),
+        }
+    }
+}
+const FAMILIES: [Family; 4] = [
+    Family::Signature,
+    Family::Address,
+    Family::HotAddress,
+    Family::Owner,
+];
+
+struct Bloom {
+    bits: Vec<u8>,
+    hashes: u32,
+}
+impl Bloom {
+    fn new(bytes: usize, cardinality: u64) -> Option<Self> {
+        if bytes == 0 {
+            return None;
+        }
+        let mut bits = Vec::new();
+        bits.try_reserve_exact(bytes).ok()?;
+        bits.resize(bytes, 0);
+        let hashes = ((bytes as f64 * 8.0 / cardinality.max(1) as f64) * std::f64::consts::LN_2)
+            .round()
+            .clamp(1.0, 16.0) as u32;
+        Some(Self { bits, hashes })
+    }
+    fn positions(&self, key: &[u8]) -> impl Iterator<Item = usize> + use<> {
+        let digest = blake3::hash(key);
+        let mut a = [0; 8];
+        let mut b = [0; 8];
+        a.copy_from_slice(&digest.as_bytes()[..8]);
+        b.copy_from_slice(&digest.as_bytes()[8..16]);
+        let a = u64::from_le_bytes(a);
+        let b = u64::from_le_bytes(b) | 1;
+        let bits = self.bits.len() as u64 * 8;
+        (0..self.hashes)
+            .map(move |i| (a.wrapping_add(u64::from(i).wrapping_mul(b)) % bits) as usize)
+    }
+    fn insert(&mut self, key: &[u8]) {
+        for bit in self.positions(key) {
+            self.bits[bit / 8] |= 1 << (bit % 8);
+        }
+    }
+    fn contains(&self, key: &[u8]) -> bool {
+        self.positions(key)
+            .all(|bit| self.bits[bit / 8] & (1 << (bit % 8)) != 0)
+    }
+}
+struct Entry {
+    token: u64,
+    filters: Option<[Option<Bloom>; 4]>,
+}
+#[derive(Default)]
+struct State {
+    entries: BTreeMap<u64, Entry>,
+    writers: BTreeMap<u64, (u64, u64)>,
+    serial: u64,
+    epoch: u64,
+    untracked_writers: usize,
+}
+
+pub(super) struct KeyIndex {
+    state: Mutex<State>,
+    width: u64,
+    quota: usize,
+    max_entries: usize,
+}
+pub(super) struct Mutation {
+    index: Arc<KeyIndex>,
+    id: Option<u64>,
+}
+impl Drop for Mutation {
+    fn drop(&mut self) {
+        let mut state = self.index.state.lock().expect("key index lock");
+        match self.id {
+            Some(id) => {
+                state.writers.remove(&id);
+            }
+            None => state.untracked_writers -= 1,
+        }
+    }
+}
+impl KeyIndex {
+    pub(super) fn new(cfg: &DiskCacheConfig) -> Self {
+        // One extra edge partition and one build/replacement slot. Reserve includes
+        // streaming buffers and bounded mutation metadata, not ClickHouse's memory.
+        let slots = cfg
+            .retain_slots
+            .div_ceil(cfg.partition_slots)
+            .saturating_add(2);
+        let quota = cfg.key_index_max_memory_bytes.saturating_sub(RESERVE) / slots;
+        Self {
+            state: Mutex::default(),
+            width: cfg.partition_slots,
+            quota: usize::try_from(quota.saturating_sub(ENTRY_OVERHEAD)).unwrap_or(0),
+            max_entries: usize::try_from(slots.saturating_sub(1)).unwrap_or(0),
+        }
+    }
+    pub(super) fn mutation(self: &Arc<Self>, start: u64, end: u64) -> Mutation {
+        let mut state = self.state.lock().expect("key index lock");
+        // Bound mutation metadata even if many callers concurrently poison slots.
+        if state.writers.len() >= 128 {
+            state.entries.clear();
+            state.epoch += 1;
+            state.untracked_writers += 1;
+            return Mutation {
+                index: self.clone(),
+                id: None,
+            };
+        }
+        state.serial += 1;
+        let id = state.serial;
+        let range = (start / self.width, end / self.width);
+        let count = state.entries.len();
+        state.entries.retain(|p, _| *p < range.0 || *p > range.1);
+        if count != state.entries.len() {
+            state.epoch += 1;
+        }
+        state.writers.insert(id, range);
+        Mutation {
+            index: self.clone(),
+            id: Some(id),
+        }
+    }
+    pub(super) fn invalidate_reads(&self) {
+        self.state.lock().expect("key index lock").epoch += 1;
+    }
+    pub(super) fn epoch(&self) -> u64 {
+        self.state.lock().expect("key index lock").epoch
+    }
+    pub(super) fn may_contain(&self, partition: u64, families: &[Family], key: &[u8]) -> bool {
+        let state = self.state.lock().expect("key index lock");
+        let Some(filters) = state
+            .entries
+            .get(&partition)
+            .and_then(|e| e.filters.as_ref())
+        else {
+            return true;
+        };
+        families.iter().any(|f| {
+            filters[*f as usize]
+                .as_ref()
+                .is_none_or(|b| b.contains(key))
+        })
+    }
+    fn begin(&self, partition: u64) -> Option<u64> {
+        let mut state = self.state.lock().expect("key index lock");
+        if state.untracked_writers > 0
+            || self.quota < 4
+            || state.entries.len() >= self.max_entries
+            || state.entries.contains_key(&partition)
+        {
+            return None;
+        }
+        if state
+            .writers
+            .values()
+            .any(|(a, b)| (*a..=*b).contains(&partition))
+        {
+            return None;
+        }
+        state.serial += 1;
+        let token = state.serial;
+        state.entries.insert(
+            partition,
+            Entry {
+                token,
+                filters: None,
+            },
+        );
+        Some(token)
+    }
+    fn finish(&self, partition: u64, token: u64, filters: Option<[Option<Bloom>; 4]>) {
+        let mut state = self.state.lock().expect("key index lock");
+        if state
+            .entries
+            .get(&partition)
+            .is_none_or(|e| e.token != token)
+        {
+            return;
+        }
+        match filters {
+            Some(filters) => {
+                state.entries.insert(
+                    partition,
+                    Entry {
+                        token,
+                        filters: Some(filters),
+                    },
+                );
+            }
+            None => {
+                state.entries.remove(&partition);
+            }
+        }
+    }
+}
+
+#[derive(Deserialize, Row)]
+struct Cardinality {
+    n: u64,
+}
+#[derive(Deserialize, Row)]
+struct KeyRow<const N: usize> {
+    key: serde_big_array::Array<u8, N>,
+}
+
+impl DiskCache {
+    pub(crate) async fn run_key_index(
+        self: Arc<Self>,
+        mut shutdown: tokio::sync::broadcast::Receiver<()>,
+    ) {
+        loop {
+            tokio::select! {
+                _ = shutdown.recv() => return,
+                _ = self.build_key_indexes() => {}
+            }
+            tokio::select! {
+                _ = shutdown.recv() => return,
+                _ = tokio::time::sleep(Duration::from_secs(5)) => {}
+            }
+        }
+    }
+    pub(super) async fn build_key_indexes(&self) {
+        let Some((floor, tip)) = self.tip_span() else {
+            return;
+        };
+        let width = self.inner.cfg.partition_slots;
+        self.publish_key_index_metrics(floor, tip);
+        for partition in (floor.div_ceil(width)..tip / width).rev() {
+            let Some(token) = self.inner.key_index.begin(partition) else {
+                continue;
+            };
+            let started = std::time::Instant::now();
+            let built = tokio::time::timeout(
+                Duration::from_secs(300),
+                self.build_partition_filters(partition),
+            )
+            .await;
+            let outcome = if matches!(&built, Ok(Ok(_))) {
+                "success"
+            } else {
+                "error"
+            };
+            let filters = match built {
+                Ok(Ok(filters)) => Some(filters),
+                _ => {
+                    crate::metrics::disk_cache_read("key_index_build", "error");
+                    None
+                }
+            };
+            self.inner.key_index.finish(partition, token, filters);
+            crate::metrics::disk_cache_key_seconds(
+                "index_build",
+                outcome,
+                started.elapsed().as_secs_f64(),
+            );
+            tracing::debug!(
+                partition,
+                elapsed_ms = started.elapsed().as_millis(),
+                "disk cache: key index build finished"
+            );
+        }
+    }
+    fn publish_key_index_metrics(&self, floor: u64, tip: u64) {
+        let state = self.inner.key_index.state.lock().expect("key index lock");
+        let indexed = state
+            .entries
+            .values()
+            .filter(|entry| entry.filters.is_some())
+            .count() as u64;
+        let allocated = state
+            .entries
+            .values()
+            .filter_map(|entry| entry.filters.as_ref())
+            .flat_map(|filters| filters.iter().flatten())
+            .map(|bloom| bloom.bits.capacity() as u64)
+            .sum::<u64>();
+        let total =
+            tip / self.inner.cfg.partition_slots - floor / self.inner.cfg.partition_slots + 1;
+        let building = state
+            .entries
+            .values()
+            .filter(|entry| entry.filters.is_none())
+            .count() as u64;
+        // Include the reserved builder/metadata allowance to report the upper bound.
+        crate::metrics::disk_cache_key_index(
+            allocated
+                + building * self.inner.key_index.quota as u64
+                + RESERVE
+                + state.entries.len() as u64 * ENTRY_OVERHEAD,
+            indexed,
+            total.saturating_sub(indexed),
+        );
+    }
+    async fn build_partition_filters(
+        &self,
+        partition: u64,
+    ) -> Result<[Option<Bloom>; 4], DiskCacheError> {
+        // A separate lane: never consume the interactive query semaphore.
+        let client = self
+            .inner
+            .local
+            .client
+            .clone()
+            .with_setting("max_threads", "1")
+            .with_setting("max_memory_usage", "67108864")
+            .with_setting("max_execution_time", "300")
+            .with_setting("max_block_size", "8192")
+            .with_setting("preferred_block_size_bytes", "1048576");
+        let mut builder = self.inner.local.clone();
+        builder.client = client;
+        builder.cache_partition = Some((self.inner.cfg.partition_slots, partition));
+        builder.query_timeout = Duration::from_secs(300);
+        let snapshot = self.source_schema();
+        let mut cardinalities = [0u64; 4];
+        for family in FAMILIES {
+            let (kind, key) = family.table();
+            if !snapshot.has_table(kind) {
+                continue;
+            }
+            let sql = format!(
+                "SELECT uniqCombined64({key}) AS n FROM `{}`.{} WHERE intDiv(slot, {}) = {partition}",
+                self.inner.cfg.database,
+                kind.local_name(),
+                self.inner.cfg.partition_slots
+            );
+            cardinalities[family as usize] = cardinality(&builder, &sql).await?.max(1);
+        }
+        let total: u128 = cardinalities.iter().map(|n| u128::from(*n)).sum();
+        let mut filters: [Option<Bloom>; 4] = std::array::from_fn(|_| None);
+        for family in FAMILIES {
+            let n = cardinalities[family as usize];
+            if n == 0 {
+                continue;
+            }
+            let share =
+                (self.inner.key_index.quota as u128 * u128::from(n) / total.max(1)) as usize;
+            let target = (n as f64 * 1.2).ceil() as usize;
+            let Some(mut bloom) = Bloom::new(share.min(target), n) else {
+                continue;
+            };
+            let (kind, key) = family.table();
+            let sql = format!(
+                "SELECT {key} AS key FROM `{}`.{} WHERE intDiv(slot, {}) = {partition}",
+                self.inner.cfg.database,
+                kind.local_name(),
+                self.inner.cfg.partition_slots
+            );
+            match family {
+                Family::Signature => read_keys::<64>(&builder, &sql, &mut bloom).await?,
+                _ => read_keys::<32>(&builder, &sql, &mut bloom).await?,
+            }
+            filters[family as usize] = Some(bloom);
+        }
+        Ok(filters)
+    }
+}
+
+async fn cardinality(
+    client: &crate::clickhouse::ClickHouseClient,
+    sql: &str,
+) -> Result<u64, DiskCacheError> {
+    let (sql, id, mut cleanup) =
+        client.annotate_lookup_query(sql.to_string(), "key_index_cardinality");
+    let row = client
+        .client
+        .clone()
+        .with_setting("query_id", id.unwrap_or_default())
+        .query(&sql)
+        .fetch_one::<Cardinality>()
+        .await
+        .map_err(|e| DiskCacheError::ClickHouse(e.to_string()))?;
+    if let Some(cleanup) = &mut cleanup {
+        cleanup.disarm();
+    }
+    Ok(row.n)
+}
+
+async fn read_keys<const N: usize>(
+    client: &crate::clickhouse::ClickHouseClient,
+    sql: &str,
+    bloom: &mut Bloom,
+) -> Result<(), DiskCacheError> {
+    let (sql, id, mut cleanup) = client.annotate_lookup_query(sql.to_string(), "key_index_keys");
+    let client = client
+        .client
+        .clone()
+        .with_setting("query_id", id.unwrap_or_default());
+    let mut count = 0u64;
+    let mut rows = client
+        .query(&sql)
+        .fetch::<KeyRow<N>>()
+        .map_err(|e| DiskCacheError::ClickHouse(e.to_string()))?;
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| DiskCacheError::ClickHouse(e.to_string()))?
+    {
+        bloom.insert(&row.key.0);
+        count += 1;
+        if count.is_multiple_of(8192) {
+            tokio::task::yield_now().await;
+        }
+    }
+    if let Some(cleanup) = &mut cleanup {
+        cleanup.disarm();
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn mutation_metadata_is_bounded_under_overload() {
+        let index = Arc::new(KeyIndex {
+            state: Mutex::default(),
+            width: 10,
+            quota: 1024,
+            max_entries: 2,
+        });
+        let guards: Vec<_> = (0..140).map(|_| index.mutation(10, 19)).collect();
+        assert_eq!(index.state.lock().unwrap().writers.len(), 128);
+        assert!(index.begin(2).is_none());
+        drop(guards);
+        assert!(index.begin(2).is_some());
+    }
+    #[test]
+    fn quota_accounts_for_builds_and_metadata() {
+        let mut cfg = super::super::key_tests::config(String::new(), String::new());
+        for width in [1, 10, 40, 1000] {
+            cfg.partition_slots = width;
+            let index = KeyIndex::new(&cfg);
+            assert!(
+                (index.quota as u64 + ENTRY_OVERHEAD) * index.max_entries as u64 + RESERVE
+                    <= cfg.key_index_max_memory_bytes
+            );
+        }
+        cfg.key_index_max_memory_bytes = RESERVE;
+        assert!(KeyIndex::new(&cfg).begin(1).is_none());
+    }
+    #[test]
+    fn family_isolation_and_failed_builds_remain_conservative() {
+        let index = KeyIndex {
+            state: Mutex::default(),
+            width: 10,
+            quota: 1024,
+            max_entries: 1,
+        };
+        let token = index.begin(1).unwrap();
+        assert!(index.begin(2).is_none());
+        index.finish(1, token, None);
+        let token = index.begin(1).unwrap();
+        let mut filters = std::array::from_fn(|_| Bloom::new(1024, 1));
+        filters[Family::Owner as usize]
+            .as_mut()
+            .unwrap()
+            .insert(b"owner");
+        index.finish(1, token, Some(filters));
+        assert!(!index.may_contain(1, &[Family::Address], b"owner"));
+        assert!(index.may_contain(1, &[Family::Address, Family::Owner], b"owner"));
+        assert!(index.may_contain(2, &[Family::Signature], b"unknown"));
+    }
+    #[test]
+    fn old_build_cannot_replace_new_generation() {
+        let index = Arc::new(KeyIndex {
+            state: Mutex::default(),
+            width: 10,
+            quota: 1024,
+            max_entries: 2,
+        });
+        let old = index.begin(1).unwrap();
+        drop(index.mutation(10, 19));
+        let new = index.begin(1).unwrap();
+        index.finish(1, old, Some(std::array::from_fn(|_| Bloom::new(32, 10))));
+        assert!(index.may_contain(1, &[Family::Signature], b"missing"));
+        index.finish(1, new, Some(std::array::from_fn(|_| Bloom::new(32, 10))));
+        assert!(!index.may_contain(1, &[Family::Signature], b"missing"));
+    }
+
+    #[test]
+    fn saturated_bloom_never_loses_inserted_keys() {
+        let mut bloom = Bloom::new(1, 10_000).unwrap();
+        for n in 0u64..10_000 {
+            bloom.insert(&n.to_le_bytes());
+        }
+        for n in 0u64..10_000 {
+            assert!(bloom.contains(&n.to_le_bytes()));
+        }
+        assert!(bloom.contains(b"false positive is safe"));
+    }
+    #[test]
+    fn invalidation_rejects_in_flight_build_and_admits_unknown_keys() {
+        let index = Arc::new(KeyIndex {
+            state: Mutex::default(),
+            width: 10,
+            quota: 1024,
+            max_entries: 4,
+        });
+        let token = index.begin(1).unwrap();
+        let mutation = index.mutation(10, 19);
+        index.finish(1, token, Some(std::array::from_fn(|_| Bloom::new(32, 10))));
+        assert!(index.may_contain(1, &[Family::Signature], b"missing"));
+        assert!(index.begin(1).is_none());
+        drop(mutation);
+        assert!(index.begin(1).is_some());
+    }
+}

--- a/crates/superbank-rpc/src/disk_cache/key_reads.rs
+++ b/crates/superbank-rpc/src/disk_cache/key_reads.rs
@@ -1,0 +1,530 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Ordered, partition-scoped reads under one cache-attempt deadline.
+use super::{
+    DiskCache, DiskGsfaPage, DiskSigStatus, clamp_until_to_floor, index::DiskTfaQuery,
+    key_index::Family, lower_bound_reaches_floor, upper_bound_reaches_tip,
+};
+use crate::clickhouse::{
+    ClickHouseClient, NumericFilter, PaginationToken, SignatureRecord, SignatureSlot, SlotBoundary,
+    SortOrder, StoredTransactionRecord, TokenAccountsFilter, TransactionsForAddressQuery,
+};
+use crate::processing::{ProcessingError, ProcessingResult};
+use crate::solana_sdk::{pubkey::Pubkey, signature::Signature};
+use std::collections::{HashMap, HashSet};
+use std::future::Future;
+use tokio::time::Instant;
+
+// Slot bounds are conservative for position cursors: SQL resolves the index
+// within the boundary slot. Saturation may retain one impossible edge slot.
+fn gsfa_window(
+    (mut floor, mut tip): (u64, u64),
+    before: Option<SlotBoundary>,
+    until: Option<SlotBoundary>,
+) -> (u64, u64) {
+    tip = tip.min(match before {
+        Some(SlotBoundary::Position(p)) => p.slot,
+        Some(SlotBoundary::Slot(slot)) => slot.saturating_sub(1),
+        None => u64::MAX,
+    });
+    floor = floor.max(match until {
+        Some(SlotBoundary::Position(p)) => p.slot,
+        Some(SlotBoundary::Slot(slot)) => slot.saturating_add(1),
+        None => 0,
+    });
+    (floor, tip)
+}
+
+fn numeric_window((floor, tip): (u64, u64), filter: &NumericFilter<u64>) -> (u64, u64) {
+    let lower = [
+        Some(floor),
+        filter.gte,
+        filter.gt.map(|v| v.saturating_add(1)),
+        filter.eq,
+    ];
+    let upper = [
+        Some(tip),
+        filter.lte,
+        filter.lt.map(|v| v.saturating_sub(1)),
+        filter.eq,
+    ];
+    (
+        lower.into_iter().flatten().max().unwrap_or(floor),
+        upper.into_iter().flatten().min().unwrap_or(tip),
+    )
+}
+
+fn tfa_window(mut span: (u64, u64), query: &TransactionsForAddressQuery) -> (u64, u64) {
+    if let Some(filter) = &query.slot_filter {
+        span = numeric_window(span, filter);
+    }
+    if let Some(filter) = &query.resolved_signature_filter {
+        for position in [filter.gt, filter.gte].into_iter().flatten() {
+            span.0 = span.0.max(position.slot);
+        }
+        for position in [filter.lt, filter.lte].into_iter().flatten() {
+            span.1 = span.1.min(position.slot);
+        }
+    }
+    if let Some(position) = query.resolved_pagination {
+        match query.sort_order {
+            SortOrder::Asc => span.0 = span.0.max(position.slot),
+            SortOrder::Desc => span.1 = span.1.min(position.slot),
+        }
+    }
+    span
+}
+
+#[derive(Default)]
+struct AddressRows {
+    records: Vec<SignatureRecord>,
+    seen: HashSet<String>,
+}
+impl AddressRows {
+    fn append(&mut self, page: Vec<crate::clickhouse::TransactionsForAddressRecord>) {
+        self.records.extend(
+            page.into_iter()
+                .filter(|r| self.seen.insert(r.signature.clone()))
+                .map(|r| SignatureRecord {
+                    signature: r.signature,
+                    slot: r.slot,
+                    slot_idx: r.slot_idx,
+                    err: r.err,
+                    memo: r.memo,
+                    block_time: r.block_time,
+                }),
+        );
+    }
+}
+
+struct Read {
+    deadline: Instant,
+    epoch: u64,
+}
+impl Read {
+    fn check(&self) -> ProcessingResult<()> {
+        if Instant::now() >= self.deadline {
+            return Err(ProcessingError::timeout_msg("disk cache deadline exceeded"));
+        }
+        Ok(())
+    }
+}
+impl DiskCache {
+    fn read(&self) -> Option<Read> {
+        self.ready().then(|| Read {
+            deadline: Instant::now() + self.inner.cfg.query_timeout,
+            epoch: self.inner.key_index.epoch(),
+        })
+    }
+    fn valid_read(&self, read: &Read) -> bool {
+        self.ready() && read.epoch == self.inner.key_index.epoch()
+    }
+    fn scoped_client(
+        &self,
+        base: &ClickHouseClient,
+        partition: u64,
+        read: &Read,
+    ) -> ClickHouseClient {
+        let mut client = base.clone();
+        client.cache_partition = Some((self.inner.cfg.partition_slots, partition));
+        client.query_timeout = read.deadline.saturating_duration_since(Instant::now());
+        client
+    }
+    fn key_span(&self) -> Option<(u64, u64)> {
+        self.inner
+            .coverage
+            .read()
+            .expect("coverage lock")
+            .covered_span()
+    }
+    fn partitions(
+        &self,
+        floor: u64,
+        tip: u64,
+        order: SortOrder,
+    ) -> impl Iterator<Item = u64> + use<> {
+        let width = self.inner.cfg.partition_slots;
+        let mut range = (floor / width..=tip / width).filter(move |_| floor <= tip);
+        std::iter::from_fn(move || match order {
+            SortOrder::Asc => range.next(),
+            SortOrder::Desc => range.next_back(),
+        })
+    }
+    fn candidate(&self, partition: u64, families: &[Family], key: &[u8]) -> bool {
+        let candidate = self.inner.key_index.may_contain(partition, families, key);
+        crate::metrics::disk_cache_read(
+            "key_partition",
+            if candidate { "probed" } else { "skipped" },
+        );
+        candidate
+    }
+    async fn attempt<T>(
+        &self,
+        operation: &'static str,
+        read: &Read,
+        future: impl Future<Output = ProcessingResult<Option<T>>>,
+    ) -> Option<T> {
+        let started = Instant::now();
+        let result = tokio::time::timeout_at(read.deadline, future).await;
+        let (value, outcome) = match result {
+            Ok(Ok(Some(value))) if self.valid_read(read) => (Some(value), "hit"),
+            Ok(Ok(_)) => (None, "miss"),
+            Ok(Err(ProcessingError::Timeout { .. })) => (None, "timeout"),
+            Ok(Err(ProcessingError::Database { context, .. }))
+                if context.contains("TIMEOUT_EXCEEDED") =>
+            {
+                (None, "timeout")
+            }
+            Ok(Err(_)) => (None, "error"),
+            Err(_) => (None, "timeout"),
+        };
+        crate::metrics::disk_cache_read(operation, outcome);
+        crate::metrics::disk_cache_key_seconds(operation, outcome, started.elapsed().as_secs_f64());
+        value
+    }
+    async fn find_position(
+        &self,
+        signature: Signature,
+        read: &Read,
+    ) -> ProcessingResult<Option<SignatureSlot>> {
+        let Some((floor, tip)) = self.key_span() else {
+            return Ok(None);
+        };
+        let base = self.query_client();
+        for partition in self.partitions(floor, tip, SortOrder::Desc) {
+            read.check()?;
+            if !self.candidate(partition, &[Family::Signature], signature.as_ref()) {
+                continue;
+            }
+            let client = self.scoped_client(&base, partition, read);
+            if let (Some(position), _) = client.get_signature_slot(&signature.to_string()).await? {
+                return Ok(self.covers_slot(position.slot).then_some(position));
+            }
+        }
+        Ok(None)
+    }
+    pub(crate) async fn signature_position(&self, signature: Signature) -> Option<SignatureSlot> {
+        let read = self.read()?;
+        self.attempt(
+            "signature_position",
+            &read,
+            self.find_position(signature, &read),
+        )
+        .await
+    }
+    pub(crate) async fn get_tx(&self, signature: Signature) -> Option<StoredTransactionRecord> {
+        let read = self.read()?;
+        self.attempt("get_tx", &read, async {
+            let Some(position) = self.find_position(signature, &read).await? else {
+                return Ok(None);
+            };
+            let client = self.scoped_client(
+                &self.query_client(),
+                position.slot / self.inner.cfg.partition_slots,
+                &read,
+            );
+            let (record, _) = client
+                .get_transaction_by_signature_and_slot(&signature.to_string(), position.slot)
+                .await?;
+            Ok(record.filter(|record| self.covers_slot(record.slot)))
+        })
+        .await
+    }
+    pub(crate) async fn get_sig_statuses(
+        &self,
+        signatures: Vec<Signature>,
+    ) -> Vec<Option<DiskSigStatus>> {
+        let Some(read) = self.read() else {
+            return vec![None; signatures.len()];
+        };
+        let mut found = HashMap::new();
+        let result = self
+            .attempt("signature_statuses", &read, async {
+                self.find_statuses(&signatures, &read, &mut found).await?;
+                Ok(found.values().any(Option::is_some).then_some(()))
+            })
+            .await;
+        // Retain independently validated results after a timeout, but never after invalidation.
+        if result.is_none() && !self.valid_read(&read) {
+            found.clear();
+        }
+        signatures
+            .iter()
+            .map(|signature| found.get(&signature.to_string()).cloned().flatten())
+            .collect()
+    }
+    async fn find_statuses(
+        &self,
+        signatures: &[Signature],
+        read: &Read,
+        found: &mut HashMap<String, Option<DiskSigStatus>>,
+    ) -> ProcessingResult<()> {
+        let Some((floor, tip)) = self.key_span() else {
+            return Ok(());
+        };
+        let base = self.query_client();
+        for partition in self.partitions(floor, tip, SortOrder::Desc) {
+            read.check()?;
+            let pending: Vec<_> = signatures
+                .iter()
+                .filter(|s| !found.contains_key(&s.to_string()))
+                .filter(|s| self.candidate(partition, &[Family::Signature], s.as_ref()))
+                .map(ToString::to_string)
+                .collect();
+            if pending.is_empty() {
+                continue;
+            }
+            let client = self.scoped_client(&base, partition, read);
+            let (records, _) = client.get_signature_statuses(&pending).await?;
+            for record in records {
+                found.insert(
+                    record.signature,
+                    self.covers_slot(record.slot).then_some(DiskSigStatus {
+                        slot: record.slot,
+                        err: record.err.and_then(|e| serde_json::to_string(&e).ok()),
+                    }),
+                );
+            }
+        }
+        Ok(())
+    }
+    fn address_families(&self, address: &Pubkey, tokens: TokenAccountsFilter) -> Vec<Family> {
+        if self.query_client().is_gsfa_hot_address(address) {
+            return vec![Family::HotAddress];
+        }
+        if tokens == TokenAccountsFilter::None {
+            vec![Family::Address]
+        } else {
+            vec![Family::Address, Family::Owner]
+        }
+    }
+    pub(crate) async fn signatures_for_address(
+        &self,
+        address: Pubkey,
+        before: Option<SlotBoundary>,
+        until: Option<SlotBoundary>,
+        limit: usize,
+    ) -> Option<DiskGsfaPage> {
+        let read = self.read()?;
+        let (floor, tip) = self.tip_span()?;
+        let (until, floor_effective) = clamp_until_to_floor(until, floor);
+        let base = self.query_client_for_address(&address, TokenAccountsFilter::None)?;
+        let families = self.address_families(&address, TokenAccountsFilter::None);
+        self.attempt("signatures_for_address", &read, async {
+            let mut records = Vec::new();
+            let (scan_floor, scan_tip) = gsfa_window((floor, tip), before, until);
+            for partition in self.partitions(scan_floor, scan_tip, SortOrder::Desc) {
+                read.check()?;
+                if records.len() >= limit {
+                    break;
+                }
+                if !self.candidate(partition, &families, address.as_ref()) {
+                    continue;
+                }
+                let client = self.scoped_client(&base, partition, &read);
+                let (page, _) = client
+                    .get_signatures_for_address_with_positions(
+                        &address.to_string(),
+                        (limit - records.len()) as u64,
+                        before,
+                        until,
+                    )
+                    .await?;
+                records.extend(page);
+            }
+            let reached_floor = records.len() < limit && floor_effective;
+            Ok(self.address_page(records, floor, tip, reached_floor, false))
+        })
+        .await
+    }
+    pub(crate) async fn transactions_for_address(
+        &self,
+        address: Pubkey,
+        query: DiskTfaQuery,
+    ) -> Option<DiskGsfaPage> {
+        let read = self.read()?;
+        let (floor, tip) = self.tip_span()?;
+        let base = self.query_client_for_address(&address, query.token_accounts)?;
+        self.attempt("transactions_for_address", &read, async {
+            let records = self
+                .address_transactions(&base, address, &query, (floor, tip), &read)
+                .await?;
+            let exhausted = records.len() < query.limit;
+            let reached_floor = exhausted
+                && query.sort_order == SortOrder::Desc
+                && lower_bound_reaches_floor(&query, floor);
+            let reached_tip = exhausted
+                && query.sort_order == SortOrder::Asc
+                && upper_bound_reaches_tip(&query, tip);
+            Ok(self.address_page(records, floor, tip, reached_floor, reached_tip))
+        })
+        .await
+    }
+    async fn address_transactions(
+        &self,
+        base: &ClickHouseClient,
+        address: Pubkey,
+        query: &DiskTfaQuery,
+        (floor, tip): (u64, u64),
+        read: &Read,
+    ) -> ProcessingResult<Vec<SignatureRecord>> {
+        let mut slot_filter = query.slot_filter.clone().unwrap_or_default();
+        slot_filter.gte = Some(slot_filter.gte.map_or(floor, |v| v.max(floor)));
+        slot_filter.lte = Some(slot_filter.lte.map_or(tip, |v| v.min(tip)));
+        let mut q = TransactionsForAddressQuery {
+            address: address.to_string(),
+            limit: query.limit as u64,
+            sort_order: query.sort_order,
+            pagination: query.pagination.map(|p| PaginationToken::SlotIndex {
+                slot: p.slot,
+                idx: p.slot_idx,
+            }),
+            resolved_pagination: query.pagination,
+            slot_filter: Some(slot_filter),
+            block_time_filter: query.block_time_filter.clone(),
+            signature_filter: None,
+            resolved_signature_filter: query.signature_filter.clone(),
+            status: query.status,
+            token_accounts: query.token_accounts,
+        };
+        let families = self.address_families(&address, query.token_accounts);
+        let mut rows = AddressRows::default();
+        let (scan_floor, scan_tip) = tfa_window((floor, tip), &q);
+        for partition in self.partitions(scan_floor, scan_tip, query.sort_order) {
+            read.check()?;
+            if rows.records.len() >= query.limit {
+                break;
+            }
+            if !self.candidate(partition, &families, address.as_ref()) {
+                continue;
+            }
+            let client = self.scoped_client(base, partition, read);
+            self.address_partition(&client, &mut q, &mut rows, query.limit, read)
+                .await?;
+        }
+        Ok(rows.records)
+    }
+    async fn address_partition(
+        &self,
+        client: &ClickHouseClient,
+        query: &mut TransactionsForAddressQuery,
+        rows: &mut AddressRows,
+        limit: usize,
+        read: &Read,
+    ) -> ProcessingResult<()> {
+        while rows.records.len() < limit {
+            read.check()?;
+            query.limit = (limit - rows.records.len()) as u64;
+            let mut client = client.clone();
+            client.query_timeout = read.deadline.saturating_duration_since(Instant::now());
+            let (page, _) = client
+                .get_transactions_for_address_signatures(query)
+                .await?;
+            let exhausted = page.len() < query.limit as usize;
+            let last = page.last().map(|r| SignatureSlot {
+                slot: r.slot,
+                slot_idx: r.slot_idx,
+            });
+            rows.append(page);
+            if exhausted {
+                break;
+            }
+            if let Some(last) = last {
+                query.pagination = Some(PaginationToken::SlotIndex {
+                    slot: last.slot,
+                    idx: last.slot_idx,
+                });
+                query.resolved_pagination = Some(last);
+            }
+        }
+        Ok(())
+    }
+    fn address_page(
+        &self,
+        records: Vec<SignatureRecord>,
+        floor: u64,
+        tip: u64,
+        reached_floor: bool,
+        reached_tip: bool,
+    ) -> Option<DiskGsfaPage> {
+        let (current_floor, current_tip) = self.tip_span()?;
+        if current_floor > floor
+            || current_tip < tip
+            || records.iter().any(|r| !self.covers_slot(r.slot))
+        {
+            return None;
+        }
+        Some(DiskGsfaPage {
+            records,
+            floor,
+            tip,
+            reached_floor,
+            reached_tip,
+        })
+    }
+}
+
+#[cfg(test)]
+mod window_tests {
+    use super::*;
+    use crate::clickhouse::{ResolvedSignatureFilter, TransactionStatusFilter};
+
+    #[test]
+    fn gsfa_cursors_skip_newer_partitions_and_preserve_boundary_slots() {
+        let p = SlotBoundary::Position(SignatureSlot {
+            slot: 25,
+            slot_idx: 3,
+        });
+        assert_eq!(gsfa_window((10, 99), Some(p), Some(p)), (25, 25));
+        assert_eq!(
+            gsfa_window((10, 99), Some(SlotBoundary::Slot(25)), None),
+            (10, 24)
+        );
+        assert_eq!(
+            gsfa_window((10, 99), None, Some(SlotBoundary::Slot(25))),
+            (26, 99)
+        );
+    }
+
+    #[test]
+    fn numeric_bounds_intersect_including_contradictions() {
+        let mut f = NumericFilter {
+            eq: Some(25),
+            ..Default::default()
+        };
+        assert_eq!(numeric_window((10, 99), &f), (25, 25));
+        f.gt = Some(25);
+        assert_eq!(numeric_window((10, 99), &f), (26, 25));
+        f.eq = None;
+        f.lt = Some(30);
+        assert_eq!(numeric_window((10, 99), &f), (26, 29));
+    }
+
+    #[test]
+    fn tfa_cursor_direction_and_signature_bounds_intersect() {
+        let position = SignatureSlot {
+            slot: 25,
+            slot_idx: 3,
+        };
+        let mut q = TransactionsForAddressQuery {
+            address: String::new(),
+            limit: 100,
+            sort_order: SortOrder::Desc,
+            pagination: None,
+            resolved_pagination: Some(position),
+            slot_filter: None,
+            block_time_filter: None,
+            signature_filter: None,
+            resolved_signature_filter: None,
+            status: TransactionStatusFilter::Any,
+            token_accounts: TokenAccountsFilter::None,
+        };
+        assert_eq!(tfa_window((10, 99), &q), (10, 25));
+        q.sort_order = SortOrder::Asc;
+        assert_eq!(tfa_window((10, 99), &q), (25, 99));
+        q.resolved_signature_filter = Some(ResolvedSignatureFilter {
+            lt: Some(position),
+            ..Default::default()
+        });
+        assert_eq!(tfa_window((10, 99), &q), (25, 25));
+    }
+}

--- a/crates/superbank-rpc/src/disk_cache/key_tests.rs
+++ b/crates/superbank-rpc/src/disk_cache/key_tests.rs
@@ -204,11 +204,12 @@ async fn assert_migration(
     execute(
         client,
         &format!(
-            "INSERT INTO {}._cache_meta VALUES ('format_version','4',now64(3)+INTERVAL 1 SECOND)",
+            "ALTER TABLE {}._cache_meta UPDATE value='4' WHERE key='format_version' SETTINGS mutations_sync=2",
             cfg.database
         ),
     )
     .await;
+    assert_resumable_rebuild(&cache, &cfg).await;
     let reopened = DiskCache::open(cfg.clone(), source).await.unwrap();
     let count = reopened
         .inner
@@ -230,9 +231,85 @@ async fn assert_migration(
     .unwrap();
     assert!(reopened.covers_slot(15));
     assert_eq!(reopened.get_tx(signature(15)).await.unwrap().slot, 15);
+    let restarted = DiskCache::open(cfg.clone(), source).await.unwrap();
+    assert_eq!(restarted.get_tx(signature(15)).await.unwrap().slot, 15);
+    execute(
+        client,
+        &format!("DROP TABLE {}._cache_meta SYNC", cfg.database),
+    )
+    .await;
+    let error = DiskCache::open(cfg.clone(), source)
+        .await
+        .err()
+        .expect("missing marker must fail closed");
+    assert!(error.to_string().contains("ownership check failed"));
+    assert_eq!(restarted.get_tx(signature(15)).await.unwrap().slot, 15);
     drop(cache);
     execute(client, &format!("DROP DATABASE {} SYNC", cfg.database)).await;
 }
+async fn assert_resumable_rebuild(cache: &DiskCache, cfg: &DiskCacheConfig) {
+    let mut admin = cache.inner.admin.clone();
+    admin.client = admin.client.with_setting("max_table_size_to_drop", "1");
+    let table = format!("{}.gsfa", cfg.database);
+    let error = admin
+        .client
+        .query(&format!("DROP TABLE {table} SYNC"))
+        .execute()
+        .await
+        .unwrap_err();
+    assert!(
+        error
+            .to_string()
+            .contains("TABLE_SIZE_EXCEEDS_MAX_DROP_SIZE_LIMIT")
+    );
+    let marker_query = format!(
+        "SELECT toString(uuid) FROM system.tables WHERE database='{}' AND name='_cache_meta'",
+        cfg.database
+    );
+    let marker = admin
+        .client
+        .query(&marker_query)
+        .fetch_one::<String>()
+        .await
+        .unwrap();
+    // Fail replacement DDL after deletion, then retry with the real schema.
+    let mut broken = (*cache.source_schema()).clone();
+    broken.tables.clear();
+    assert!(
+        schema::initialize_cache_schema(&admin, &broken, &cfg.schema_config())
+            .await
+            .is_err()
+    );
+    assert_eq!(
+        admin
+            .client
+            .query(&marker_query)
+            .fetch_one::<String>()
+            .await
+            .unwrap(),
+        marker
+    );
+    assert!(
+        schema::initialize_cache_schema(&admin, &cache.source_schema(), &cfg.schema_config())
+            .await
+            .unwrap()
+    );
+    assert!(
+        !schema::initialize_cache_schema(&admin, &cache.source_schema(), &cfg.schema_config())
+            .await
+            .unwrap()
+    );
+    assert_eq!(
+        admin
+            .client
+            .query(&marker_query)
+            .fetch_one::<String>()
+            .await
+            .unwrap(),
+        marker
+    );
+}
+
 async fn assert_pruning(client: &clickhouse::Client, database: &str) {
     let query = format!(
         "EXPLAIN indexes=1 SELECT slot FROM {database}.signatures PREWHERE signature=toFixedString('sig-15',64) AND intDiv(slot,10)=1"

--- a/crates/superbank-rpc/src/disk_cache/key_tests.rs
+++ b/crates/superbank-rpc/src/disk_cache/key_tests.rs
@@ -1,0 +1,420 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Opt-in integration against a disposable, loopback ClickHouse server.
+use super::*;
+use crate::clickhouse::{NumericFilter, SortOrder, TransactionStatusFilter};
+use crate::solana_sdk::{pubkey::Pubkey, signature::Signature};
+
+fn signature(slot: u64) -> Signature {
+    let mut key = [0; 64];
+    let value = format!("sig-{slot}");
+    key[..value.len()].copy_from_slice(value.as_bytes());
+    Signature::from(key)
+}
+fn address(value: &str) -> Pubkey {
+    let mut key = [0; 32];
+    key[..value.len()].copy_from_slice(value.as_bytes());
+    Pubkey::from(key)
+}
+pub(super) fn config(url: String, database: String) -> DiskCacheConfig {
+    DiskCacheConfig {
+        url,
+        database,
+        username: "default".into(),
+        password: String::new(),
+        required: false,
+        retain_slots: 40,
+        max_bytes: 0,
+        partition_slots: 10,
+        query_timeout: Duration::from_secs(2),
+        key_index_max_memory_bytes: 128 * 1024 * 1024,
+        query_concurrency: 2,
+        query_max_threads: 2,
+        schema_check_interval: Duration::from_secs(300),
+        memory_blocks_metadata: false,
+        memory_retain_slots: None,
+        memory_max_bytes: None,
+        block_index: None,
+    }
+}
+async fn execute(client: &clickhouse::Client, sql: &str) {
+    client
+        .query(sql)
+        .execute()
+        .await
+        .unwrap_or_else(|e| panic!("{e}: {sql}"));
+}
+fn statements(sql: &str) -> Vec<&str> {
+    let mut quote = false;
+    let mut escaped = false;
+    let mut start = 0;
+    let mut result = Vec::new();
+    for (offset, ch) in sql.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match ch {
+            '\\' if quote => escaped = true,
+            '\'' => quote = !quote,
+            ';' if !quote => {
+                result.push(&sql[start..offset]);
+                start = offset + 1;
+            }
+            _ => {}
+        }
+    }
+    if !sql[start..].trim().is_empty() {
+        result.push(&sql[start..]);
+    }
+    result
+}
+async fn fixture(client: &clickhouse::Client, database: &str) {
+    execute(client, &format!("CREATE DATABASE {database}")).await;
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../ddl/local");
+    for table in [
+        "transactions",
+        "blocks_metadata",
+        "signatures",
+        "gsfa",
+        "gsfa_hot",
+        "token_owner_activity",
+    ] {
+        let sql = std::fs::read_to_string(root.join(format!("{table}.sql")))
+            .unwrap()
+            .replace("default.", &format!("{database}."));
+        let sql = if table == "gsfa_hot" {
+            sql.replace("% 32", "% 64").replace(
+                "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                &address("address").to_string(),
+            )
+        } else {
+            sql
+        };
+        for statement in statements(&sql) {
+            execute(client, statement).await;
+        }
+    }
+    execute(client, &format!("INSERT INTO {database}.blocks_metadata (slot,parent_slot,blockhash,parent_blockhash,block_time,block_height,executed_transaction_count) SELECT number,number-1,toFixedString('hash',32),toFixedString('hash',32),1700000000+number,number,1 FROM numbers(10,40)")).await;
+}
+async fn insert_transactions(client: &clickhouse::Client, database: &str) {
+    execute(client, &format!("INSERT INTO {database}.transactions (signature, slot, slot_idx, tx_signatures, tx_account_keys, tx_num_required_signatures, meta_status_ok, meta_post_token_balances_present, meta_post_token_account_index, meta_post_token_mint, meta_post_token_owner, meta_post_token_program_id, meta_post_token_amount, meta_post_token_decimals, meta_post_token_ui_amount, meta_post_token_ui_amount_string) SELECT toFixedString(concat('sig-', toString(number)),64), number, 0, [toFixedString(concat('sig-', toString(number)),64)], [toFixedString('address',32)], 1, 1, 1, [0], [toFixedString('mint',32)], [toFixedString('owner',32)], [toFixedString('program',32)], ['1'], [0], [1.0], ['1'] FROM numbers(10,40)")).await;
+}
+fn tfa(order: SortOrder, tokens: TokenAccountsFilter) -> index::DiskTfaQuery {
+    index::DiskTfaQuery {
+        limit: 100,
+        sort_order: order,
+        pagination: None,
+        slot_filter: Some(NumericFilter::default()),
+        block_time_filter: None,
+        signature_filter: None,
+        status: TransactionStatusFilter::Any,
+        token_accounts: tokens,
+    }
+}
+
+async fn assert_pagination(cache: &DiskCache) {
+    for order in [SortOrder::Asc, SortOrder::Desc] {
+        let mut query = tfa(order, TokenAccountsFilter::All);
+        query.limit = 7;
+        let mut slots = Vec::new();
+        loop {
+            let page = cache
+                .transactions_for_address(address("owner"), query.clone())
+                .await
+                .unwrap();
+            let Some(last) = page.records.last() else {
+                break;
+            };
+            query.pagination = Some(crate::clickhouse::SignatureSlot {
+                slot: last.slot,
+                slot_idx: last.slot_idx,
+            });
+            slots.extend(page.records.iter().map(|r| r.slot));
+            if page.records.len() < query.limit {
+                break;
+            }
+        }
+        let mut expected: Vec<_> = (10..50).collect();
+        if order == SortOrder::Desc {
+            expected.reverse();
+        }
+        assert_eq!(slots, expected);
+    }
+}
+async fn assert_cross_partition_duplicates(client: &clickhouse::Client, cache: &DiskCache) {
+    let _mutation = cache.begin_fill(39, 39);
+    execute(client, &format!("INSERT INTO {}.transactions (signature,slot,slot_idx,tx_account_keys,meta_status_ok) SELECT signature,39,0,tx_account_keys,1 FROM {}.transactions WHERE slot=49 LIMIT 1", cache.inner.cfg.database,cache.inner.cfg.database)).await;
+    cache
+        .publish_range_coverage(vec![(39, SlotStatus::Covered { tx_count: 2 })])
+        .await
+        .unwrap();
+    drop(_mutation);
+    let mut query = tfa(SortOrder::Desc, TokenAccountsFilter::None);
+    query.limit = 15;
+    let page = cache
+        .transactions_for_address(address("address"), query)
+        .await
+        .unwrap();
+    assert_eq!(
+        page.records.iter().map(|r| r.slot).collect::<Vec<_>>(),
+        (35..50).rev().collect::<Vec<_>>()
+    );
+}
+
+async fn wait_for_query(client: &clickhouse::Client, id: &str, running: bool) {
+    for _ in 0..50 {
+        let count = client
+            .query("SELECT count() FROM system.processes WHERE query_id=?")
+            .bind(id)
+            .fetch_one::<u64>()
+            .await
+            .unwrap();
+        if (count > 0) == running {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("query running state did not become {running}");
+}
+async fn assert_cancellation(client: &clickhouse::Client, cache: &DiskCache) {
+    let mut lookup = cache.query_client();
+    lookup.cache_partition = Some((10, 1));
+    let (sql,id,cleanup)=lookup.annotate_lookup_query("SELECT sum(cityHash64(number)) FROM numbers(1000000000000) SETTINGS max_execution_time=2,max_threads=1".into(),"test_cache_cancel");
+    let id = id.unwrap();
+    let query_client = lookup.client.clone().with_setting("query_id", id.clone());
+    let task = tokio::spawn(async move {
+        let _cleanup = cleanup;
+        query_client.query(&sql).execute().await
+    });
+    wait_for_query(client, &id, true).await;
+    task.abort();
+    let _ = task.await;
+    wait_for_query(client, &id, false).await;
+}
+
+async fn assert_migration(
+    client: &clickhouse::Client,
+    source: &ClickHouseClient,
+    cfg: &DiskCacheConfig,
+) {
+    let mut cfg = cfg.clone();
+    cfg.database.push_str("_migration");
+    let cache = DiskCache::open(cfg.clone(), source).await.unwrap();
+    insert_transactions(client, &cfg.database).await;
+    execute(
+        client,
+        &format!(
+            "INSERT INTO {}._cache_meta VALUES ('format_version','4',now64(3)+INTERVAL 1 SECOND)",
+            cfg.database
+        ),
+    )
+    .await;
+    let reopened = DiskCache::open(cfg.clone(), source).await.unwrap();
+    let count = reopened
+        .inner
+        .local
+        .client
+        .query("SELECT count() AS count FROM signatures")
+        .fetch_one::<u64>()
+        .await
+        .unwrap();
+    assert_eq!(count, 0);
+    assert!(reopened.tip_span().is_none());
+    filler::fill_range(
+        &reopened,
+        source,
+        filler::SlotRange { start: 10, end: 19 },
+        &filler::FillerConfig::default(),
+    )
+    .await
+    .unwrap();
+    assert!(reopened.covers_slot(15));
+    assert_eq!(reopened.get_tx(signature(15)).await.unwrap().slot, 15);
+    drop(cache);
+    execute(client, &format!("DROP DATABASE {} SYNC", cfg.database)).await;
+}
+async fn assert_pruning(client: &clickhouse::Client, database: &str) {
+    let query = format!(
+        "EXPLAIN indexes=1 SELECT slot FROM {database}.signatures PREWHERE signature=toFixedString('sig-15',64) AND intDiv(slot,10)=1"
+    );
+    let explain = client
+        .query(&query)
+        .fetch_all::<String>()
+        .await
+        .unwrap()
+        .join("\n");
+    assert!(explain.contains("Parts: 1/4"), "{explain}");
+    let ddl = client
+        .query(&format!("SHOW CREATE TABLE {database}.signatures"))
+        .fetch_one::<String>()
+        .await
+        .unwrap();
+    assert!(ddl.contains("slot DESC"), "{ddl}");
+    assert!(ddl.contains("index_granularity = 512"), "{ddl}");
+}
+
+#[tokio::test]
+#[ignore = "requires disposable ClickHouse: DISK_CACHE_TEST_URL=http://127.0.0.1:18123"]
+async fn key_routing_clickhouse_integration() {
+    let url = std::env::var("DISK_CACHE_TEST_URL").expect("explicit disposable ClickHouse URL");
+    assert!(url.starts_with("http://127.0.0.1:"));
+    let database = format!("test_key_router_{}", now_version());
+    let cache_database = format!("{database}_cache");
+    let client = clickhouse::Client::default()
+        .with_url(&url)
+        .with_user("default");
+    fixture(&client, &database).await;
+    insert_transactions(&client, &database).await;
+    let mut source = ClickHouseClient::new(
+        &url,
+        &database,
+        "default",
+        "",
+        ClickHouseClientOptions::new(
+            RoutingPolicy {
+                transport: RoutingTransport::Http,
+                scope: RoutingScope::Distributed,
+            },
+            None,
+            vec![address("address").to_string()],
+            format!("{database}.gsfa_hot"),
+            format!("{database}.gsfa_hot"),
+        ),
+    );
+    source.use_table_names(ClickHouseTableNames::in_database(&database));
+    let cfg = config(url, cache_database.clone());
+    let cache = DiskCache::open(cfg.clone(), &source).await.unwrap();
+    insert_transactions(&client, &cache_database).await;
+    cache
+        .publish_range_coverage(
+            (10..50)
+                .map(|slot| (slot, SlotStatus::Covered { tx_count: 1 }))
+                .collect(),
+        )
+        .await
+        .unwrap();
+    cache.build_key_indexes().await;
+    assert!(!cache.inner.key_index.may_contain(
+        1,
+        &[key_index::Family::Signature],
+        signature(35).as_ref()
+    ));
+    assert!(cache.inner.key_index.may_contain(
+        1,
+        &[key_index::Family::Signature],
+        signature(15).as_ref()
+    ));
+    assert_eq!(
+        cache.signature_position(signature(15)).await.unwrap().slot,
+        15
+    );
+    assert_eq!(cache.get_tx(signature(15)).await.unwrap().slot, 15);
+    assert!(cache.signature_position(signature(500)).await.is_none());
+    let statuses = cache
+        .get_sig_statuses(vec![
+            signature(15),
+            signature(500),
+            signature(15),
+            signature(45),
+        ])
+        .await;
+    assert_eq!(
+        statuses
+            .iter()
+            .map(|s| s.as_ref().map(|s| s.slot))
+            .collect::<Vec<_>>(),
+        [Some(15), None, Some(15), Some(45)]
+    );
+    let page = cache
+        .signatures_for_address(address("address"), None, None, 100)
+        .await
+        .unwrap();
+    assert_eq!(
+        page.records.iter().map(|r| r.slot).collect::<Vec<_>>(),
+        (10..50).rev().collect::<Vec<_>>()
+    );
+    for (key, tokens) in [
+        ("address", TokenAccountsFilter::None),
+        ("owner", TokenAccountsFilter::All),
+        ("owner", TokenAccountsFilter::BalanceChanged),
+    ] {
+        let page = cache
+            .transactions_for_address(address(key), tfa(SortOrder::Asc, tokens))
+            .await
+            .unwrap();
+        assert_eq!(
+            page.records.iter().map(|r| r.slot).collect::<Vec<_>>(),
+            (10..50).collect::<Vec<_>>()
+        );
+    }
+    let mut scoped = cache.query_client();
+    scoped.cache_partition = Some((10, 2));
+    assert!(
+        scoped
+            .get_signature_slot(&signature(15).to_string())
+            .await
+            .unwrap()
+            .0
+            .is_none()
+    );
+    assert_eq!(
+        cache
+            .query_client()
+            .get_signature_slot(&signature(15).to_string())
+            .await
+            .unwrap()
+            .0
+            .unwrap()
+            .slot,
+        15
+    );
+    assert_pagination(&cache).await;
+    assert_pruning(&client, &cache_database).await;
+    assert_migration(&client, &source, &cfg).await;
+    assert_cancellation(&client, &cache).await;
+    assert_cross_partition_duplicates(&client, &cache).await;
+    cache.poison_slot(15).await;
+    assert!(cache.get_tx(signature(15)).await.is_none());
+    assert!(cache.inner.key_index.may_contain(
+        1,
+        &[key_index::Family::Signature],
+        signature(500).as_ref()
+    ));
+    let mut reopened_cfg = cfg;
+    reopened_cfg.query_timeout = Duration::from_millis(50);
+    let reopened = DiskCache::open(reopened_cfg, &source).await.unwrap();
+    assert!(
+        reopened
+            .query_client()
+            .is_gsfa_hot_address(&address("address"))
+    );
+    let hot_page = reopened
+        .signatures_for_address(address("address"), None, None, 3)
+        .await
+        .unwrap();
+    assert_eq!(
+        hot_page
+            .records
+            .iter()
+            .map(|row| row.slot)
+            .collect::<Vec<_>>(),
+        [49, 48, 47]
+    );
+    let _permits = reopened
+        .inner
+        .local
+        .http_query_sem
+        .acquire_many(2)
+        .await
+        .unwrap();
+    let started = std::time::Instant::now();
+    assert!(reopened.get_tx(signature(45)).await.is_none());
+    assert!(started.elapsed() < Duration::from_millis(200));
+    drop(_permits);
+    if std::env::var_os("DISK_CACHE_TEST_KEEP").is_some() {
+        eprintln!("Kept source database {database} and cache {cache_database}");
+        return;
+    }
+    execute(&client, &format!("DROP DATABASE {cache_database} SYNC")).await;
+    execute(&client, &format!("DROP DATABASE {database} SYNC")).await;
+}

--- a/crates/superbank-rpc/src/disk_cache/mod.rs
+++ b/crates/superbank-rpc/src/disk_cache/mod.rs
@@ -21,9 +21,8 @@ use tracing::{info, warn};
 
 use crate::clickhouse::{
     BlockMetadataRecord, ClickHouseClient, ClickHouseClientOptions, ClickHouseTableNames,
-    PaginationToken, QueryCacheConfig, RoutingPolicy, RoutingScope, RoutingTransport,
-    SignatureRecord, SlotBoundary, SortOrder, StoredBlockPayload, StoredBlockRecord,
-    StoredTransactionRecord, TokenAccountsFilter, TransactionsForAddressQuery,
+    QueryCacheConfig, RoutingPolicy, RoutingScope, RoutingTransport, SignatureRecord, SlotBoundary,
+    StoredBlockPayload, StoredBlockRecord, StoredTransactionRecord, TokenAccountsFilter,
 };
 use crate::config::ClickHouseStartupTableCheck;
 use crate::solana_sdk;
@@ -32,7 +31,12 @@ pub(crate) mod block_index;
 pub(crate) mod coverage;
 pub(crate) mod filler;
 pub(crate) mod index;
+pub(crate) mod key_index;
+mod key_reads;
+#[cfg(test)]
+mod key_tests;
 pub(crate) mod schema;
+mod schema_settings;
 
 pub(crate) use block_index::{BlockIndexConfig, BlockTimeLookup};
 use coverage::CoverageMap;
@@ -70,6 +74,9 @@ pub(crate) struct DiskCacheConfig {
     pub(crate) required: bool,
     pub(crate) retain_slots: u64,
     pub(crate) max_bytes: u64,
+    pub(crate) key_index_max_memory_bytes: u64,
+    pub(crate) query_concurrency: usize,
+    pub(crate) query_max_threads: u64,
     pub(crate) partition_slots: u64,
     pub(crate) query_timeout: Duration,
     pub(crate) schema_check_interval: Duration,
@@ -217,6 +224,7 @@ pub(crate) struct DiskCacheInner {
     pub(crate) schema: RwLock<Arc<SourceSchemaSnapshot>>,
     coverage: RwLock<CoverageMap>,
     block_index: Option<Arc<block_index::BlockIndex>>,
+    key_index: Arc<key_index::KeyIndex>,
     min_retained: AtomicU64,
     ready: AtomicBool,
 }
@@ -269,10 +277,14 @@ impl DiskCache {
             )
             .with_query_timeout(cfg.query_timeout)
             .with_query_cache_config(QueryCacheConfig::default())
-            .with_http_concurrency(64)
+            .with_http_concurrency(cfg.query_concurrency)
             .with_startup_table_check(ClickHouseStartupTableCheck::Exists),
         );
         local.use_table_names(table_names);
+        local.client = local
+            .client
+            .clone()
+            .with_setting("max_threads", cfg.query_max_threads.to_string());
         local.set_blocks_metadata_supports_prewhere(!cfg.memory_blocks_metadata);
 
         let schema_config = cfg.schema_config();
@@ -292,7 +304,9 @@ impl DiskCache {
             None => None,
         };
 
+        let key_index = Arc::new(key_index::KeyIndex::new(&cfg));
         let inner = Arc::new(DiskCacheInner {
+            key_index,
             cfg,
             admin,
             query_client: RwLock::new(local.clone()),
@@ -439,6 +453,8 @@ impl DiskCache {
         }
 
         self.set_ready(false);
+        self.inner.key_index.invalidate_reads();
+        let _mutation = self.inner.key_index.mutation(0, u64::MAX);
         let result = async {
             schema::initialize_cache_schema(&self.inner.admin, &snapshot, &schema_config).await?;
             let mut query_client = self.inner.local.clone();
@@ -698,173 +714,6 @@ impl DiskCache {
         }
     }
 
-    pub(crate) async fn get_tx(
-        &self,
-        signature: solana_sdk::signature::Signature,
-    ) -> Option<StoredTransactionRecord> {
-        if !self.ready() {
-            return None;
-        }
-        let signature = signature.to_string();
-        let record = self
-            .inner
-            .local
-            .get_transaction_by_signature(&signature)
-            .await
-            .ok()
-            .and_then(|(record, _)| record)
-            .filter(|record| self.covers_slot(record.slot));
-        crate::metrics::disk_cache_read("get_tx", if record.is_some() { "hit" } else { "miss" });
-        record
-    }
-
-    pub(crate) async fn get_sig_statuses(
-        &self,
-        signatures: Vec<solana_sdk::signature::Signature>,
-    ) -> Vec<Option<DiskSigStatus>> {
-        if !self.ready() {
-            return vec![None; signatures.len()];
-        }
-        let encoded: Vec<String> = signatures.iter().map(ToString::to_string).collect();
-        let records = match self.query_client().get_signature_statuses(&encoded).await {
-            Ok((records, _)) => records,
-            Err(err) => {
-                warn!("disk cache: signature-status read failed: {err}");
-                return vec![None; signatures.len()];
-            }
-        };
-        let by_signature: HashMap<_, _> = records
-            .into_iter()
-            .filter(|record| self.covers_slot(record.slot))
-            .map(|record| {
-                let err = record
-                    .err
-                    .and_then(|value| serde_json::to_string(&value).ok());
-                (
-                    record.signature,
-                    DiskSigStatus {
-                        slot: record.slot,
-                        err,
-                    },
-                )
-            })
-            .collect();
-        encoded
-            .into_iter()
-            .map(|signature| by_signature.get(&signature).cloned())
-            .collect()
-    }
-
-    pub(crate) async fn signature_position(
-        &self,
-        signature: solana_sdk::signature::Signature,
-    ) -> Option<crate::clickhouse::SignatureSlot> {
-        if !self.ready() {
-            return None;
-        }
-        let signature = signature.to_string();
-        self.query_client()
-            .get_signature_slot(&signature)
-            .await
-            .ok()
-            .and_then(|(position, _)| position)
-            .filter(|position| self.covers_slot(position.slot))
-    }
-
-    pub(crate) async fn signatures_for_address(
-        &self,
-        address: solana_sdk::pubkey::Pubkey,
-        before: Option<SlotBoundary>,
-        until: Option<SlotBoundary>,
-        limit: usize,
-    ) -> Option<DiskGsfaPage> {
-        let (floor, tip) = self.tip_span()?;
-        let (until, floor_effective) = clamp_until_to_floor(until, floor);
-        let client = self.query_client_for_address(&address, TokenAccountsFilter::None)?;
-        let (records, _) = client
-            .get_signatures_for_address_with_positions(
-                &address.to_string(),
-                limit as u64,
-                before,
-                until,
-            )
-            .await
-            .ok()?;
-        let reached_floor = records.len() < limit && floor_effective;
-        crate::metrics::disk_cache_read(
-            "signatures_for_address",
-            if records.is_empty() && !reached_floor {
-                "miss"
-            } else {
-                "hit"
-            },
-        );
-        Some(DiskGsfaPage {
-            records,
-            reached_floor,
-            reached_tip: false,
-            floor,
-            tip,
-        })
-    }
-
-    pub(crate) async fn transactions_for_address(
-        &self,
-        address: solana_sdk::pubkey::Pubkey,
-        query: index::DiskTfaQuery,
-    ) -> Option<DiskGsfaPage> {
-        let (floor, tip) = self.tip_span()?;
-        let floor_effective = lower_bound_reaches_floor(&query, floor);
-        let tip_effective = upper_bound_reaches_tip(&query, tip);
-        let mut slot_filter = query.slot_filter.clone().unwrap_or_default();
-        slot_filter.gte = Some(slot_filter.gte.map_or(floor, |value| value.max(floor)));
-        slot_filter.lte = Some(slot_filter.lte.map_or(tip, |value| value.min(tip)));
-        let clickhouse_query = TransactionsForAddressQuery {
-            address: address.to_string(),
-            limit: query.limit as u64,
-            sort_order: query.sort_order,
-            pagination: query.pagination.map(|position| PaginationToken::SlotIndex {
-                slot: position.slot,
-                idx: position.slot_idx,
-            }),
-            resolved_pagination: query.pagination,
-            slot_filter: Some(slot_filter),
-            block_time_filter: query.block_time_filter,
-            signature_filter: None,
-            resolved_signature_filter: query.signature_filter,
-            status: query.status,
-            token_accounts: query.token_accounts,
-        };
-        let client = self.query_client_for_address(&address, query.token_accounts)?;
-        let (records, _) = client
-            .get_transactions_for_address_signatures(&clickhouse_query)
-            .await
-            .ok()?;
-        let records: Vec<SignatureRecord> = records
-            .into_iter()
-            .filter(|record| self.covers_slot(record.slot))
-            .map(|record| SignatureRecord {
-                signature: record.signature,
-                slot: record.slot,
-                slot_idx: record.slot_idx,
-                err: record.err,
-                memo: record.memo,
-                block_time: record.block_time,
-            })
-            .collect();
-        let reached_floor =
-            query.sort_order == SortOrder::Desc && records.len() < query.limit && floor_effective;
-        let reached_tip =
-            query.sort_order == SortOrder::Asc && records.len() < query.limit && tip_effective;
-        Some(DiskGsfaPage {
-            records,
-            reached_floor,
-            reached_tip,
-            floor,
-            tip,
-        })
-    }
-
     pub(crate) async fn get_txs_by_position(
         &self,
         positions: Vec<(u64, u32)>,
@@ -908,6 +757,7 @@ impl DiskCache {
                 return None;
             }
             client.gsfa_table = client.gsfa_hot_table.clone();
+            client.bucket_moduli.gsfa = client.bucket_moduli.gsfa_hot;
             client.gsfa_hot_pubkeys.clear();
         }
         Some(client)
@@ -943,6 +793,19 @@ impl DiskCache {
             }
         }
         Ok(())
+    }
+
+    fn begin_fill(&self, start: u64, end: u64) -> key_index::Mutation {
+        if self
+            .inner
+            .coverage
+            .read()
+            .expect("coverage lock")
+            .intersects(start, end)
+        {
+            self.inner.key_index.invalidate_reads();
+        }
+        self.inner.key_index.mutation(start, end)
     }
 
     pub(crate) async fn publish_range_coverage(
@@ -996,6 +859,8 @@ impl DiskCache {
     }
 
     async fn poison_slot(&self, slot: u64) {
+        self.inner.key_index.invalidate_reads();
+        let _mutation = self.inner.key_index.mutation(slot, slot);
         self.inner
             .coverage
             .write()
@@ -1098,6 +963,8 @@ impl DiskCache {
         if new_floor <= old_floor {
             return Ok(false);
         }
+        self.inner.key_index.invalidate_reads();
+        let _mutation = self.inner.key_index.mutation(0, new_floor - 1);
         self.drop_partitions_below(new_floor).await?;
         self.inner.min_retained.store(new_floor, Ordering::Relaxed);
         self.inner
@@ -1278,6 +1145,7 @@ fn upper_bound_reaches_tip(query: &index::DiskTfaQuery, tip: u64) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::clickhouse::SortOrder;
 
     #[test]
     fn automatic_partition_width_is_bounded() {

--- a/crates/superbank-rpc/src/disk_cache/schema.rs
+++ b/crates/superbank-rpc/src/disk_cache/schema.rs
@@ -681,6 +681,33 @@ async fn reset_coverage_after_memory_restart(
     Ok(true)
 }
 
+/// Called only after validating the ownership marker. Keep the marker and its
+/// old fingerprint until all replacement DDL succeeds, so interruption retries
+/// the rebuild instead of leaving an unowned, partially dropped database.
+async fn rebuild_owned_tables(
+    local: &ClickHouseClient,
+    config: &CacheSchemaConfig,
+    existing: &[String],
+) -> Result<(), SchemaError> {
+    // Remove forwarding views before their source/target tables.
+    let mut tables: Vec<_> = existing.iter().filter(|name| *name != META_TABLE).collect();
+    tables.sort_by_key(|name| !name.ends_with("__mv"));
+    for name in tables {
+        local
+            .client
+            .clone()
+            .with_setting("max_table_size_to_drop", "0")
+            .query(&format!(
+                "DROP TABLE IF EXISTS {} SYNC",
+                quote_table(&config.database, name)
+            ))
+            .execute()
+            .await
+            .map_err(|err| SchemaError::Query(err.to_string()))?;
+    }
+    Ok(())
+}
+
 pub(crate) async fn initialize_cache_schema(
     local: &ClickHouseClient,
     snapshot: &SourceSchemaSnapshot,
@@ -712,11 +739,7 @@ pub(crate) async fn initialize_cache_schema(
         if value("format_version") != Some(expected_version.as_str())
             || value("fingerprint") != Some(snapshot.fingerprint.as_str())
         {
-            execute(
-                local,
-                &format!("DROP DATABASE {} SYNC", quote_identifier(&config.database)),
-            )
-            .await?;
+            rebuild_owned_tables(local, config, &existing).await?;
             rebuilt = true;
         }
     }

--- a/crates/superbank-rpc/src/disk_cache/schema.rs
+++ b/crates/superbank-rpc/src/disk_cache/schema.rs
@@ -12,7 +12,7 @@ use serde::Deserialize;
 
 use crate::clickhouse::ClickHouseClient;
 
-pub(crate) const CACHE_FORMAT_VERSION: u32 = 4;
+pub(crate) const CACHE_FORMAT_VERSION: u32 = 5;
 pub(crate) const CACHE_MAGIC: &str = "superbank-clickhouse-forward-cache";
 pub(crate) const META_TABLE: &str = "_cache_meta";
 pub(crate) const COVERAGE_TABLE: &str = "_cache_coverage";
@@ -118,9 +118,18 @@ pub(crate) struct SourceTableSchema {
     storage: TableRow,
     view_select: Option<String>,
     indexes: Vec<String>,
+    settings: std::collections::BTreeMap<String, u64>,
 }
 
 impl SourceTableSchema {
+    fn with_storage_settings(mut self) -> Result<Self, SchemaError> {
+        self.settings = super::schema_settings::extract(&self.storage.create_table_query)?;
+        if let Some(key) = super::schema_settings::sorting_key(&self.storage.create_table_query) {
+            self.storage.sorting_key = key;
+        }
+        Ok(self)
+    }
+
     pub(crate) fn insert_columns(&self) -> Vec<String> {
         self.columns
             .iter()
@@ -291,7 +300,7 @@ async fn inspect_table(
     }
 
     let indexes = extract_index_definitions(&storage.create_table_query);
-    Ok(SourceTableSchema {
+    SourceTableSchema {
         kind,
         logical_name,
         storage_name,
@@ -299,7 +308,9 @@ async fn inspect_table(
         storage,
         view_select,
         indexes,
-    })
+        settings: Default::default(),
+    }
+    .with_storage_settings()
 }
 
 pub(crate) async fn inspect_source_schema(
@@ -408,6 +419,7 @@ fn schema_fingerprint(tables: &[SourceTableSchema], config: &CacheSchemaConfig) 
                 column.compression_codec
             );
         }
+        let _ = writeln!(input, "settings={:?}", table.settings);
         for index in &table.indexes {
             let _ = writeln!(input, "index={index}");
         }
@@ -474,15 +486,15 @@ fn create_cache_table_sql(
     } else {
         table.storage.primary_key.trim()
     };
-    let reverse_setting = if sorting_key.to_ascii_uppercase().contains(" DESC") {
-        " SETTINGS allow_experimental_reverse_key = 1"
-    } else {
-        ""
-    };
+    let mut settings = table.settings.clone();
+    if sorting_key.to_ascii_uppercase().contains(" DESC") {
+        settings.insert("allow_experimental_reverse_key".into(), 1);
+    }
+    let settings = super::schema_settings::clause(&settings);
     Ok(format!(
         "CREATE TABLE IF NOT EXISTS {target} (\n    {columns}\n) \
          ENGINE = ReplacingMergeTree(slot) \
-         PARTITION BY intDiv(slot, {}) PRIMARY KEY ({primary_key}) ORDER BY ({sorting_key}){reverse_setting}",
+         PARTITION BY intDiv(slot, {}) PRIMARY KEY ({primary_key}) ORDER BY ({sorting_key}){settings}",
         config.partition_slots
     ))
 }
@@ -522,8 +534,16 @@ fn create_cache_view_sql(
     let view_name = format!("{}__mv", table.kind.local_name());
     let view = quote_table(&config.database, &view_name);
     let target = quote_table(&config.database, table.kind.local_name());
+    // Source views may explicitly emit materialized bucket columns. The target
+    // recomputes them, so insert only ordinary columns into the forwarding view.
+    let columns = table
+        .insert_columns()
+        .iter()
+        .map(|name| quote_identifier(name))
+        .collect::<Vec<_>>()
+        .join(", ");
     Ok(format!(
-        "CREATE MATERIALIZED VIEW IF NOT EXISTS {view} TO {target} AS {rewritten}"
+        "CREATE MATERIALIZED VIEW IF NOT EXISTS {view} TO {target} AS SELECT {columns} FROM ({rewritten})"
     ))
 }
 
@@ -787,7 +807,7 @@ fn extract_index_definitions(create: &str) -> Vec<String> {
         .collect()
 }
 
-fn split_top_level(input: &str) -> Vec<&str> {
+pub(super) fn split_top_level(input: &str) -> Vec<&str> {
     let mut entries = Vec::new();
     let mut start = 0usize;
     let mut depth = 0usize;
@@ -877,6 +897,7 @@ mod tests {
             },
             view_select: None,
             indexes: Vec::new(),
+            settings: Default::default(),
         };
         let config = |partition_slots| CacheSchemaConfig {
             database: "cache".into(),

--- a/crates/superbank-rpc/src/disk_cache/schema_settings.rs
+++ b/crates/superbank-rpc/src/disk_cache/schema_settings.rs
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Copy only portable, numeric MergeTree tuning from the source schema.
+
+use super::schema::SchemaError;
+use std::collections::BTreeMap;
+
+const ALLOWED: &[&str] = &[
+    "index_granularity",
+    "index_granularity_bytes",
+    "min_bytes_for_wide_part",
+    "compress_primary_key",
+    "compress_marks",
+    "allow_experimental_reverse_key",
+];
+
+#[derive(Default)]
+struct Scanner {
+    depth: usize,
+    quote: Option<char>,
+    escaped: bool,
+}
+
+impl Scanner {
+    fn consume(&mut self, ch: char) {
+        if self.escaped {
+            self.escaped = false;
+            return;
+        }
+        if let Some(quote) = self.quote {
+            if ch == '\\' {
+                self.escaped = true;
+            }
+            if ch == quote {
+                self.quote = None;
+            }
+            return;
+        }
+        match ch {
+            '\'' | '"' | '`' => self.quote = Some(ch),
+            '(' | '[' => self.depth += 1,
+            ')' | ']' => self.depth = self.depth.saturating_sub(1),
+            _ => {}
+        }
+    }
+}
+
+fn top_level_keyword(sql: &str, keyword: &str) -> Option<usize> {
+    let mut scan = Scanner::default();
+    for (i, ch) in sql.char_indices() {
+        if scan.depth == 0
+            && scan.quote.is_none()
+            && sql[i..]
+                .get(..keyword.len())
+                .is_some_and(|s| s.eq_ignore_ascii_case(keyword))
+        {
+            return Some(i);
+        }
+        scan.consume(ch);
+    }
+    None
+}
+
+pub(super) fn extract(sql: &str) -> Result<BTreeMap<String, u64>, SchemaError> {
+    let mut result = BTreeMap::new();
+    let Some(start) = top_level_keyword(sql, " SETTINGS ") else {
+        return Ok(result);
+    };
+    let tail = &sql[start + 10..];
+    let end = top_level_keyword(tail, " AS ").unwrap_or(tail.len());
+    for entry in super::schema::split_top_level(&tail[..end]) {
+        let (name, value) = entry.trim().split_once('=').unwrap_or((entry.trim(), ""));
+        let name = name.trim().trim_matches('`').to_ascii_lowercase();
+        if !ALLOWED.contains(&name.as_str()) {
+            continue;
+        }
+        let value = value
+            .trim()
+            .trim_end_matches(';')
+            .parse::<u64>()
+            .map_err(|_| SchemaError::Invalid(format!("invalid source setting {name}")))?;
+        validate(&name, value)?;
+        result.insert(name, value);
+    }
+    Ok(result)
+}
+
+pub(super) fn sorting_key(sql: &str) -> Option<String> {
+    let start = top_level_keyword(sql, " ORDER BY ")? + 10;
+    let tail = &sql[start..];
+    let end = [" SETTINGS ", " TTL ", " COMMENT ", " AS ", " SAMPLE BY "]
+        .iter()
+        .filter_map(|keyword| top_level_keyword(tail, keyword))
+        .min()
+        .unwrap_or(tail.len());
+    let key = tail[..end].trim().trim_end_matches(';');
+    let key = key
+        .strip_prefix("tuple(")
+        .and_then(|s| s.strip_suffix(')'))
+        .unwrap_or(key);
+    Some(key.to_string())
+}
+
+fn validate(name: &str, value: u64) -> Result<(), SchemaError> {
+    let invalid = match name {
+        "compress_primary_key" | "compress_marks" | "allow_experimental_reverse_key" => value > 1,
+        "index_granularity" => value == 0,
+        _ => false,
+    };
+    if invalid {
+        return Err(SchemaError::Invalid(format!(
+            "invalid source setting {name}={value}"
+        )));
+    }
+    Ok(())
+}
+
+pub(super) fn clause(settings: &BTreeMap<String, u64>) -> String {
+    if settings.is_empty() {
+        return String::new();
+    }
+    format!(
+        " SETTINGS {}",
+        settings
+            .iter()
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn copies_only_top_level_portable_settings() {
+        let sql = "CREATE TABLE t (s String DEFAULT ' SETTINGS compress_marks=0') ENGINE=MergeTree ORDER BY s SETTINGS storage_policy='x, y', index_granularity=512, compress_marks=1 AS SELECT s FROM source";
+        assert_eq!(
+            clause(&extract(sql).unwrap()),
+            " SETTINGS compress_marks=1, index_granularity=512"
+        );
+    }
+    #[test]
+    fn retains_reverse_sort_directions_from_canonical_ddl() {
+        assert_eq!(
+            sorting_key(
+                "CREATE TABLE t (a UInt64) ENGINE=MergeTree PRIMARY KEY a ORDER BY tuple(a DESC, b) SETTINGS allow_experimental_reverse_key=1"
+            ),
+            Some("a DESC, b".into())
+        );
+    }
+    #[test]
+    fn rejects_invalid_supported_values() {
+        for value in ["-1", "0", "oops"] {
+            assert!(
+                extract(&format!(
+                    "CREATE TABLE t SETTINGS index_granularity={value}"
+                ))
+                .is_err()
+            );
+        }
+        assert!(extract("CREATE TABLE t SETTINGS compress_marks=2").is_err());
+    }
+}

--- a/crates/superbank-rpc/src/metrics.rs
+++ b/crates/superbank-rpc/src/metrics.rs
@@ -568,6 +568,14 @@ pub struct Metrics {
     superbank_grpc_stream_errors_total: Family<SuperbankGrpcErrorLabels, Counter>,
 
     #[cfg(feature = "disk-cache")]
+    disk_cache_key_seconds: Family<DiskCacheReadLabels, Histogram>,
+    #[cfg(feature = "disk-cache")]
+    disk_cache_key_index_bytes: Gauge,
+    #[cfg(feature = "disk-cache")]
+    disk_cache_key_index_partitions: Gauge,
+    #[cfg(feature = "disk-cache")]
+    disk_cache_key_index_unknown_partitions: Gauge,
+    #[cfg(feature = "disk-cache")]
     disk_cache_active: Gauge,
     #[cfg(feature = "disk-cache")]
     disk_cache_reads_total: Family<DiskCacheReadLabels, Counter>,
@@ -686,6 +694,15 @@ impl Metrics {
         #[cfg(feature = "grpc-streaming")]
         let superbank_grpc_stream_errors_total = Family::default();
 
+        #[cfg(feature = "disk-cache")]
+        let disk_cache_key_seconds =
+            Family::new_with_constructor(latency_histogram as fn() -> Histogram);
+        #[cfg(feature = "disk-cache")]
+        let disk_cache_key_index_bytes = Gauge::default();
+        #[cfg(feature = "disk-cache")]
+        let disk_cache_key_index_partitions = Gauge::default();
+        #[cfg(feature = "disk-cache")]
+        let disk_cache_key_index_unknown_partitions = Gauge::default();
         #[cfg(feature = "disk-cache")]
         let disk_cache_active = Gauge::default();
         #[cfg(feature = "disk-cache")]
@@ -995,6 +1012,26 @@ impl Metrics {
         #[cfg(feature = "disk-cache")]
         {
             registry.register(
+                "disk_cache_key_seconds",
+                "Partition routing index instrumentation",
+                disk_cache_key_seconds.clone(),
+            );
+            registry.register(
+                "disk_cache_key_index_bytes",
+                "Partition routing index instrumentation",
+                disk_cache_key_index_bytes.clone(),
+            );
+            registry.register(
+                "disk_cache_key_index_partitions",
+                "Partition routing index instrumentation",
+                disk_cache_key_index_partitions.clone(),
+            );
+            registry.register(
+                "disk_cache_key_index_unknown_partitions",
+                "Partition routing index instrumentation",
+                disk_cache_key_index_unknown_partitions.clone(),
+            );
+            registry.register(
                 "disk_cache_active",
                 "Whether the disk cache is open and serving (1) or disabled (0)",
                 disk_cache_active.clone(),
@@ -1143,6 +1180,14 @@ impl Metrics {
             superbank_grpc_stream_messages_total,
             #[cfg(feature = "grpc-streaming")]
             superbank_grpc_stream_errors_total,
+            #[cfg(feature = "disk-cache")]
+            disk_cache_key_seconds,
+            #[cfg(feature = "disk-cache")]
+            disk_cache_key_index_bytes,
+            #[cfg(feature = "disk-cache")]
+            disk_cache_key_index_partitions,
+            #[cfg(feature = "disk-cache")]
+            disk_cache_key_index_unknown_partitions,
             #[cfg(feature = "disk-cache")]
             disk_cache_active,
             #[cfg(feature = "disk-cache")]
@@ -2153,5 +2198,31 @@ pub async fn metrics_handler() -> impl IntoResponse {
             warn!("Failed to scrape metrics: {err}");
             StatusCode::INTERNAL_SERVER_ERROR.into_response()
         }
+    }
+}
+
+#[cfg(feature = "disk-cache")]
+pub(crate) fn disk_cache_key_seconds(operation: &'static str, outcome: &'static str, seconds: f64) {
+    if let Some(metrics) = metrics() {
+        metrics
+            .disk_cache_key_seconds
+            .get_or_create(&DiskCacheReadLabels {
+                operation: operation.into(),
+                outcome: outcome.into(),
+            })
+            .observe(seconds);
+    }
+}
+
+#[cfg(feature = "disk-cache")]
+pub(crate) fn disk_cache_key_index(bytes: u64, indexed: u64, unknown: u64) {
+    if let Some(metrics) = metrics() {
+        metrics.disk_cache_key_index_bytes.set(clamp_i64(bytes));
+        metrics
+            .disk_cache_key_index_partitions
+            .set(clamp_i64(indexed));
+        metrics
+            .disk_cache_key_index_unknown_partitions
+            .set(clamp_i64(unknown));
     }
 }

--- a/crates/superbank-rpc/src/server.rs
+++ b/crates/superbank-rpc/src/server.rs
@@ -691,6 +691,9 @@ async fn start_disk_cache(
         required: args.disk_cache_required,
         retain_slots,
         max_bytes: args.disk_cache_max_bytes,
+        key_index_max_memory_bytes: args.disk_cache_key_index_max_memory_bytes,
+        query_concurrency: args.disk_cache_query_concurrency as usize,
+        query_max_threads: args.disk_cache_query_max_threads,
         partition_slots: args
             .disk_cache_partition_slots
             .unwrap_or_else(|| automatic_partition_slots(retain_slots)),
@@ -802,6 +805,7 @@ async fn run_disk_cache_supervisor(
     }
 
     let cache = cache.expect("cache initialized");
+    let key_index_task = tokio::spawn(cache.clone().run_key_index(shutdown.resubscribe()));
     let block_index_task = cache
         .block_index()
         .map(|index| tokio::spawn(index.clone().run(source.clone(), shutdown.resubscribe())));
@@ -811,6 +815,8 @@ async fn run_disk_cache_supervisor(
         let _ = shutdown.recv().await;
         cache.set_ready(false);
     }
+    key_index_task.abort();
+    let _ = key_index_task.await;
     if let Some(task) = block_index_task {
         let _ = task.await;
     }

--- a/scripts/test/check-rust-complexity.py
+++ b/scripts/test/check-rust-complexity.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Gate changed Rust functions: new McCabe <=10, existing complexity cannot rise.
+
+Requires rust-code-analysis-cli 0.0.25. Pass --base to compare another Git revision.
+No repository files are rewritten. Closures are measured as separate functions.
+"""
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+
+
+def git(*args):
+    return subprocess.check_output(["git", *args], text=True)
+
+
+def analyze(path):
+    tool = os.environ.get("RUST_CODE_ANALYSIS", "rust-code-analysis-cli")
+    tree = json.loads(subprocess.check_output([tool, "-p", str(path), "-m", "-O", "json"], text=True))
+    lines = path.read_text().splitlines()
+    result = {}
+
+    def visit(node, parents):
+        kind, name = node["kind"], node["name"]
+        key = (*parents, name)
+        if kind == "function":
+            nested = sum(child["metrics"]["cyclomatic"]["sum"] for child in node["spaces"])
+            complexity = node["metrics"]["cyclomatic"]["sum"] - nested
+            body = "\n".join(lines[node["start_line"] - 1:node["end_line"]])
+            result[key] = (complexity, body, node["start_line"])
+        for child in node["spaces"]:
+            visit(child, parents if kind == "unit" else key)
+
+    visit(tree, ())
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default="HEAD")
+    args = parser.parse_args()
+    changed = set(git("diff", "--name-only", args.base).splitlines())
+    changed.update(git("ls-files", "--others", "--exclude-standard").splitlines())
+    failures = []
+    checked = 0
+    with tempfile.TemporaryDirectory(prefix="superbank-complexity-") as directory:
+        for filename in sorted(changed):
+            path = Path(filename)
+            if path.suffix != ".rs" or not path.is_file():
+                continue
+            previous = subprocess.run(["git", "show", f"{args.base}:{filename}"], capture_output=True, text=True)
+            baseline = {}
+            if previous.returncode == 0:
+                old = Path(directory) / path.name
+                old.write_text(previous.stdout)
+                baseline = analyze(old)
+            for name, (score, body, line) in analyze(path).items():
+                prior = baseline.get(name)
+                if prior and prior[1] == body:
+                    continue
+                checked += 1
+                limit = prior[0] if prior else 10
+                if score > limit:
+                    failures.append(f"{filename}:{line}: {'::'.join(name)} McCabe {score:g} > {limit:g}")
+    print(f"Checked {checked} changed Rust functions")
+    for failure in failures:
+        print(failure)
+    raise SystemExit(bool(failures))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/k6/README.md
+++ b/tests/k6/README.md
@@ -846,3 +846,63 @@ tests/k6/
 ### Threshold Failures
 
 If thresholds fail, k6 will exit with a non-zero code. Check the output for which thresholds failed and adjust your expectations or fix the underlying issue.
+
+### Disk-cache partition-routing regression gate
+
+`scenarios/performance/superbank-rpc-disk-cache-key-routing.js` runs 70 mixed key requests/s
+for 30 minutes. It rejects undersized datasets (fewer than 900 million signature rows,
+80 partitions, or 600 active signature parts) and requires a non-repeating request manifest.
+Use an isolated representative deployment with concurrent ingestion around 4,600 transactions/s.
+Do not run this load against production as part of routine repository validation.
+
+Supply `KEY_REQUEST_FILE` as a JSON array of at least 126,070 entries (including a one-second scheduling buffer):
+
+```json
+[{"method":"getTransaction","params":["<signature>",{"encoding":"json","maxSupportedTransactionVersion":1}],"ageBand":"oldest","expectedDiskHit":true,"expected":{}}]
+```
+
+Replace `expected` with the actual reference result. For `getSignatureStatuses`, store its
+`value`; for `getTransactionsForAddress`, store its `data`, excluding the tier-dependent cursor.
+Capture expected results from an independent reference over finalized data before measuring.
+For status-hit fixtures, capture the reference with `searchTransactionHistory=true`, then run
+the target with history disabled and non-null expected statuses. Status responses may still
+touch ClickHouse for their context slot. Disable the head cache in both benchmark targets.
+Include recent, middle, and oldest retained keys, all four key methods, misses, and out-of-window
+keys. Use 100-result address pages and include ascending/descending, token-owner, and cursor cases.
+A useful rate split is 40 getTransaction, 10 single-key getSignatureStatuses, 10
+getSignaturesForAddress, and 10 getTransactionsForAddress requests per second.
+
+```sh
+KEY_REQUEST_FILE=/absolute/path/requests.json RPC_URL=http://127.0.0.1:8899 \
+KEY_CLICKHOUSE_URL=http://127.0.0.1:8123 METRICS_URL=http://127.0.0.1:9900/metrics \
+k6 run tests/k6/scenarios/performance/superbank-rpc-disk-cache-key-routing.js
+```
+
+Acceptance requires exact data parity, no dropped iterations, index memory within 4 GiB,
+no growing ingestion backlog, signature-attempt p99 below 250 ms, and address-attempt p99 below
+500 ms. The script applies those latency thresholds to end-to-end disk hits, which is stricter
+than local-attempt latency. Inspect `superbank_disk_cache_key_seconds` for **all** attempts,
+including misses/timeouts, and compare backlog and ingestion rate before/after. Preserve the
+query-log selected-part counts and metrics alongside the k6 summary. A passing k6 process alone
+does not establish the ingestion and all-attempt gates.
+
+Repeat cold-start and invalidation tests separately: correctness and the two-second deadline
+must hold while the index is unavailable, but the steady-state latency targets apply after
+index building. `KEY_ROUTING_SMOKE=1` runs for ten seconds at one request/s and skips dataset-size checks; this is
+explicitly not a full-size performance pass. Existing disk-cache parity walks remain required.
+
+The Rust integration fixture uses a disposable loopback ClickHouse and the repository DDL:
+
+```sh
+DISK_CACHE_TEST_URL=http://127.0.0.1:18123 \
+cargo test -p superbank-rpc --all-features --locked key_routing_clickhouse_integration -- --ignored
+```
+
+It creates uniquely named `test_key_router_*` databases and removes them on success. Set
+`DISK_CACHE_TEST_KEEP=1` only when retaining the fixture for a local RPC/k6 smoke run.
+
+For the scoped Rust complexity gate, install `rust-code-analysis-cli` version `0.0.25` and run
+`python3 scripts/test/check-rust-complexity.py --base HEAD` before committing. New functions must
+have McCabe complexity at most 10; changed existing functions must not increase. After committing,
+pass the branch base revision instead of `HEAD`. Set `RUST_CODE_ANALYSIS` to an explicit tool path
+when it is not on `PATH`.

--- a/tests/k6/scenarios/performance/superbank-rpc-disk-cache-key-routing.js
+++ b/tests/k6/scenarios/performance/superbank-rpc-disk-cache-key-routing.js
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Full-retention regression gate. See tests/k6/README.md for fixture requirements.
+import http from 'k6/http';
+import exec from 'k6/execution';
+import { check, fail } from 'k6';
+import { SharedArray } from 'k6/data';
+import { Trend } from 'k6/metrics';
+import { deepEqual } from '../../lib/compare.js';
+
+const smoke = __ENV.KEY_ROUTING_SMOKE === '1';
+const seconds = smoke ? 10 : 1800;
+const rate = smoke ? 1 : 70;
+const requests = new SharedArray('key routing workload', () => JSON.parse(open(__ENV.KEY_REQUEST_FILE)));
+const signatureMs = new Trend('key_signature_ms');
+const addressMs = new Trend('key_address_ms');
+const allowed = new Set(['getTransaction', 'getSignatureStatuses', 'getSignaturesForAddress', 'getTransactionsForAddress']);
+
+export const options = {
+  scenarios: { keys: { executor: 'constant-arrival-rate', rate, timeUnit: '1s', duration: `${seconds}s`, preAllocatedVUs: 100, maxVUs: 200 } },
+  thresholds: { checks: ['rate==1'], http_req_failed: ['rate==0'], dropped_iterations: ['count==0'],
+    key_signature_ms: ['p(99)<250'], key_address_ms: ['p(99)<500'] },
+};
+function reject(message) {
+  check(null, { 'benchmark preconditions and resource gates': () => false });
+  fail(message);
+}
+function normalized(method, result) {
+  if (method === 'getTransactionsForAddress') return result?.data ?? null;
+  if (method === 'getSignatureStatuses') return result?.value ?? null;
+  return result;
+}
+function preflight() {
+  if (requests.length < rate * (seconds + 1)) reject('Workload must contain one entry per iteration; repeating a small key pool hides fanout.');
+  const bands = new Set();
+  const methods = new Set();
+  const keys = new Set();
+  let signatureHits = 0;
+  let addressHits = 0;
+  for (const request of requests) {
+    if (!allowed.has(request.method) || !Object.prototype.hasOwnProperty.call(request, 'expected')) reject('Each entry requires an allowed method and expected result.');
+    methods.add(request.method); bands.add(request.ageBand);
+    if (request.expectedDiskHit === true) {
+      if (request.method === 'getSignatureStatuses' && (request.params[1]?.searchTransactionHistory === true || !Array.isArray(request.expected) || request.expected.some(v => v === null))) reject('Status hit fixtures must disable history fallback and expect non-null cached values.');
+      if (request.method === 'getTransaction' || request.method === 'getSignatureStatuses') signatureHits++;
+      else addressHits++;
+    }
+    if (request.method === 'getTransaction') {
+      if (keys.has(request.params[0])) reject('getTransaction keys must not repeat.');
+      keys.add(request.params[0]);
+    }
+  }
+  if (signatureHits === 0 || addressHits === 0) reject('Both signature and address hit latency need samples.');
+  if (!smoke && (signatureHits < 10000 || addressHits < 10000)) reject('Full-size runs require at least 10,000 hits in each latency class.');
+  if (!smoke && (methods.size !== 4 || !['recent', 'middle', 'oldest'].every(b => bands.has(b)))) reject('Include all four methods and all three retention age bands.');
+}
+function sizeGate() {
+  if (smoke) return;
+  const database = __ENV.KEY_CLICKHOUSE_DATABASE || 'superbank_disk_cache';
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(database)) reject('Invalid cache database identifier.');
+  if (!__ENV.KEY_CLICKHOUSE_URL || !__ENV.METRICS_URL) reject('Full-size runs require KEY_CLICKHOUSE_URL and METRICS_URL.');
+  const response = http.post(__ENV.KEY_CLICKHOUSE_URL,
+    `SELECT sum(rows) AS rows, uniqExact(partition_id) AS partitions, count() AS parts FROM system.parts WHERE active AND database='${database}' AND table='signatures' FORMAT JSONEachRow`);
+  if (response.status !== 200) reject('Could not inspect cache size.');
+  const size = response.json();
+  if (Number(size.rows) < 900000000 || Number(size.partitions) < 80 || Number(size.parts) < 600) reject('Dataset is too small to establish the full-size performance gate.');
+}
+function indexGate() {
+  if (!__ENV.METRICS_URL) return;
+  const response = http.get(__ENV.METRICS_URL);
+  const bytes = response.body.match(/^superbank_disk_cache_key_index_bytes\s+(\S+)/m);
+  if (response.status !== 200 || !bytes || Number(bytes[1]) > 4294967296) reject('Index memory budget exceeded or metrics unavailable.');
+}
+export function setup() { preflight(); sizeGate(); indexGate(); }
+export default function () {
+  const request = requests[exec.scenario.iterationInTest];
+  if (!request) reject('Workload exhausted.');
+  const response = http.post(__ENV.RPC_URL, JSON.stringify({ jsonrpc: '2.0', id: exec.scenario.iterationInTest, method: request.method, params: request.params }), { headers: { 'Content-Type': 'application/json' } });
+  let body;
+  try { body = response.json(); } catch (_) { body = null; }
+  const source = String(response.headers['X-Superbank-Sources'] || '').toLowerCase();
+  check(response, {
+    'successful response': r => r.status === 200 && body !== null && !body.error,
+    'exact data parity': () => body !== null && deepEqual(normalized(request.method, body.result), request.expected),
+    'expected disk hit': () => request.expectedDiskHit !== true || (source.includes('disk-cache') && !source.includes('head-cache') && (request.method === 'getSignatureStatuses' || !source.includes('clickhouse'))),
+  });
+  // End-to-end hit latency is a conservative upper bound on the local attempt.
+  // Miss/fallback attempt latency is evaluated separately from exported histograms.
+  if (request.expectedDiskHit === true) {
+    const metric = request.method === 'getTransaction' || request.method === 'getSignatureStatuses' ? signatureMs : addressMs;
+    metric.add(response.timings.duration);
+  }
+  if (exec.scenario.iterationInTest % 700 === 0) indexGate();
+}
+export function teardown() { indexGate(); }


### PR DESCRIPTION
Key lookups against the slot-partitioned disk cache could search hundreds of ClickHouse parts, consuming CPU and exhausting the local query deadline. Route signature and address reads through a bounded, per-partition Bloom membership index, preserving slot-based eviction and source fallback. Apply cursor and slot bounds before probing, and keep admission, probes, and transaction hydration within one shared 2s cache-attempt deadline.

- Cover transaction lookup, signature positions/status batches, regular and hot address history, and token-owner history. Unknown or invalidated filters remain candidates; writes invalidate filters before mutation and stale builds cannot publish.
- Default to a 4 GiB index budget, eight concurrent local interactive queries, and two ClickHouse threads per query. Build filters asynchronously on a separate single-thread query lane.
- Preserve portable source MergeTree settings and reverse sort directions; project insertable columns in forwarding views. Add attempt/outcome and index coverage metrics, regression tests, and a reproducible k6 benchmark.

**Upgrade behavior:** cache format changes from 4 to 5. Startup verifies the ownership marker, preserves it while dropping and recreating the owned cache tables, and refills them from the source cluster. Each owned-table drop overrides `max_table_size_to_drop` for that query only. Interrupted rebuilds retain the old marker/fingerprint and can retry. Source data and the separately owned historical block index are preserved. Uncovered reads fall back to the source during refill, increasing source traffic. This PR contains no deployment changes.

Validation completed locally:

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo clippy -p superbank-rpc --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo test -p superbank-rpc --all-features --locked`: 502 passed, 2 ignored; the opt-in integration test was run separately.
- `cargo build -p superbank-rpc --all-features --locked`
- Cyclomatic complexity check: 146 changed Rust functions passed.
- Real ClickHouse 26.1.2.11 integration: key routing, invalidation, pagination/deduplication, hot bucket mapping, query cancellation, partition pruning, format upgrade, and Native refill passed.
- k6 basic: 2,474 successful requests, zero failed; parity: 117/117 checks; routing smoke: 33/33 checks.

**Performance gate remains open:** small local fixtures do not establish the production latency targets. Before deployment, run the documented full-size workload against approximately one billion signature rows with concurrent ingestion. The target is signature p99 below 250ms and address-page p99 below 500ms; representative data and load were unavailable locally.

Follow-up rebuild regression validation on ClickHouse 26.1.2.11: a 1-byte drop limit rejects an ordinary table drop but allows the verified cache rebuild; replacement DDL failure preserves the marker UUID and a retry succeeds; subsequent restarts retain refilled data; missing ownership markers still reject without deleting remaining data. RPC all-feature tests (502 passed), all-feature Clippy, formatting, and changed-function complexity checks passed after this fix. The README includes one-time recovery for caches whose marker was removed by the previous database-wide drop.
