### PR TITLE
fix(rpc): bound primary lookups after fast cache misses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,3 +90,48 @@ jobs:
 
       - name: Test optional features (superbank-rpc)
         run: cargo test -p superbank-rpc --all-features --locked
+
+  clickhouse-protocol:
+    name: ClickHouse protocol integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9 # stable
+        with:
+          toolchain: stable
+
+      - name: Install native dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libclang-dev llvm-dev pkg-config libudev-dev libusb-1.0-0-dev
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3
+        with:
+          version: "25.3"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          shared-key: ci-clickhouse-protocol
+
+      - name: Test production Rust protocol against ClickHouse 26.2.3.2
+        run: python3 scripts/test/test-clickhouse-http-disconnect.py --output "${RUNNER_TEMP}/clickhouse-protocol"
+
+      - name: Show integration results
+        if: always()
+        run: |
+          python3 - <<'PY'
+          import os
+          from pathlib import Path
+          root = Path(os.environ["RUNNER_TEMP"]) / "clickhouse-protocol"
+          for name in ("rust-build.log", "report.json", "rust-integration.log"):
+              path = root / name
+              if path.exists():
+                  print(path.read_text())
+          PY

--- a/README.md
+++ b/README.md
@@ -180,7 +180,9 @@ curl -sS http://localhost:8899 \
 The RPC server bounds primary signature-status history work with
 `GET_SIGNATURE_STATUSES_MAX_CONCURRENCY` (default `4`) and
 `GET_SIGNATURE_STATUSES_MAX_THREADS` (default `2`). `CLICKHOUSE_CLUSTER` identifies the primary
-cluster for cancellation in distributed mode as well as shard discovery in shard-direct mode.
+cluster for gateway-based termination verification in distributed HTTP mode as well as shard
+discovery in shard-direct mode. Abandoned distributed HTTP status reads use native disconnect
+cancellation and retain admission until every expected replica is observed clear twice.
 Use `rbx2` for RBX2 or an empty value for standalone ClickHouse. See the
 [RPC configuration and cancellation requirements](crates/superbank-rpc/README.md#primary-signature-status-overload-protection).
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,13 @@ curl -sS http://localhost:8899 \
 
 ## Configuration
 
+The RPC server bounds primary signature-status history work with
+`GET_SIGNATURE_STATUSES_MAX_CONCURRENCY` (default `4`) and
+`GET_SIGNATURE_STATUSES_MAX_THREADS` (default `2`). `CLICKHOUSE_CLUSTER` identifies the primary
+cluster for cancellation in distributed mode as well as shard discovery in shard-direct mode.
+Use `rbx2` for RBX2 or an empty value for standalone ClickHouse. See the
+[RPC configuration and cancellation requirements](crates/superbank-rpc/README.md#primary-signature-status-overload-protection).
+
 - `superbank` supports YAML config, CLI flags, and environment variables.
   Precedence is: flags > env > config file > defaults.
   See `crates/superbank/README.md` and `superbank.example.yaml`.

--- a/crates/superbank-rpc/README.md
+++ b/crates/superbank-rpc/README.md
@@ -112,9 +112,15 @@ Existing `{cluster}` macro support is preserved. For standalone development, set
 `CLICKHOUSE_CLUSTER=''`; verification then covers the single server behind that URL.
 Before submitting the first protected read, discovery validates unique `hostName()` identities
 against `system.clusters` and requires the coordinator to belong to the discovered cluster.
-The application account must be able to read `system.clusters`, `system.one`, and
+Initialization also executes the actual process-inspection probe with a unique query ID
+and requires complete replica coverage before caching success. The application account
+must be able to read `system.clusters`, `system.one`, and
 `system.processes` across all replicas and use the required query settings. Unavailable,
 ambiguous, or unsupported discovery fails before submitting the source lookup.
+Failed or cancelled initialization attempts share a one-second retry backoff across client
+clones. Requests during backoff fail promptly without submitting discovery or source work;
+their admission permits are released. Internal verification logs include the failing phase
+and underlying ClickHouse error; external RPC errors remain unchanged.
 
 One verifier is shared by client clones. On abandonment it retains the source permit until
 two consecutive, fully covered observations show neither the query ID nor its
@@ -630,7 +636,7 @@ Table selection (environment variables, read at startup):
 | `CLICKHOUSE_TOKEN_OWNER_ACTIVITY_TABLE` | `default.token_owner_activity` | — |
 
 Shard routing:
-When `CLICKHOUSE_SCOPE=distributed`, superbank-rpc sends every ClickHouse query through `CLICKHOUSE_URL`. It does not read `CLICKHOUSE_TOPOLOGY_CONFIG`, discover `system.clusters`, connect to shard endpoints, query local tables, or validate local schemas. Explicit shard-local settings are ignored with a startup warning.
+When `CLICKHOUSE_SCOPE=distributed`, superbank-rpc sends every ClickHouse query through `CLICKHOUSE_URL`. Primary signature-status protection inspects `system.clusters` and replica processes through that gateway. It does not read `CLICKHOUSE_TOPOLOGY_CONFIG`, connect directly to shard endpoints, query shard-local application tables, or validate local schemas. Explicit shard-local settings are ignored with a startup warning.
 
 When `CLICKHOUSE_SCOPE=shard-direct`, superbank-rpc discovers shards from `system.clusters` and validates local table schemas. Local tables default to `{table}_local` when not provided explicitly. `CLICKHOUSE_TRANSPORT` selects the shard-direct transport (`tcp` or `http`). When a shard has multiple replicas, startup selects the first reachable replica, warns about unavailable replicas, and fails only if no replica is reachable for a shard. Background health checks move traffic away from failed replicas and restore recovered replicas to the failover pool.
 

--- a/crates/superbank-rpc/README.md
+++ b/crates/superbank-rpc/README.md
@@ -90,6 +90,42 @@ Notes:
   `gt`/`gte` for `untilSlot`).
   Token account filters require the token-owner activity table (see below).
 
+### Primary signature-status overload protection
+
+History requests may contain up to 256 signatures. Cache-negative membership skips only local
+cache work: unresolved signatures still need a primary lookup when `searchTransactionHistory`
+is true. Primary admission is shared across client clones, precedes HTTP admission, and consumes
+`CLICKHOUSE_QUERY_TIMEOUT_MS`; keep that timeout below `RPC_REQUEST_TIMEOUT_MS`.
+
+Distributed primary status queries always carry a query ID and explicit thread/index-thread,
+replica, and remaining execution-time limits, including when optional query tuning is disabled.
+On cancellation or error, a bounded cleanup task retains the source permit and dispatches
+`KILL QUERY ON CLUSTER` for the query ID and matching `initial_query_id`. Configure
+`CLICKHOUSE_CLUSTER=rbx2` for RBX2. For standalone development without a ClickHouse cluster, set
+`CLICKHOUSE_CLUSTER=''` to issue a local kill; `scripts/dev/run-local-rpc.sh` preserves
+this explicit empty value. Existing `{cluster}` macro support is preserved.
+Local disk-cache clients never inherit the primary cleanup cluster.
+
+Cleanup has at most two seconds to dispatch, with capacity reserved by the source permit.
+A `kill_dispatched` metric means dispatch succeeded, not that every replica stopped: cluster
+kills use the distributed DDL queue. The application cap therefore is not a hard count of live
+ClickHouse queries after cleanup timeout/failure. Deployment requires verifying the application's
+`KILL QUERY`/`CLUSTER` privileges, distributed DDL availability, and actual coordinator/leaf
+termination. Shard-direct reads retain their existing transport cleanup; the new distributed
+query protections are also applied when a shard-direct request falls back to the coordinator.
+
+Metrics `superbank_rpc_signature_status_batch_size{stage="input"|"primary_fallback"}` count
+accepted-size input arrays (including duplicates) and unresolved history candidates before
+primary admission. Fallback observations are recorded when history candidates are evaluated,
+including zero when caches resolve them. They are not JSON-RPC envelope batch sizes or counts
+of submitted ClickHouse queries. `superbank_rpc_signature_status_admission_seconds` includes
+both successful and cancelled primary admission waits. Cleanup outcomes remain under
+`superbank_rpc_clickhouse_shard_query_cleanup_total_total{operation="signature_statuses"}`.
+
+See the [miss replay and cancellation gate](../../tests/k6/README.md) for the matched-rate
+256-signature workload. Preserve PR #88's fast-negative behavior during warm and cold cache
+validation; do not use cache warming delays as backend protection.
+
 ## ClickHouse schemas
 
 Choose one schema set under `ddl/`:
@@ -507,6 +543,8 @@ CLI flags and environment variables (see `crates/superbank-rpc/src/config.rs`):
 | `--get-inflation-reward-max-concurrency` | `GET_INFLATION_REWARD_MAX_CONCURRENCY` | `20` | Maximum active `getInflationReward` ClickHouse workflows per RPC instance. Excess calls fail fast with node-unhealthy (`-32005`); `0` disables this method-level admission check. |
 | `--get-inflation-reward-query-timeout-ms` | `GET_INFLATION_REWARD_QUERY_TIMEOUT_MS` | `5000` | End-to-end ClickHouse budget for HTTP-permit admission plus the targeted boundary and partition lookup. Must be below `RPC_REQUEST_TIMEOUT_MS`. |
 | `--get-inflation-reward-max-threads` | `GET_INFLATION_REWARD_MAX_THREADS` | `2` | ClickHouse `max_threads` applied to every reward lookup query. |
+| `--get-signature-statuses-max-concurrency` | `GET_SIGNATURE_STATUSES_MAX_CONCURRENCY` | `4` | Maximum primary signature-status workflows per RPC process, including pending cleanup. Must be positive. Admission waits consume the ClickHouse operation timeout; local disk-cache reads use their existing limits. |
+| `--get-signature-statuses-max-threads` | `GET_SIGNATURE_STATUSES_MAX_THREADS` | `2` | Required `max_threads` and `max_threads_for_indexes` for distributed primary signature-status queries. Must be positive. These queries also disable hedging and parallel replicas. |
 | `--get-inflation-reward-max-memory-bytes` | `GET_INFLATION_REWARD_MAX_MEMORY_BYTES` | `536870912` | ClickHouse `max_memory_usage` applied to every reward lookup query. |
 | `--get-inflation-reward-max-bytes-to-read` | `GET_INFLATION_REWARD_MAX_BYTES_TO_READ` | `536870912` | ClickHouse `max_bytes_to_read` applied to every reward lookup query. |
 | `--emit-http-errors` | `SUPERBANK_RPC_EMIT_HTTP_ERRORS` | `false` | Return HTTP `503 Service Unavailable` for selected server-side JSON-RPC failures; response bodies are unchanged. |
@@ -544,7 +582,7 @@ CLI flags and environment variables (see `crates/superbank-rpc/src/config.rs`):
 | `--clickhouse-replica-health-check-interval-ms` | `CLICKHOUSE_REPLICA_HEALTH_CHECK_INTERVAL_MS` | `10000` | Background health-check interval for shard-direct replicas. Unavailable replicas are restored to the failover pool after recovery. |
 | `--clickhouse-tcp-pool-min` | `CLICKHOUSE_TCP_POOL_MIN` | `10` | Shard-direct only. Minimum connections retained per shard in each ClickHouse native (TCP) connection pool. |
 | `--clickhouse-tcp-pool-max` | `CLICKHOUSE_TCP_POOL_MAX` | `20` | Shard-direct only. Maximum connections per shard in each ClickHouse native (TCP) connection pool. Total native connections per instance are bounded by this value times the number of shards, so size it against the ClickHouse connection budget. |
-| `--clickhouse-cluster` | `CLICKHOUSE_CLUSTER` | `{cluster}` | Shard-direct only. Cluster used for topology discovery. |
+| `--clickhouse-cluster` | `CLICKHOUSE_CLUSTER` | `{cluster}` | Cluster identity in both scopes: topology discovery in shard-direct mode and primary signature-status cancellation across coordinator/replicas in distributed mode. Supports ClickHouse macros. Set explicitly to `rbx2` for RBX2, or an empty string for standalone ClickHouse with no cluster. |
 | `--clickhouse-topology-config` | `CLICKHOUSE_TOPOLOGY_CONFIG` | — | Shard-direct only. Optional authoritative YAML shard topology. When set, superbank-rpc skips `system.clusters` discovery, uses the YAML shard/IP/port mapping for shard-local connections, and routes `getTransactionsForAddress` to the address-owner shard. |
 | `--clickhouse-gsfa-local-table` | `CLICKHOUSE_GSFA_LOCAL_TABLE` | — | Shard-direct only. Local GSFA table used by shard-direct reads and owner-shard `getTransactionsForAddress` routing. |
 | `--clickhouse-hot-address` | `CLICKHOUSE_GSFA_HOT_ADDRESSES` | empty | Repeatable; env accepts comma-separated values. |
@@ -604,7 +642,7 @@ Additional env flags:
 | `CLICKHOUSE_QUERY_ID_PREFIX` | `superbank` | `auto` or `off`/`0`/`false` disables. |
 | `CLICKHOUSE_GSFA_STRICT_PAGINATION` | `true` | — |
 | `CLICKHOUSE_GSFA_FALLBACK_TRANSACTIONS` | disabled | `empty`/`true` for empty-only fallback; `force`/`always` for incomplete fallback. |
-| `CLICKHOUSE_DISABLE_QUERY_SETTINGS` | `false` | Disables per-query ClickHouse `SETTINGS` overrides (including `getInflationReward` thread, memory, read-byte, and execution-time caps) when truthy. The targeted query shape and RPC admission limits remain active. |
+| `CLICKHOUSE_DISABLE_QUERY_SETTINGS` | `false` | Disables optional per-query ClickHouse `SETTINGS` overrides (including `getInflationReward` thread, memory, read-byte, and execution-time caps) when truthy. Required local-cache and distributed primary `getSignatureStatuses` safety settings still apply; unsupported safety settings fail the operation without an uncapped retry. RPC admission limits remain active. |
 
 ### ClickHouse query cache (read queries)
 

--- a/crates/superbank-rpc/README.md
+++ b/crates/superbank-rpc/README.md
@@ -323,6 +323,14 @@ coverage. The bounded local transaction projection uses the source signatures vi
 Ordinary appends and partial eviction preserve existing bits. Repairs remain unknown until their
 update completes; failed or cancelled updates invalidate completeness. Missing and incomplete
 filters rebuild asynchronously from actual materialized-table keys, newest partitions first.
+Signature and address maintenance run in independent bounded loops. Signature sweeps retry
+incomplete partitions after a five-second delay between sweeps; scan duration and other signature
+builds add to recovery time. Before each address-partition build, maintenance checks live signature
+completeness and cache readiness. New address builds pause while any signature partition is unknown;
+an already-running address scan can finish alongside one signature rebuild. Persistent signature
+failures therefore pause address warming, while queries retain their existing safe fallbacks.
+Both workers stop with the existing cache task. This scheduling change preserves cache format 5,
+its schema fingerprint, and existing disk data; only the in-memory indexes rebuild on restart.
 Stale builds cannot publish across invalidation or schema reset. Address filters continue to
 rebuild on complete historical partitions and invalidate on mutation. This assumes the owned
 cache has no independent external writers.
@@ -358,7 +366,12 @@ The `superbank_disk_cache_reads_total` outcomes distinguish misses, query errors
 `superbank_disk_cache_key_seconds` records complete attempts, admission waits, and index builds;
 `superbank_disk_cache_key_index_bytes` reports reserved index memory, and
 `superbank_disk_cache_key_index_partitions` / `superbank_disk_cache_key_index_unknown_partitions`
-show address index coverage. `superbank_disk_cache_signature_index_partitions` and
+show address index coverage and refresh during builds and paused maintenance.
+`superbank_disk_cache_key_seconds{operation="signature_index_build"}` distinguishes `success`,
+`error`, `timeout`, and `superseded` attempts. Allocation or conflicting-writer deferrals use
+`superbank_disk_cache_reads_total{operation="signature_index_build",outcome="deferred"}`.
+Partition IDs appear only in diagnostic logs, not metric labels.
+`superbank_disk_cache_signature_index_partitions` and
 `superbank_disk_cache_signature_index_unknown_partitions` separately show signature completeness.
 `superbank_disk_cache_signature_membership_seconds` has microsecond buckets and `absent`,
 `possible`, and `unknown` outcomes. Partition probe/skip counters use

--- a/crates/superbank-rpc/README.md
+++ b/crates/superbank-rpc/README.md
@@ -99,28 +99,51 @@ is true. Primary admission is shared across client clones, precedes HTTP admissi
 
 Distributed primary status queries always carry a query ID and explicit thread/index-thread,
 replica, and remaining execution-time limits, including when optional query tuning is disabled.
-On cancellation or error, a bounded cleanup task retains the source permit and dispatches
-`KILL QUERY ON CLUSTER` for the query ID and matching `initial_query_id`. Configure
-`CLICKHOUSE_CLUSTER=rbx2` for RBX2. For standalone development without a ClickHouse cluster, set
-`CLICKHOUSE_CLUSTER=''` to issue a local kill; `scripts/dev/run-local-rpc.sh` preserves
-this explicit empty value. Existing `{cluster}` macro support is preserved.
-Local disk-cache clients never inherit the primary cleanup cluster.
+Primary **distributed HTTP** status reads send `readonly=2` and
+`cancel_http_readonly_queries_on_client_close=1` as HTTP parameters. Dropping an abandoned
+response closes its connection so ClickHouse can cancel it without the distributed DDL queue.
+These settings are scoped to this read and its verification requests; the shared client,
+other RPC methods, shard-direct cleanup, and disk-cache reads/writes keep their existing behavior.
+Do not enable `readonly` on the shared application profile to configure this feature.
 
-Cleanup has at most two seconds to dispatch, with capacity reserved by the source permit.
-A `kill_dispatched` metric means dispatch succeeded, not that every replica stopped: cluster
-kills use the distributed DDL queue. The application cap therefore is not a hard count of live
-ClickHouse queries after cleanup timeout/failure. Deployment requires verifying the application's
-`KILL QUERY`/`CLUSTER` privileges, distributed DDL availability, and actual coordinator/leaf
-termination. Shard-direct reads retain their existing transport cleanup; the new distributed
-query protections are also applied when a shard-direct request falls back to the coordinator.
+Configure `CLICKHOUSE_CLUSTER=rbx2` for RBX2. The verifier uses the configured gateway and
+`clusterAllReplicas` to inspect every replica, never direct application-to-node connections.
+Existing `{cluster}` macro support is preserved. For standalone development, set
+`CLICKHOUSE_CLUSTER=''`; verification then covers the single server behind that URL.
+Before submitting the first protected read, discovery validates unique `hostName()` identities
+against `system.clusters` and requires the coordinator to belong to the discovered cluster.
+The application account must be able to read `system.clusters`, `system.one`, and
+`system.processes` across all replicas and use the required query settings. Unavailable,
+ambiguous, or unsupported discovery fails before submitting the source lookup.
+
+One verifier is shared by client clones. On abandonment it retains the source permit until
+two consecutive, fully covered observations show neither the query ID nor its
+`initial_query_id` on any expected node. It batches pending IDs into one in-flight probe,
+checks every 250 ms, and uses one-thread, one-second HTTP/server budgets with unavailable
+shards treated as errors. After five seconds without confirmation it records `unconfirmed`,
+keeps the permit, and retries once per second. Successful later verification restores capacity.
+Probe errors, partial coverage, or changed topology never establish absence. Cached topology
+is fixed for the client lifetime; a topology change requires rediscovery through a process restart.
+If verification is unavailable, all configured source slots can remain reserved and subsequent
+status history reads can time out in admission. Other lookup methods keep their existing limits.
+
+Absence observations are operational evidence of termination, not proof of what caused it.
+This mechanism requires a gateway that closes the upstream request when the downstream closes
+and never forwards buffered requests after abandonment. A gateway that delays forwarding can
+make an absent query appear after the checks. Verify that contract on the deployed route before
+promotion; the local proxy fixture is not proof about production. There is no DDL-kill fallback
+for this path. Shard-direct/TCP paths retain their existing best-effort cleanup.
 
 Metrics `superbank_rpc_signature_status_batch_size{stage="input"|"primary_fallback"}` count
 accepted-size input arrays (including duplicates) and unresolved history candidates before
 primary admission. Fallback observations are recorded when history candidates are evaluated,
 including zero when caches resolve them. They are not JSON-RPC envelope batch sizes or counts
 of submitted ClickHouse queries. `superbank_rpc_signature_status_admission_seconds` includes
-both successful and cancelled primary admission waits. Cleanup outcomes remain under
-`superbank_rpc_clickhouse_shard_query_cleanup_total_total{operation="signature_statuses"}`.
+both successful and cancelled primary admission waits.
+`superbank_rpc_signature_status_disconnect_pending` counts abandoned reads still retaining
+source capacity. `superbank_rpc_signature_status_disconnect_verification_total{outcome="confirmed_absent"|"unconfirmed"}`
+counts absence confirmations and five-second failures (once per abandoned query). Legacy cleanup
+outcomes remain under `superbank_rpc_clickhouse_shard_query_cleanup_total_total{operation="signature_statuses"}`.
 
 See the [miss replay and cancellation gate](../../tests/k6/README.md) for the matched-rate
 256-signature workload. Preserve PR #88's fast-negative behavior during warm and cold cache

--- a/crates/superbank-rpc/README.md
+++ b/crates/superbank-rpc/README.md
@@ -312,17 +312,30 @@ Candidate partitions are queried in result order, one at a time, until the answe
 the shared `DISK_CACHE_QUERY_TIMEOUT_MS` deadline expires. Admission waiting and transaction
 hydration count against that deadline. Incomplete address pages use source fallback.
 
-The routing index rebuilds asynchronously from actual materialized-table keys, newest complete
-historical partitions first. The actively filled partition, unbuilt filters, and invalidated
-filters remain query candidates. Fill/repair, poisoning, eviction, and schema rebuild invalidate
-filters before changing data. A stale build cannot publish, and a read whose exclusions became
-invalid falls back. This assumes the owned cache has no independent external writers.
+Signature membership covers every retained partition, including the active and partially
+retained edges and gaps between covered ranges. Each signature is hashed once and checked under
+one index lock. A complete negative returns before ClickHouse admission, client cloning, or
+signature encoding. Positive candidates still require a database lookup: Bloom filters can
+produce false positives.
+
+Fills add all signature keys, including secondary transaction signatures, before publishing
+coverage. The bounded local transaction projection uses the source signatures view's expressions.
+Ordinary appends and partial eviction preserve existing bits. Repairs remain unknown until their
+update completes; failed or cancelled updates invalidate completeness. Missing and incomplete
+filters rebuild asynchronously from actual materialized-table keys, newest partitions first.
+Stale builds cannot publish across invalidation or schema reset. Address filters continue to
+rebuild on complete historical partitions and invalidate on mutation. This assumes the owned
+cache has no independent external writers.
 
 The memory budget reserves 64 MiB for buffers/metadata and allocates the remaining space across
-the retention window. Filters target roughly 1% false positives; limited memory reduces
-selectivity rather than correctness. A single builder uses one ClickHouse execution thread and a
-separate 64 MiB server query-memory limit. Initialization and index failures preserve source
-fallback; a cold index can have higher latency than a fully built index.
+the retention window. Two-thirds of each partition's bitmap allowance is reserved for signatures
+with seven probes; the remainder serves address filters. Signature selectivity depends on the
+number of keys per partition and partition count: validate the **aggregate** false-positive rate,
+targeting at most 1%, rather than a per-partition rate. Limited memory reduces selectivity rather
+than correctness. The default budget remains 4 GiB. Background scans and fill updates each use
+one ClickHouse execution thread and a separate 64 MiB server query-memory limit. Initialization
+and index failures preserve source fallback; a cold index can have higher latency than a fully
+built index.
 
 Cache format **5** preserves the source's portable MergeTree index/mark settings and reverse
 sort directions from canonical DDL. Forwarding views project only insertable columns so the
@@ -345,8 +358,11 @@ The `superbank_disk_cache_reads_total` outcomes distinguish misses, query errors
 `superbank_disk_cache_key_seconds` records complete attempts, admission waits, and index builds;
 `superbank_disk_cache_key_index_bytes` reports reserved index memory, and
 `superbank_disk_cache_key_index_partitions` / `superbank_disk_cache_key_index_unknown_partitions`
-show index coverage. Partition probe/skip counters use `operation="key_partition"` with bounded
-labels; no keys or partition IDs are metric labels.
+show address index coverage. `superbank_disk_cache_signature_index_partitions` and
+`superbank_disk_cache_signature_index_unknown_partitions` separately show signature completeness.
+`superbank_disk_cache_signature_membership_seconds` has microsecond buckets and `absent`,
+`possible`, and `unknown` outcomes. Partition probe/skip counters use
+`operation="key_partition"` with bounded labels; no keys or partition IDs are metric labels.
 
 Query-facing tables use `ReplacingMergeTree` by default. `blocks_metadata` can opt into the ClickHouse `Memory` engine with `DISK_CACHE_MEMORY_TABLES=blocks_metadata`. This mode requires explicit row and byte caps. Memory-engine coverage is reset after a local ClickHouse restart because those rows are not durable. No other query-facing table is accepted in the Memory allowlist in this release.
 

--- a/crates/superbank-rpc/src/clickhouse/client.rs
+++ b/crates/superbank-rpc/src/clickhouse/client.rs
@@ -26,6 +26,7 @@ use crate::processing::{ProcessingError, ProcessingResult};
 
 use super::cache::SignatureSlotCache;
 use super::constants::DEFAULT_BUCKET_MODULUS;
+use super::disconnect::{DisconnectGuard, DisconnectVerifier};
 use super::gsfa::GsfaShardRouter;
 use super::queries::{
     GSFA_REQUIRED_COLUMNS, SIGNATURES_REQUIRED_COLUMNS, TOKEN_OWNER_REQUIRED_COLUMNS,
@@ -68,6 +69,32 @@ pub(crate) fn shard_tcp_query_timeout_for(query_timeout: Duration) -> Duration {
 
     let tcp_timeout_ms = timeout_ms.saturating_sub(reserve_ms);
     Duration::from_millis(tcp_timeout_ms.min(u128::from(u64::MAX)) as u64)
+}
+
+pub(crate) enum SignatureStatusCleanup {
+    Http(Box<HttpQueryCleanup>),
+    Disconnect(DisconnectGuard),
+}
+
+impl SignatureStatusCleanup {
+    /// Construction failures precede HTTP submission and need no absence probes.
+    pub(crate) fn before_submission<T>(
+        result: ProcessingResult<T>,
+        cleanup: &mut Option<Self>,
+    ) -> ProcessingResult<T> {
+        if result.is_err() {
+            Self::disarm_optional(cleanup);
+        }
+        result
+    }
+
+    pub(crate) fn disarm_optional(cleanup: &mut Option<Self>) {
+        match cleanup {
+            Some(Self::Http(guard)) => guard.disarm(),
+            Some(Self::Disconnect(guard)) => guard.disarm(),
+            None => {}
+        }
+    }
 }
 
 struct ShardTcpQueryCleanup {
@@ -463,6 +490,7 @@ pub struct ClickHouseClient {
     pub(crate) signature_status_max_threads: usize,
     signature_status_sem: Arc<Semaphore>,
     query_cleanup_cluster: Option<String>,
+    signature_status_disconnect: DisconnectVerifier,
     pub(crate) inflation_reward_limits: InflationRewardQueryLimits,
     pub(crate) tcp_access_check_timeout: Duration,
     pub(crate) replica_health_check_interval: Duration,
@@ -574,7 +602,7 @@ const HTTP_TCP_KEEPALIVE: Duration = Duration::from_secs(60);
 ///
 /// NB: this mirrors the crate default's plain-HTTP connector. superbank builds `clickhouse`
 /// without a TLS feature, so ClickHouse connections are HTTP-only, the same as before.
-fn build_clickhouse_http_client(
+pub(super) fn build_clickhouse_http_client(
     url: &str,
     database: &str,
     username: &str,
@@ -815,6 +843,8 @@ impl ClickHouseClient {
             config
         });
 
+        let signature_status_disconnect =
+            DisconnectVerifier::new(client.clone(), query_cleanup_cluster.clone());
         Self {
             client,
             url: url.to_string(),
@@ -852,6 +882,7 @@ impl ClickHouseClient {
             signature_status_max_threads: signature_status_max_threads.max(1),
             signature_status_sem: Arc::new(Semaphore::new(signature_status_max_concurrency.max(1))),
             query_cleanup_cluster,
+            signature_status_disconnect,
             inflation_reward_limits,
             tcp_access_check_timeout,
             replica_health_check_interval,
@@ -1021,15 +1052,37 @@ impl ClickHouseClient {
 
     /// Arm only immediately before submitting the HTTP request. Required IDs are independent
     /// of optional query-ID logging. A cancelled source retains admission through cleanup.
-    pub(crate) fn annotate_signature_status_query(
+    pub(crate) async fn annotate_signature_status_query(
         &self,
         query: String,
         source_permit: Option<OwnedSemaphorePermit>,
-    ) -> (String, Option<String>, Option<HttpQueryCleanup>) {
+    ) -> ProcessingResult<(String, Option<String>, Option<SignatureStatusCleanup>)> {
         let Some(source_permit) = source_permit else {
-            return self.annotate_lookup_query(query, "signature_statuses");
+            let (query, id, cleanup) = self.annotate_lookup_query(query, "signature_statuses");
+            return Ok((
+                query,
+                id,
+                cleanup.map(Box::new).map(SignatureStatusCleanup::Http),
+            ));
         };
         let (query, query_id) = super::util::annotate_required_query(query, "signature_statuses");
+        self.primary_signature_status_cleanup(query_id.clone(), source_permit)
+            .await
+            .map(|cleanup| (query, Some(query_id), Some(cleanup)))
+    }
+
+    async fn primary_signature_status_cleanup(
+        &self,
+        query_id: String,
+        source_permit: OwnedSemaphorePermit,
+    ) -> ProcessingResult<SignatureStatusCleanup> {
+        if self.signature_status_native_disconnect() {
+            return self
+                .signature_status_disconnect
+                .arm(query_id, source_permit)
+                .await
+                .map(SignatureStatusCleanup::Disconnect);
+        }
         let cluster = self.query_cleanup_cluster.clone().or_else(|| {
             self.shard_routing
                 .as_ref()
@@ -1040,10 +1093,38 @@ impl ClickHouseClient {
             cluster,
             "signature_statuses",
             self.query_timeout,
-            query_id.clone(),
+            query_id,
         );
         cleanup.source_permit = Some(source_permit);
-        (query, Some(query_id), Some(cleanup))
+        Ok(SignatureStatusCleanup::Http(Box::new(cleanup)))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_http_client_for_tests(&mut self, client: HttpClient) {
+        self.signature_status_disconnect =
+            DisconnectVerifier::new(client.clone(), self.query_cleanup_cluster.clone());
+        self.client = client;
+    }
+
+    fn signature_status_native_disconnect(&self) -> bool {
+        self.cache_partition.is_none()
+            && self.routing_policy.scope == RoutingScope::Distributed
+            && self.transport_http()
+    }
+
+    pub(crate) fn signature_status_http_query(
+        &self,
+        sql: &str,
+        query_id: Option<String>,
+    ) -> clickhouse::query::Query {
+        let query = super::util::http_query_with_id(&self.client, sql, query_id);
+        if self.signature_status_native_disconnect() {
+            query
+                .with_setting("readonly", "2")
+                .with_setting("cancel_http_readonly_queries_on_client_close", "1")
+        } else {
+            query
+        }
     }
 
     fn cache_settings_or(&self, settings: String, timeout: Duration) -> String {
@@ -2547,18 +2628,25 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn primary_status_cleanup_retains_admission_and_targets_cluster() {
+    async fn shard_direct_status_cleanup_retains_admission_and_targets_cluster() {
         let mut server = CleanupServer::new().await;
-        let client = server.client();
+        let mut client = server.client();
+        client.routing_policy.scope = RoutingScope::ShardDirect;
         let (source, http) = client
             .acquire_signature_status_permits()
             .await
             .expect("admission");
-        let (_, id, cleanup) = client.annotate_signature_status_query("SELECT 1".into(), source);
+        let (_, id, cleanup) = client
+            .annotate_signature_status_query("SELECT 1".into(), source)
+            .await
+            .expect("guard");
         let id = id.expect("required ID");
         assert!(client.shard_routing.is_none());
         assert_eq!(
-            cleanup.as_ref().expect("guard").cluster.as_deref(),
+            match cleanup.as_ref().expect("guard") {
+                super::SignatureStatusCleanup::Http(guard) => guard.cluster.as_deref(),
+                _ => panic!("expected legacy cleanup"),
+            },
             Some("rbx2")
         );
         drop(http);
@@ -2580,15 +2668,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn primary_status_cleanup_timeout_releases_admission() {
+    async fn shard_direct_status_cleanup_timeout_releases_admission() {
         let mut server = CleanupServer::new().await;
         let mut client = server.client();
+        client.routing_policy.scope = RoutingScope::ShardDirect;
         client.query_timeout = Duration::from_millis(50);
         let (source, http) = client
             .acquire_signature_status_permits()
             .await
             .expect("admission");
-        let (_, _, cleanup) = client.annotate_signature_status_query("SELECT 1".into(), source);
+        let (_, _, cleanup) = client
+            .annotate_signature_status_query("SELECT 1".into(), source)
+            .await
+            .expect("guard");
         drop(http);
         drop(cleanup);
         server.next_request().await;
@@ -2604,16 +2696,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn primary_status_cleanup_connection_failure_releases_admission() {
+    async fn shard_direct_status_cleanup_connection_failure_releases_admission() {
         let server = CleanupServer::new().await;
-        let client = server.client();
+        let mut client = server.client();
+        client.routing_policy.scope = RoutingScope::ShardDirect;
         server.task.abort();
         tokio::task::yield_now().await;
         let (source, http) = client
             .acquire_signature_status_permits()
             .await
             .expect("admission");
-        let (_, _, cleanup) = client.annotate_signature_status_query("SELECT 1".into(), source);
+        let (_, _, cleanup) = client
+            .annotate_signature_status_query("SELECT 1".into(), source)
+            .await
+            .expect("guard");
         drop(http);
         drop(cleanup);
         let permits = tokio::time::timeout(
@@ -2628,17 +2724,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn primary_status_success_disarms_cleanup_and_releases_admission() {
+    async fn shard_direct_status_success_disarms_cleanup_and_releases_admission() {
         let mut server = CleanupServer::new().await;
-        let client = server.client();
+        let mut client = server.client();
+        client.routing_policy.scope = RoutingScope::ShardDirect;
         let (source, http) = client
             .acquire_signature_status_permits()
             .await
             .expect("admission");
-        let (_, id, mut cleanup) =
-            client.annotate_signature_status_query("SELECT 1".into(), source);
+        let (_, id, mut cleanup) = client
+            .annotate_signature_status_query("SELECT 1".into(), source)
+            .await
+            .expect("guard");
         assert!(id.is_some());
-        super::HttpQueryCleanup::disarm_optional(&mut cleanup);
+        super::SignatureStatusCleanup::disarm_optional(&mut cleanup);
         assert_eq!(client.signature_status_sem.available_permits(), 1);
         drop(http);
         drop(cleanup);

--- a/crates/superbank-rpc/src/clickhouse/client.rs
+++ b/crates/superbank-rpc/src/clickhouse/client.rs
@@ -19,7 +19,7 @@ use hyper_util::client::legacy::{Client as HyperClient, connect::HttpConnector};
 use hyper_util::rt::TokioExecutor;
 use reqwest::Url;
 use serde::Deserialize;
-use tokio::sync::Semaphore;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore, SemaphorePermit};
 
 use crate::config::{ClickHouseStartupTableCheck, has_usable_gsfa_hot_addresses};
 use crate::processing::{ProcessingError, ProcessingResult};
@@ -133,6 +133,8 @@ impl Drop for ShardTcpQueryCleanup {
 }
 
 pub(crate) struct HttpQueryCleanup {
+    // A primary workflow reserves its own cleanup capacity until cleanup completes.
+    source_permit: Option<OwnedSemaphorePermit>,
     client: HttpClient,
     cluster: Option<String>,
     operation: &'static str,
@@ -149,6 +151,7 @@ impl HttpQueryCleanup {
         query_id: String,
     ) -> Self {
         Self {
+            source_permit: None,
             client,
             cluster,
             operation,
@@ -165,6 +168,7 @@ impl HttpQueryCleanup {
 
     pub(crate) fn disarm(&mut self) {
         self.query_id = None;
+        self.source_permit = None;
     }
 
     pub(crate) fn spawn_cleanup(&mut self, reason: &'static str) {
@@ -174,6 +178,7 @@ impl HttpQueryCleanup {
 
         crate::metrics::clickhouse_shard_query_abort(self.operation, "http", reason);
 
+        let source_permit = self.source_permit.take();
         let client = self.client.clone();
         let cluster = self.cluster.clone();
         let operation = self.operation;
@@ -181,7 +186,15 @@ impl HttpQueryCleanup {
         match tokio::runtime::Handle::try_current() {
             Ok(handle) => {
                 handle.spawn(async move {
-                    kill_http_query(client, cluster, operation, query_timeout, query_id).await;
+                    kill_http_query(
+                        client,
+                        cluster,
+                        operation,
+                        query_timeout,
+                        query_id,
+                        source_permit,
+                    )
+                    .await;
                 });
             }
             Err(err) => {
@@ -216,16 +229,23 @@ fn kill_query_sql(cluster: Option<&str>, query_id: &str) -> String {
     }
 }
 
+fn acquire_http_cleanup_permit(
+    source_permit: Option<OwnedSemaphorePermit>,
+) -> Result<OwnedSemaphorePermit, tokio::sync::TryAcquireError> {
+    // A source permit reserves cleanup capacity; keep it until the KILL finishes or times out.
+    // Only other operations compete for the existing best-effort global cleanup capacity.
+    source_permit.map_or_else(|| kill_query_semaphore().clone().try_acquire_owned(), Ok)
+}
+
 async fn kill_http_query(
     client: HttpClient,
     cluster: Option<String>,
     operation: &'static str,
     query_timeout: Duration,
     query_id: String,
+    source_permit: Option<OwnedSemaphorePermit>,
 ) {
-    // Hard-cap concurrent KILL cleanups; drop this one if the budget is exhausted rather than
-    // opening yet another connection while ClickHouse is already overloaded.
-    let _permit = match kill_query_semaphore().clone().try_acquire_owned() {
+    let _permit = match acquire_http_cleanup_permit(source_permit) {
         Ok(permit) => permit,
         Err(_) => {
             crate::metrics::clickhouse_shard_query_cleanup(operation, "kill_throttled");
@@ -440,6 +460,9 @@ pub struct ClickHouseClient {
     pub(crate) routing_policy: RoutingPolicy,
 
     pub(crate) query_timeout: Duration,
+    pub(crate) signature_status_max_threads: usize,
+    signature_status_sem: Arc<Semaphore>,
+    query_cleanup_cluster: Option<String>,
     pub(crate) inflation_reward_limits: InflationRewardQueryLimits,
     pub(crate) tcp_access_check_timeout: Duration,
     pub(crate) replica_health_check_interval: Duration,
@@ -493,6 +516,9 @@ pub struct ClickHouseClientOptions {
     pub gsfa_hot_table: String,
     pub gsfa_hot_local_table: String,
     pub query_timeout: Duration,
+    pub signature_status_max_concurrency: usize,
+    pub signature_status_max_threads: usize,
+    pub query_cleanup_cluster: Option<String>,
     pub tcp_access_check_timeout: Duration,
     pub replica_health_check_interval: Duration,
     pub query_cache: QueryCacheConfig,
@@ -593,6 +619,9 @@ impl ClickHouseClientOptions {
             gsfa_hot_table,
             gsfa_hot_local_table,
             query_timeout: Duration::from_millis(8_000),
+            signature_status_max_concurrency: 4,
+            signature_status_max_threads: 2,
+            query_cleanup_cluster: None,
             tcp_access_check_timeout: Duration::from_secs(2),
             replica_health_check_interval: Duration::from_secs(10),
             query_cache: QueryCacheConfig::default(),
@@ -605,6 +634,23 @@ impl ClickHouseClientOptions {
             startup_table_check: ClickHouseStartupTableCheck::Exists,
             inflation_reward_limits: InflationRewardQueryLimits::default(),
         }
+    }
+
+    pub fn with_signature_status_limits(
+        mut self,
+        max_concurrency: usize,
+        max_threads: usize,
+    ) -> Self {
+        self.signature_status_max_concurrency = max_concurrency.max(1);
+        self.signature_status_max_threads = max_threads.max(1);
+        self
+    }
+
+    /// Cluster identity for primary HTTP cancellation, independent of read routing.
+    pub fn with_query_cleanup_cluster(mut self, cluster: String) -> Self {
+        self.query_cleanup_cluster =
+            (!cluster.trim().is_empty()).then(|| cluster.trim().to_owned());
+        self
     }
 
     pub fn with_query_timeout(mut self, timeout: Duration) -> Self {
@@ -679,6 +725,9 @@ impl ClickHouseClient {
             gsfa_hot_table,
             gsfa_hot_local_table,
             query_timeout,
+            signature_status_max_concurrency,
+            signature_status_max_threads,
+            query_cleanup_cluster,
             tcp_access_check_timeout,
             replica_health_check_interval,
             query_cache,
@@ -695,7 +744,8 @@ impl ClickHouseClient {
             build_clickhouse_http_client(url, database, username, password, http_connect_timeout);
 
         // Distributed scope is coordinator-only. Ignore any injected shard routing so all
-        // startup checks, cleanup queries, and reads stay on the configured HTTP endpoint.
+        // startup checks and reads stay on the configured HTTP endpoint. Primary cancellation
+        // keeps its independently configured cluster identity.
         let shard_routing = if routing_policy.scope == RoutingScope::ShardDirect {
             shard_routing
         } else {
@@ -799,6 +849,9 @@ impl ClickHouseClient {
             routing_policy,
 
             query_timeout,
+            signature_status_max_threads: signature_status_max_threads.max(1),
+            signature_status_sem: Arc::new(Semaphore::new(signature_status_max_concurrency.max(1))),
+            query_cleanup_cluster,
             inflation_reward_limits,
             tcp_access_check_timeout,
             replica_health_check_interval,
@@ -833,6 +886,7 @@ impl ClickHouseClient {
         self.blocks_metadata_local_table = None;
         self.shard_topology = None;
         self.shard_routing = None;
+        self.query_cleanup_cluster = None;
         self.gsfa_router = None;
     }
 
@@ -941,6 +995,55 @@ impl ClickHouseClient {
             let (query, id) = super::util::annotate_query(query, operation);
             (query, id, None)
         }
+    }
+
+    /// Acquires source admission before HTTP admission; the caller owns the operation deadline.
+    /// Local-cache reads retain their existing HTTP admission behavior.
+    pub(crate) async fn acquire_signature_status_permits(
+        &self,
+    ) -> ProcessingResult<(Option<OwnedSemaphorePermit>, SemaphorePermit<'_>)> {
+        let source_permit = if self.cache_partition.is_none() {
+            Some(
+                self.signature_status_sem
+                    .clone()
+                    .acquire_owned()
+                    .await
+                    .map_err(|_| {
+                        ProcessingError::database_msg("Signature status source semaphore closed")
+                    })?,
+            )
+        } else {
+            None
+        };
+        let http_permit = self.acquire_http_query_permit().await?;
+        Ok((source_permit, http_permit))
+    }
+
+    /// Arm only immediately before submitting the HTTP request. Required IDs are independent
+    /// of optional query-ID logging. A cancelled source retains admission through cleanup.
+    pub(crate) fn annotate_signature_status_query(
+        &self,
+        query: String,
+        source_permit: Option<OwnedSemaphorePermit>,
+    ) -> (String, Option<String>, Option<HttpQueryCleanup>) {
+        let Some(source_permit) = source_permit else {
+            return self.annotate_lookup_query(query, "signature_statuses");
+        };
+        let (query, query_id) = super::util::annotate_required_query(query, "signature_statuses");
+        let cluster = self.query_cleanup_cluster.clone().or_else(|| {
+            self.shard_routing
+                .as_ref()
+                .map(|routing| routing.cluster.clone())
+        });
+        let mut cleanup = HttpQueryCleanup::new(
+            self.client.clone(),
+            cluster,
+            "signature_statuses",
+            self.query_timeout,
+            query_id.clone(),
+        );
+        cleanup.source_permit = Some(source_permit);
+        (query, Some(query_id), Some(cleanup))
     }
 
     fn cache_settings_or(&self, settings: String, timeout: Duration) -> String {
@@ -2349,6 +2452,251 @@ mod tests {
         ShardRoutingConfig,
     };
     use crate::processing::ProcessingError;
+
+    struct CleanupServer {
+        url: String,
+        requests: tokio::sync::mpsc::UnboundedReceiver<String>,
+        responses: Arc<tokio::sync::Semaphore>,
+        task: tokio::task::JoinHandle<()>,
+    }
+
+    impl CleanupServer {
+        async fn new() -> Self {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("bind");
+            let url = format!("http://{}", listener.local_addr().expect("address"));
+            let (sender, requests) = tokio::sync::mpsc::unbounded_channel();
+            let responses = Arc::new(tokio::sync::Semaphore::new(0));
+            let response_gate = responses.clone();
+            let app = axum::Router::new().fallback(move |body: axum::body::Bytes| {
+                let sender = sender.clone();
+                let response_gate = response_gate.clone();
+                async move {
+                    let _ = sender.send(String::from_utf8(body.to_vec()).expect("SQL text"));
+                    let _permit = response_gate.acquire().await.expect("response gate");
+                    axum::http::StatusCode::OK
+                }
+            });
+            let task =
+                tokio::spawn(async move { axum::serve(listener, app).await.expect("server") });
+            Self {
+                url,
+                requests,
+                responses,
+                task,
+            }
+        }
+
+        fn client(&self) -> ClickHouseClient {
+            ClickHouseClient::new(
+                &self.url,
+                "default",
+                "default",
+                "",
+                ClickHouseClientOptions::new(
+                    RoutingPolicy {
+                        transport: RoutingTransport::Http,
+                        scope: RoutingScope::Distributed,
+                    },
+                    None,
+                    Vec::new(),
+                    "default.gsfa_hot".into(),
+                    "default.gsfa_hot_local".into(),
+                )
+                .with_query_cleanup_cluster("rbx2".into())
+                .with_signature_status_limits(1, 2),
+            )
+        }
+
+        async fn next_request(&mut self) -> String {
+            tokio::time::timeout(Duration::from_secs(1), self.requests.recv())
+                .await
+                .expect("cleanup request timeout")
+                .expect("cleanup request")
+        }
+    }
+
+    impl Drop for CleanupServer {
+        fn drop(&mut self) {
+            self.task.abort();
+        }
+    }
+
+    #[tokio::test]
+    async fn primary_status_admission_is_shared_and_precedes_http_admission() {
+        let client = test_client_with_hot_addresses(Vec::new());
+        let other = client.clone();
+        let held = client
+            .signature_status_sem
+            .clone()
+            .acquire_many_owned(4)
+            .await
+            .expect("permits");
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(10),
+                other.acquire_signature_status_permits(),
+            )
+            .await
+            .is_err()
+        );
+        assert_eq!(client.http_query_sem.available_permits(), 512);
+        drop(held);
+        assert!(other.acquire_signature_status_permits().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn primary_status_cleanup_retains_admission_and_targets_cluster() {
+        let mut server = CleanupServer::new().await;
+        let client = server.client();
+        let (source, http) = client
+            .acquire_signature_status_permits()
+            .await
+            .expect("admission");
+        let (_, id, cleanup) = client.annotate_signature_status_query("SELECT 1".into(), source);
+        let id = id.expect("required ID");
+        assert!(client.shard_routing.is_none());
+        assert_eq!(
+            cleanup.as_ref().expect("guard").cluster.as_deref(),
+            Some("rbx2")
+        );
+        drop(http);
+        drop(cleanup);
+        let sql = server.next_request().await;
+        assert!(sql.contains("KILL QUERY ON CLUSTER 'rbx2'"));
+        assert!(sql.contains(&format!("query_id = '{id}' OR initial_query_id = '{id}'")));
+        assert!(sql.contains("ASYNC"));
+        assert_eq!(client.signature_status_sem.available_permits(), 0);
+        server.responses.add_permits(1);
+        let (source, _http) = tokio::time::timeout(
+            Duration::from_secs(1),
+            client.acquire_signature_status_permits(),
+        )
+        .await
+        .expect("cleanup completes")
+        .expect("admission resumes");
+        drop(source);
+    }
+
+    #[tokio::test]
+    async fn primary_status_cleanup_timeout_releases_admission() {
+        let mut server = CleanupServer::new().await;
+        let mut client = server.client();
+        client.query_timeout = Duration::from_millis(50);
+        let (source, http) = client
+            .acquire_signature_status_permits()
+            .await
+            .expect("admission");
+        let (_, _, cleanup) = client.annotate_signature_status_query("SELECT 1".into(), source);
+        drop(http);
+        drop(cleanup);
+        server.next_request().await;
+        let permits = tokio::time::timeout(
+            Duration::from_secs(1),
+            client.acquire_signature_status_permits(),
+        )
+        .await
+        .expect("bounded cleanup")
+        .expect("admission resumes");
+        drop(permits);
+        assert_eq!(client.signature_status_sem.available_permits(), 1);
+    }
+
+    #[tokio::test]
+    async fn primary_status_cleanup_connection_failure_releases_admission() {
+        let server = CleanupServer::new().await;
+        let client = server.client();
+        server.task.abort();
+        tokio::task::yield_now().await;
+        let (source, http) = client
+            .acquire_signature_status_permits()
+            .await
+            .expect("admission");
+        let (_, _, cleanup) = client.annotate_signature_status_query("SELECT 1".into(), source);
+        drop(http);
+        drop(cleanup);
+        let permits = tokio::time::timeout(
+            Duration::from_secs(1),
+            client.acquire_signature_status_permits(),
+        )
+        .await
+        .expect("cleanup failure bounded")
+        .expect("admission resumes");
+        drop(permits);
+        assert_eq!(client.signature_status_sem.available_permits(), 1);
+    }
+
+    #[tokio::test]
+    async fn primary_status_success_disarms_cleanup_and_releases_admission() {
+        let mut server = CleanupServer::new().await;
+        let client = server.client();
+        let (source, http) = client
+            .acquire_signature_status_permits()
+            .await
+            .expect("admission");
+        let (_, id, mut cleanup) =
+            client.annotate_signature_status_query("SELECT 1".into(), source);
+        assert!(id.is_some());
+        super::HttpQueryCleanup::disarm_optional(&mut cleanup);
+        assert_eq!(client.signature_status_sem.available_permits(), 1);
+        drop(http);
+        drop(cleanup);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(10), server.requests.recv())
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_status_admission_does_not_consume_source_capacity() {
+        let mut client = test_client_with_hot_addresses(Vec::new());
+        client.cache_partition = Some((10, 1));
+        let held = client
+            .signature_status_sem
+            .clone()
+            .acquire_many_owned(4)
+            .await
+            .expect("permits");
+        let (source, _http) = client
+            .acquire_signature_status_permits()
+            .await
+            .expect("cache admission");
+        assert!(source.is_none());
+        drop(held);
+    }
+
+    #[cfg(feature = "disk-cache")]
+    #[test]
+    fn local_table_mapping_clears_primary_cleanup_cluster() {
+        let mut client = test_client_with_hot_addresses(Vec::new());
+        client.query_cleanup_cluster = Some("rbx2".into());
+        client.use_table_names(super::ClickHouseTableNames::in_database("cache"));
+        assert!(client.query_cleanup_cluster.is_none());
+    }
+
+    #[test]
+    fn cleanup_cluster_accepts_macros_and_empty_standalone_identity() {
+        let options = ClickHouseClientOptions::new(
+            RoutingPolicy {
+                transport: RoutingTransport::Http,
+                scope: RoutingScope::Distributed,
+            },
+            None,
+            Vec::new(),
+            "default.gsfa_hot".into(),
+            "default.gsfa_hot_local".into(),
+        )
+        .with_query_cleanup_cluster(" {cluster} ".into());
+        assert_eq!(options.query_cleanup_cluster.as_deref(), Some("{cluster}"));
+        assert!(
+            options
+                .with_query_cleanup_cluster(" ".into())
+                .query_cleanup_cluster
+                .is_none()
+        );
+    }
 
     struct TempTopologyConfig {
         path: PathBuf,

--- a/crates/superbank-rpc/src/clickhouse/disconnect.rs
+++ b/crates/superbank-rpc/src/clickhouse/disconnect.rs
@@ -22,6 +22,12 @@ use crate::processing::{ProcessingError, ProcessingResult};
 const PROBE_TIMEOUT: Duration = Duration::from_secs(1);
 const POLL_INTERVAL: Duration = Duration::from_millis(250);
 const UNCONFIRMED_AFTER: Duration = Duration::from_secs(5);
+const INITIALIZATION_BACKOFF: Duration = Duration::from_secs(1);
+
+#[cfg(test)]
+mod initialization_tests;
+#[cfg(test)]
+mod integration_tests;
 
 #[derive(Clone)]
 pub(crate) struct DisconnectVerifier(Arc<Inner>);
@@ -30,6 +36,7 @@ struct Inner {
     client: HttpClient,
     cluster: Option<String>,
     topology: OnceCell<Topology>,
+    retry_after: Mutex<Option<Instant>>,
     pending: Mutex<BTreeMap<String, Pending>>,
     notify: Arc<Notify>,
     worker_running: AtomicBool,
@@ -66,6 +73,7 @@ impl DisconnectVerifier {
             client,
             cluster,
             topology: OnceCell::new(),
+            retry_after: Mutex::new(None),
             pending: Mutex::new(BTreeMap::new()),
             notify: Arc::new(Notify::new()),
             worker_running: AtomicBool::new(false),
@@ -81,7 +89,7 @@ impl DisconnectVerifier {
     ) -> ProcessingResult<DisconnectGuard> {
         self.0
             .topology
-            .get_or_try_init(|| discover(&self.0))
+            .get_or_try_init(|| self.initialize())
             .await?;
         start_worker(&self.0);
         Ok(DisconnectGuard {
@@ -89,6 +97,48 @@ impl DisconnectVerifier {
             query_id,
             permit: Some(permit),
         })
+    }
+
+    async fn initialize(&self) -> ProcessingResult<Topology> {
+        let mut attempt = InitializationAttempt::begin(&self.0.retry_after)?;
+        let topology = discover(&self.0).await?;
+        attempt.succeeded = true;
+        Ok(topology)
+    }
+}
+
+// OnceCell serializes attempts. This guard also applies backoff when the caller
+// drops initialization while it is awaiting ClickHouse; no lock crosses an await.
+struct InitializationAttempt<'a> {
+    retry_after: &'a Mutex<Option<Instant>>,
+    succeeded: bool,
+}
+
+impl<'a> InitializationAttempt<'a> {
+    fn begin(retry_after: &'a Mutex<Option<Instant>>) -> ProcessingResult<Self> {
+        if retry_after
+            .lock()
+            .expect("disconnect initialization state poisoned")
+            .is_some_and(|deadline| Instant::now() < deadline)
+        {
+            return Err(ProcessingError::database_msg(
+                "primary disconnect verification initialization is backing off",
+            ));
+        }
+        Ok(Self {
+            retry_after,
+            succeeded: false,
+        })
+    }
+}
+
+impl Drop for InitializationAttempt<'_> {
+    fn drop(&mut self) {
+        *self
+            .retry_after
+            .lock()
+            .expect("disconnect initialization state poisoned") =
+            (!self.succeeded).then(|| Instant::now() + INITIALIZATION_BACKOFF);
     }
 }
 
@@ -237,7 +287,7 @@ fn discovery_sql(cluster: Option<&str>) -> String {
     };
     format!(
         "SELECT hostName() AS node, toUInt64(0) AS expected, toUInt8(0) AS coordinator FROM {} \
-         UNION ALL SELECT hostName() AS node, (SELECT count() FROM system.clusters WHERE cluster = {}) AS expected, \
+         UNION ALL SELECT hostName() AS node, ifNull((SELECT count() FROM system.clusters WHERE cluster = {}), toUInt64(0)) AS expected, \
          toUInt8(1) AS coordinator FROM system.one",
         table(Some(cluster), "one"),
         quoted(cluster),
@@ -283,7 +333,7 @@ async fn resolve_cluster(owner: &Inner) -> ProcessingResult<Option<String>> {
     if !cluster.contains('{') {
         return Ok(Some(cluster.into()));
     }
-    let rows = fetch::<MacroRow>(&owner.client, &macro_sql(cluster)?).await?;
+    let rows = fetch::<MacroRow>(&owner.client, &macro_sql(cluster)?, "macro_resolution").await?;
     let mut rows = rows.into_iter();
     let resolved = rows
         .next()
@@ -300,8 +350,22 @@ async fn resolve_cluster(owner: &Inner) -> ProcessingResult<Option<String>> {
 }
 
 async fn discover(owner: &Inner) -> ProcessingResult<Topology> {
+    let topology = discover_topology(owner).await?;
+    // Exercise the same table, decoder, coverage checks and settings needed to
+    // release admission. A unique nonempty ID prevents an empty-set shortcut.
+    let id = next_required_query_id("status_disconnect_preflight");
+    probe_topology(&owner.client, &topology, &[id], "capability_probe").await?;
+    Ok(topology)
+}
+
+async fn discover_topology(owner: &Inner) -> ProcessingResult<Topology> {
     let cluster = resolve_cluster(owner).await?;
-    let rows = fetch::<DiscoveryRow>(&owner.client, &discovery_sql(cluster.as_deref())).await?;
+    let rows = fetch::<DiscoveryRow>(
+        &owner.client,
+        &discovery_sql(cluster.as_deref()),
+        "discovery",
+    )
+    .await?;
     Ok(Topology {
         nodes: validate_topology(rows, cluster.is_some())?,
         cluster,
@@ -365,8 +429,17 @@ async fn probe(owner: &Inner, ids: &[String]) -> ProcessingResult<HashSet<String
         .topology
         .get()
         .expect("topology precedes source submission");
+    probe_topology(&owner.client, topology, ids, "termination_probe").await
+}
+
+async fn probe_topology(
+    client: &HttpClient,
+    topology: &Topology,
+    ids: &[String],
+    phase: &'static str,
+) -> ProcessingResult<HashSet<String>> {
     let rows =
-        fetch::<ProbeRow>(&owner.client, &probe_sql(topology.cluster.as_deref(), ids)).await?;
+        fetch::<ProbeRow>(client, &probe_sql(topology.cluster.as_deref(), ids), phase).await?;
     validate_observation(rows, &topology.nodes)
 }
 
@@ -399,6 +472,7 @@ fn validate_observation(
 async fn fetch<T: clickhouse::RowOwned + clickhouse::RowRead>(
     client: &HttpClient,
     sql: &str,
+    phase: &'static str,
 ) -> ProcessingResult<Vec<T>> {
     let query = client
         .query(sql)
@@ -421,8 +495,16 @@ async fn fetch<T: clickhouse::RowOwned + clickhouse::RowRead>(
         .with_setting("use_query_cache", "0");
     tokio::time::timeout(PROBE_TIMEOUT, query.fetch_all::<T>())
         .await
-        .map_err(|error| ProcessingError::timeout("primary disconnect verification", error))?
-        .map_err(|error| ProcessingError::database("primary disconnect verification", error))
+        .map_err(|error| {
+            tracing::warn!(phase, %error, "Primary disconnect verification timed out");
+            ProcessingError::timeout("primary disconnect verification", error)
+        })?
+        .map_err(|error| {
+            // Log the SDK cause before wrapping it in the stable RPC-facing context.
+            // Do not log the client, credentials or SQL/request payload.
+            tracing::warn!(phase, ?error, "Primary disconnect verification failed");
+            ProcessingError::database("primary disconnect verification", error)
+        })
 }
 
 #[cfg(test)]
@@ -731,6 +813,10 @@ mod tests {
         bytes.extend_from_slice(value.as_bytes());
     }
 
+    fn is_termination_probe(sql: &str) -> bool {
+        sql.contains("system.processes") && !sql.contains("status_disconnect_preflight")
+    }
+
     #[tokio::test]
     async fn worker_batches_ids_uses_http_settings_and_stops_with_owner() {
         use axum::extract::OriginalUri;
@@ -805,7 +891,7 @@ mod tests {
             assert_eq!(params["max_execution_time_leaf"], "1");
             assert!(params.contains_key("query_id"));
             assert!(!sql.contains("KILL"));
-            if sql.contains("system.processes") {
+            if is_termination_probe(&sql) {
                 assert!(sql.contains("q1") && sql.contains("q2"));
                 probes += 1;
             }

--- a/crates/superbank-rpc/src/clickhouse/disconnect.rs
+++ b/crates/superbank-rpc/src/clickhouse/disconnect.rs
@@ -1,0 +1,826 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+/* Copyright 2025-2026 Triton One Limited. All rights reserved. */
+
+//! Admission accounting for primary HTTP reads abandoned by their caller.
+//!
+//! Disconnect is the cancellation mechanism. These read-only probes observe
+//! termination; they never issue KILL or acquire a source-query permit.
+
+use std::collections::{BTreeMap, HashSet};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex, Weak};
+use std::time::Duration;
+
+use clickhouse::Client as HttpClient;
+use serde::Deserialize;
+use tokio::sync::{Notify, OnceCell, OwnedSemaphorePermit};
+use tokio::time::Instant;
+
+use super::util::next_required_query_id;
+use crate::processing::{ProcessingError, ProcessingResult};
+
+const PROBE_TIMEOUT: Duration = Duration::from_secs(1);
+const POLL_INTERVAL: Duration = Duration::from_millis(250);
+const UNCONFIRMED_AFTER: Duration = Duration::from_secs(5);
+
+#[derive(Clone)]
+pub(crate) struct DisconnectVerifier(Arc<Inner>);
+
+struct Inner {
+    client: HttpClient,
+    cluster: Option<String>,
+    topology: OnceCell<Topology>,
+    pending: Mutex<BTreeMap<String, Pending>>,
+    notify: Arc<Notify>,
+    worker_running: AtomicBool,
+}
+
+#[derive(Debug)]
+struct Topology {
+    nodes: HashSet<String>,
+    cluster: Option<String>,
+}
+
+struct Pending {
+    _permit: OwnedSemaphorePermit,
+    abandoned_at: Instant,
+    quiet_observations: u8,
+    unconfirmed: bool,
+}
+
+impl Drop for Pending {
+    fn drop(&mut self) {
+        crate::metrics::signature_status_disconnect_pending_dec();
+    }
+}
+
+pub(crate) struct DisconnectGuard {
+    owner: Arc<Inner>,
+    query_id: String,
+    permit: Option<OwnedSemaphorePermit>,
+}
+
+impl DisconnectVerifier {
+    pub(crate) fn new(client: HttpClient, cluster: Option<String>) -> Self {
+        Self(Arc::new(Inner {
+            client,
+            cluster,
+            topology: OnceCell::new(),
+            pending: Mutex::new(BTreeMap::new()),
+            notify: Arc::new(Notify::new()),
+            worker_running: AtomicBool::new(false),
+        }))
+    }
+
+    /// Discover complete coverage and validate required HTTP settings before
+    /// submitting source work. Discovery failure is safe to release admission.
+    pub(crate) async fn arm(
+        &self,
+        query_id: String,
+        permit: OwnedSemaphorePermit,
+    ) -> ProcessingResult<DisconnectGuard> {
+        self.0
+            .topology
+            .get_or_try_init(|| discover(&self.0))
+            .await?;
+        start_worker(&self.0);
+        Ok(DisconnectGuard {
+            owner: self.0.clone(),
+            query_id,
+            permit: Some(permit),
+        })
+    }
+}
+
+impl DisconnectGuard {
+    /// Only call after a fully consumed successful response, or before submission.
+    pub(crate) fn disarm(&mut self) {
+        self.permit = None;
+    }
+}
+
+impl Drop for DisconnectGuard {
+    fn drop(&mut self) {
+        let Some(permit) = self.permit.take() else {
+            return;
+        };
+        crate::metrics::signature_status_disconnect_pending_inc();
+        let pending = Pending {
+            _permit: permit,
+            abandoned_at: Instant::now(),
+            quiet_observations: 0,
+            unconfirmed: false,
+        };
+        // Required query IDs are unique across the client lifetime. Keeping the
+        // map in the owner also retains admission if no runtime can run probes.
+        self.owner
+            .pending
+            .lock()
+            .expect("disconnect state poisoned")
+            .insert(self.query_id.clone(), pending);
+        start_worker(&self.owner);
+        self.owner.notify.notify_one();
+    }
+}
+
+struct WorkerExit(Weak<Inner>);
+
+impl Drop for WorkerExit {
+    fn drop(&mut self) {
+        if let Some(owner) = self.0.upgrade() {
+            owner.worker_running.store(false, Ordering::Release);
+        }
+    }
+}
+
+fn start_worker(owner: &Arc<Inner>) {
+    let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+        return;
+    };
+    if owner
+        .worker_running
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return;
+    }
+    let weak = Arc::downgrade(owner);
+    let notify = owner.notify.clone();
+    let exit = WorkerExit(weak.clone());
+    runtime.spawn(worker(weak, notify, exit));
+}
+
+async fn worker(weak: Weak<Inner>, notify: Arc<Notify>, _exit: WorkerExit) {
+    loop {
+        let Some(owner) = weak.upgrade() else { return };
+        let ids: Vec<String> = owner
+            .pending
+            .lock()
+            .expect("disconnect state poisoned")
+            .keys()
+            .cloned()
+            .collect();
+        if ids.is_empty() {
+            drop(owner);
+            // Periodic weak upgrade notices service shutdown without retaining it.
+            tokio::select! {
+                _ = notify.notified() => {},
+                _ = tokio::time::sleep(PROBE_TIMEOUT) => {},
+            }
+            continue;
+        }
+        let result = probe(&owner, &ids).await;
+        let interval = apply_observation(&owner, &ids, result.as_ref().ok());
+        if let Err(error) = result {
+            tracing::warn!(%error, "Unable to verify abandoned primary status queries");
+        }
+        drop(owner);
+        // New arrivals cannot accelerate an existing ID's second quiet check.
+        tokio::time::sleep(interval).await;
+    }
+}
+
+fn apply_observation(owner: &Inner, ids: &[String], active: Option<&HashSet<String>>) -> Duration {
+    let mut pending = owner.pending.lock().expect("disconnect state poisoned");
+    for id in ids {
+        let Some(entry) = pending.get_mut(id) else {
+            continue;
+        };
+        entry.quiet_observations = match active {
+            Some(active) if !active.contains(id) => entry.quiet_observations + 1,
+            _ => 0,
+        };
+        if entry.quiet_observations >= 2 {
+            tracing::debug!(query_id = %id, "Observed primary status query termination");
+            crate::metrics::signature_status_disconnect_verification("confirmed_absent");
+            pending.remove(id);
+        } else if entry.abandoned_at.elapsed() >= UNCONFIRMED_AFTER && !entry.unconfirmed {
+            entry.unconfirmed = true;
+            tracing::warn!(query_id = %id, "Primary status termination unconfirmed; retaining admission");
+            crate::metrics::signature_status_disconnect_verification("unconfirmed");
+        }
+    }
+    if pending.values().all(|entry| entry.unconfirmed) {
+        PROBE_TIMEOUT
+    } else {
+        POLL_INTERVAL
+    }
+}
+
+#[derive(clickhouse::Row, Deserialize)]
+struct DiscoveryRow {
+    node: String,
+    expected: u64,
+    coordinator: u8,
+}
+
+#[derive(clickhouse::Row, Deserialize)]
+struct ProbeRow {
+    node: String,
+    active_id: String,
+}
+
+fn quoted(value: &str) -> String {
+    format!("'{}'", value.replace('\\', "\\\\").replace('\'', "\\'"))
+}
+
+fn table(cluster: Option<&str>, name: &str) -> String {
+    match cluster {
+        Some(cluster) => format!("clusterAllReplicas({}, system.{name})", quoted(cluster)),
+        None => format!("system.{name}"),
+    }
+}
+
+fn discovery_sql(cluster: Option<&str>) -> String {
+    let Some(cluster) = cluster else {
+        return "SELECT hostName() AS node, toUInt64(1) AS expected, toUInt8(1) AS coordinator FROM system.one".into();
+    };
+    format!(
+        "SELECT hostName() AS node, toUInt64(0) AS expected, toUInt8(0) AS coordinator FROM {} \
+         UNION ALL SELECT hostName() AS node, (SELECT count() FROM system.clusters WHERE cluster = {}) AS expected, \
+         toUInt8(1) AS coordinator FROM system.one",
+        table(Some(cluster), "one"),
+        quoted(cluster),
+    )
+}
+
+#[derive(clickhouse::Row, Deserialize)]
+struct MacroRow {
+    cluster: String,
+}
+
+// Table functions expand macros, but system.clusters contains resolved names.
+// Resolve once through ClickHouse so both discovery and probes use that name.
+fn macro_sql(cluster: &str) -> ProcessingResult<String> {
+    let mut remaining = cluster;
+    let mut pieces = Vec::new();
+    while let Some(start) = remaining.find('{') {
+        pieces.push(quoted(&remaining[..start]));
+        let end = remaining[start..]
+            .find('}')
+            .ok_or_else(|| ProcessingError::database_msg("unclosed ClickHouse cluster macro"))?
+            + start;
+        let name = &remaining[start + 1..end];
+        if name.is_empty() || name.contains('{') {
+            return Err(ProcessingError::database_msg(
+                "invalid ClickHouse cluster macro",
+            ));
+        }
+        pieces.push(format!("getMacro({})", quoted(name)));
+        remaining = &remaining[end + 1..];
+    }
+    pieces.push(quoted(remaining));
+    Ok(format!(
+        "SELECT concat({}) AS cluster FROM system.one",
+        pieces.join(", ")
+    ))
+}
+
+async fn resolve_cluster(owner: &Inner) -> ProcessingResult<Option<String>> {
+    let Some(cluster) = owner.cluster.as_deref() else {
+        return Ok(None);
+    };
+    if !cluster.contains('{') {
+        return Ok(Some(cluster.into()));
+    }
+    let rows = fetch::<MacroRow>(&owner.client, &macro_sql(cluster)?).await?;
+    let mut rows = rows.into_iter();
+    let resolved = rows
+        .next()
+        .filter(|row| !row.cluster.is_empty())
+        .ok_or_else(|| {
+            ProcessingError::database_msg("empty ClickHouse cluster macro resolution")
+        })?;
+    if rows.next().is_some() {
+        return Err(ProcessingError::database_msg(
+            "ambiguous ClickHouse cluster macro resolution",
+        ));
+    }
+    Ok(Some(resolved.cluster))
+}
+
+async fn discover(owner: &Inner) -> ProcessingResult<Topology> {
+    let cluster = resolve_cluster(owner).await?;
+    let rows = fetch::<DiscoveryRow>(&owner.client, &discovery_sql(cluster.as_deref())).await?;
+    Ok(Topology {
+        nodes: validate_topology(rows, cluster.is_some())?,
+        cluster,
+    })
+}
+
+fn validate_topology(
+    rows: Vec<DiscoveryRow>,
+    distributed: bool,
+) -> ProcessingResult<HashSet<String>> {
+    let mut expected = None;
+    let mut coordinator = None;
+    let mut nodes = HashSet::new();
+    for row in rows {
+        if row.coordinator == 1 {
+            if coordinator.replace(row.node.clone()).is_some() {
+                return Err(ProcessingError::database_msg(
+                    "duplicate verification coordinator",
+                ));
+            }
+            expected = Some(row.expected);
+            if !distributed {
+                nodes.insert(row.node);
+            }
+        } else if row.node.is_empty() || !nodes.insert(row.node) {
+            return Err(ProcessingError::database_msg(
+                "ambiguous verification replica identity",
+            ));
+        }
+    }
+    let complete = expected == Some(nodes.len() as u64)
+        && !nodes.is_empty()
+        && coordinator
+            .as_ref()
+            .is_some_and(|node| nodes.contains(node));
+    if !complete {
+        return Err(ProcessingError::database_msg(
+            "incomplete primary disconnect verification topology",
+        ));
+    }
+    Ok(nodes)
+}
+
+fn probe_sql(cluster: Option<&str>, ids: &[String]) -> String {
+    let ids = ids
+        .iter()
+        .map(|id| quoted(id))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "SELECT hostName() AS node, '' AS active_id FROM {} \
+         UNION ALL SELECT hostName() AS node, if(query_id IN ({ids}), query_id, initial_query_id) AS active_id \
+         FROM {} WHERE query_id IN ({ids}) OR initial_query_id IN ({ids})",
+        table(cluster, "one"),
+        table(cluster, "processes"),
+    )
+}
+
+async fn probe(owner: &Inner, ids: &[String]) -> ProcessingResult<HashSet<String>> {
+    let topology = owner
+        .topology
+        .get()
+        .expect("topology precedes source submission");
+    let rows =
+        fetch::<ProbeRow>(&owner.client, &probe_sql(topology.cluster.as_deref(), ids)).await?;
+    validate_observation(rows, &topology.nodes)
+}
+
+fn validate_observation(
+    rows: Vec<ProbeRow>,
+    expected: &HashSet<String>,
+) -> ProcessingResult<HashSet<String>> {
+    let mut covered = HashSet::new();
+    let mut active = HashSet::new();
+    for row in rows {
+        if !expected.contains(&row.node) {
+            return Err(ProcessingError::database_msg(
+                "primary verification topology changed",
+            ));
+        }
+        if row.active_id.is_empty() {
+            covered.insert(row.node);
+        } else {
+            active.insert(row.active_id);
+        }
+    }
+    if &covered != expected {
+        return Err(ProcessingError::database_msg(
+            "incomplete primary verification coverage",
+        ));
+    }
+    Ok(active)
+}
+
+async fn fetch<T: clickhouse::RowOwned + clickhouse::RowRead>(
+    client: &HttpClient,
+    sql: &str,
+) -> ProcessingResult<Vec<T>> {
+    let query = client
+        .query(sql)
+        .with_setting(
+            "query_id",
+            next_required_query_id("status_disconnect_verification"),
+        )
+        .with_setting("readonly", "2")
+        .with_setting("cancel_http_readonly_queries_on_client_close", "1")
+        .with_setting("max_threads", "1")
+        .with_setting("max_threads_for_indexes", "1")
+        .with_setting("max_parallel_replicas", "1")
+        .with_setting("use_hedged_requests", "0")
+        .with_setting("skip_unavailable_shards", "0")
+        .with_setting("max_execution_time", "1")
+        .with_setting("max_execution_time_leaf", "1")
+        .with_setting("timeout_overflow_mode", "throw")
+        .with_setting("timeout_overflow_mode_leaf", "throw")
+        .with_setting("timeout_before_checking_execution_speed", "0")
+        .with_setting("use_query_cache", "0");
+    tokio::time::timeout(PROBE_TIMEOUT, query.fetch_all::<T>())
+        .await
+        .map_err(|error| ProcessingError::timeout("primary disconnect verification", error))?
+        .map_err(|error| ProcessingError::database("primary disconnect verification", error))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+    use tokio::sync::Semaphore;
+
+    fn verifier() -> DisconnectVerifier {
+        let verifier = DisconnectVerifier::new(HttpClient::default(), None);
+        verifier
+            .0
+            .topology
+            .set(Topology {
+                nodes: HashSet::from(["node1".into()]),
+                cluster: None,
+            })
+            .unwrap();
+        verifier
+    }
+
+    fn pending(verifier: &DisconnectVerifier, semaphore: &Arc<Semaphore>, id: &str) {
+        crate::metrics::signature_status_disconnect_pending_inc();
+        verifier.0.pending.lock().unwrap().insert(
+            id.into(),
+            Pending {
+                _permit: semaphore.clone().try_acquire_owned().unwrap(),
+                abandoned_at: Instant::now(),
+                quiet_observations: 0,
+                unconfirmed: false,
+            },
+        );
+    }
+
+    #[test]
+    fn discovery_rejects_missing_ambiguous_or_outside_coordinator() {
+        let row = |node: &str, expected, coordinator| DiscoveryRow {
+            node: node.into(),
+            expected,
+            coordinator,
+        };
+        assert!(validate_topology(vec![row("a", 0, 0), row("a", 1, 1)], true).is_ok());
+        assert!(validate_topology(vec![row("a", 0, 0), row("a", 2, 1)], true).is_err());
+        assert!(
+            validate_topology(vec![row("a", 0, 0), row("a", 0, 0), row("a", 2, 1)], true).is_err()
+        );
+        assert!(validate_topology(vec![row("a", 0, 0), row("gateway", 1, 1)], true).is_err());
+        assert!(validate_topology(Vec::new(), true).is_err());
+    }
+
+    #[test]
+    fn probes_require_complete_sentinels_and_track_initial_ids() {
+        let expected = HashSet::from(["a".into(), "b".into()]);
+        let row = |node: &str, id: &str| ProbeRow {
+            node: node.into(),
+            active_id: id.into(),
+        };
+        assert!(validate_observation(vec![row("a", ""), row("b", "q")], &expected).is_err());
+        assert!(validate_observation(vec![row("a", ""), row("new", "")], &expected).is_err());
+        let active =
+            validate_observation(vec![row("a", ""), row("b", ""), row("b", "q")], &expected)
+                .unwrap();
+        assert_eq!(active, HashSet::from(["q".into()]));
+        let sql = probe_sql(Some("rbx2"), &["q".into()]);
+        assert!(sql.contains("initial_query_id"));
+        assert!(!sql.contains("KILL"));
+        assert_eq!(quoted("a'\\b"), "'a\\'\\\\b'");
+    }
+
+    #[tokio::test]
+    async fn errors_and_active_work_reset_quiet_new_ids_do_not_inherit_observations() {
+        let verifier = verifier();
+        let semaphore = Arc::new(Semaphore::new(2));
+        pending(&verifier, &semaphore, "old");
+        let old = vec!["old".into()];
+        let quiet = HashSet::new();
+        apply_observation(&verifier.0, &old, Some(&quiet));
+        apply_observation(&verifier.0, &old, None);
+        apply_observation(&verifier.0, &old, Some(&quiet));
+        assert_eq!(semaphore.available_permits(), 1);
+        apply_observation(&verifier.0, &old, Some(&HashSet::from(["old".into()])));
+        apply_observation(&verifier.0, &old, Some(&quiet));
+        pending(&verifier, &semaphore, "new");
+        apply_observation(&verifier.0, &old, Some(&quiet));
+        assert_eq!(semaphore.available_permits(), 1);
+        let new = vec!["new".into()];
+        apply_observation(&verifier.0, &new, Some(&quiet));
+        assert_eq!(semaphore.available_permits(), 1);
+        apply_observation(&verifier.0, &new, Some(&quiet));
+        assert_eq!(semaphore.available_permits(), 2);
+    }
+
+    #[tokio::test]
+    async fn unconfirmed_work_retains_admission_until_recovery() {
+        let verifier = verifier();
+        let semaphore = Arc::new(Semaphore::new(1));
+        pending(&verifier, &semaphore, "q");
+        verifier
+            .0
+            .pending
+            .lock()
+            .unwrap()
+            .get_mut("q")
+            .unwrap()
+            .abandoned_at = Instant::now() - Duration::from_secs(6);
+        let ids = vec!["q".into()];
+        assert_eq!(apply_observation(&verifier.0, &ids, None), PROBE_TIMEOUT);
+        assert_eq!(semaphore.available_permits(), 0);
+        assert!(verifier.0.pending.lock().unwrap()["q"].unconfirmed);
+        apply_observation(&verifier.0, &ids, Some(&HashSet::new()));
+        assert_eq!(semaphore.available_permits(), 0);
+        apply_observation(&verifier.0, &ids, Some(&HashSet::new()));
+        assert_eq!(semaphore.available_permits(), 1);
+    }
+
+    #[test]
+    fn missing_runtime_retains_admission_until_owner_shutdown() {
+        let verifier = verifier();
+        let semaphore = Arc::new(Semaphore::new(1));
+        let guard = DisconnectGuard {
+            owner: verifier.0.clone(),
+            query_id: "q".into(),
+            permit: Some(semaphore.clone().try_acquire_owned().unwrap()),
+        };
+        drop(guard);
+        assert_eq!(semaphore.available_permits(), 0);
+        assert!(!verifier.0.worker_running.load(Ordering::Acquire));
+        drop(verifier);
+        assert_eq!(semaphore.available_permits(), 1);
+    }
+
+    #[test]
+    fn successful_guard_releases_without_probe() {
+        let verifier = verifier();
+        let semaphore = Arc::new(Semaphore::new(1));
+        let mut guard = DisconnectGuard {
+            owner: verifier.0.clone(),
+            query_id: "q".into(),
+            permit: Some(semaphore.clone().try_acquire_owned().unwrap()),
+        };
+        guard.disarm();
+        drop(guard);
+        assert_eq!(semaphore.available_permits(), 1);
+        assert!(verifier.0.pending.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn cluster_macros_are_resolved_before_topology_lookup() {
+        assert_eq!(
+            macro_sql("prefix-{cluster}-{zone}").unwrap(),
+            "SELECT concat('prefix-', getMacro('cluster'), '-', getMacro('zone'), '') AS cluster FROM system.one"
+        );
+        assert!(macro_sql("{unclosed").is_err());
+        assert!(macro_sql("{}").is_err());
+        assert!(macro_sql("{{nested}").is_err());
+    }
+
+    #[tokio::test]
+    async fn slow_probe_keeps_permit_and_inflight_worker_exits_on_owner_shutdown() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let (sender, mut requests) = tokio::sync::mpsc::unbounded_channel();
+        let app = axum::Router::new().fallback(move || {
+            let sender = sender.clone();
+            async move {
+                let _ = sender.send(());
+                tokio::time::sleep(Duration::from_secs(10)).await;
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR
+            }
+        });
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let verifier = DisconnectVerifier::new(HttpClient::default().with_url(url), None);
+        verifier
+            .0
+            .topology
+            .set(Topology {
+                nodes: HashSet::from(["node1".into()]),
+                cluster: None,
+            })
+            .unwrap();
+        let semaphore = Arc::new(Semaphore::new(1));
+        drop(
+            verifier
+                .arm("q".into(), semaphore.clone().acquire_owned().await.unwrap())
+                .await
+                .unwrap(),
+        );
+        tokio::time::timeout(Duration::from_secs(2), requests.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        // The second probe proves the first timed out and reset quiet accounting.
+        tokio::time::timeout(Duration::from_secs(2), requests.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(semaphore.available_permits(), 0);
+        assert_eq!(
+            verifier.0.pending.lock().unwrap()["q"].quiet_observations,
+            0
+        );
+        let weak = Arc::downgrade(&verifier.0);
+        drop(verifier);
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while weak.upgrade().is_some() {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap();
+        assert_eq!(semaphore.available_permits(), 1);
+        server.abort();
+    }
+
+    async fn read_http_request(socket: &mut tokio::net::TcpStream) {
+        use tokio::io::AsyncReadExt;
+        let mut request = Vec::new();
+        let mut buffer = [0_u8; 2048];
+        let header_end = loop {
+            let n = socket.read(&mut buffer).await.unwrap();
+            assert!(n > 0);
+            request.extend_from_slice(&buffer[..n]);
+            if let Some(end) = request.windows(4).position(|window| window == b"\r\n\r\n") {
+                break end + 4;
+            }
+        };
+        let headers = std::str::from_utf8(&request[..header_end]).unwrap();
+        let content_length: usize = headers
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                name.eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse().unwrap())
+            })
+            .expect("sized ClickHouse query body");
+        while request.len() < header_end + content_length {
+            let n = socket.read(&mut buffer).await.unwrap();
+            assert!(n > 0);
+            request.extend_from_slice(&buffer[..n]);
+        }
+    }
+
+    async fn assert_transport_disconnect(streaming: bool) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            read_http_request(&mut socket).await;
+            if streaming {
+                socket.write_all(b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nContent-Type: application/octet-stream\r\n\r\n8\r\n").await.unwrap();
+                socket.write_all(&42_u64.to_le_bytes()).await.unwrap();
+                socket.write_all(b"\r\n").await.unwrap();
+            }
+            ready_tx.send(()).unwrap();
+            let mut byte = [0_u8; 1];
+            let closed = tokio::time::timeout(Duration::from_secs(2), socket.read(&mut byte))
+                .await
+                .expect("dropping query must close upstream socket");
+            assert!(
+                matches!(closed, Ok(0)) || closed.is_err(),
+                "upstream socket remained readable"
+            );
+        });
+        let client = super::super::client::build_clickhouse_http_client(
+            &url,
+            "default",
+            "",
+            "",
+            PROBE_TIMEOUT,
+        )
+        .with_validation(false)
+        .with_compression(clickhouse::Compression::None);
+        let query = client
+            .query("SELECT toUInt64(42)")
+            .with_setting("readonly", "2")
+            .with_setting("cancel_http_readonly_queries_on_client_close", "1");
+        if streaming {
+            let mut cursor = query.fetch::<u64>().unwrap();
+            assert_eq!(cursor.next().await.unwrap(), Some(42));
+            ready_rx.await.unwrap();
+            drop(cursor);
+        } else {
+            let task = tokio::spawn(query.fetch_all::<u64>());
+            ready_rx.await.unwrap();
+            task.abort();
+            assert!(task.await.unwrap_err().is_cancelled());
+        }
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn production_http_transport_closes_when_dropped_before_headers() {
+        assert_transport_disconnect(false).await;
+    }
+
+    #[tokio::test]
+    async fn production_http_transport_closes_when_streaming_cursor_is_dropped() {
+        assert_transport_disconnect(true).await;
+    }
+
+    fn string(bytes: &mut Vec<u8>, value: &str) {
+        assert!(value.len() < 128);
+        bytes.push(value.len() as u8);
+        bytes.extend_from_slice(value.as_bytes());
+    }
+
+    #[tokio::test]
+    async fn worker_batches_ids_uses_http_settings_and_stops_with_owner() {
+        use axum::extract::OriginalUri;
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let (sender, mut requests) = tokio::sync::mpsc::unbounded_channel();
+        let active = Arc::new(AtomicUsize::new(0));
+        let maximum = Arc::new(AtomicUsize::new(0));
+        let active_handler = active.clone();
+        let maximum_handler = maximum.clone();
+        let app = axum::Router::new().fallback(
+            move |OriginalUri(uri): OriginalUri, body: axum::body::Bytes| {
+                let sender = sender.clone();
+                let active = active_handler.clone();
+                let maximum = maximum_handler.clone();
+                async move {
+                    let count = active.fetch_add(1, Ordering::SeqCst) + 1;
+                    maximum.fetch_max(count, Ordering::SeqCst);
+                    let sql = String::from_utf8(body.to_vec()).unwrap();
+                    sender.send((uri.to_string(), sql.clone())).unwrap();
+                    let mut bytes = Vec::new();
+                    string(&mut bytes, "node1");
+                    if sql.contains("AS coordinator") {
+                        bytes.extend_from_slice(&1_u64.to_le_bytes());
+                        bytes.push(1);
+                    } else {
+                        string(&mut bytes, "");
+                    }
+                    tokio::time::sleep(Duration::from_millis(5)).await;
+                    active.fetch_sub(1, Ordering::SeqCst);
+                    bytes
+                }
+            },
+        );
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let client = HttpClient::default()
+            .with_url(url)
+            .with_validation(false)
+            .with_compression(clickhouse::Compression::None);
+        let verifier = DisconnectVerifier::new(client, None);
+        let semaphore = Arc::new(Semaphore::new(2));
+        let first = verifier
+            .arm(
+                "q1".into(),
+                semaphore.clone().acquire_owned().await.unwrap(),
+            )
+            .await
+            .unwrap();
+        let second = verifier
+            .arm(
+                "q2".into(),
+                semaphore.clone().acquire_owned().await.unwrap(),
+            )
+            .await
+            .unwrap();
+        drop(first);
+        drop(second);
+        tokio::time::timeout(Duration::from_secs(3), async {
+            while semaphore.available_permits() != 2 {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap();
+        let mut probes = 0;
+        while let Ok((uri, sql)) = requests.try_recv() {
+            let url = reqwest::Url::parse(&format!("http://localhost{uri}")).unwrap();
+            let params: BTreeMap<_, _> = url.query_pairs().into_owned().collect();
+            assert_eq!(params["readonly"], "2");
+            assert_eq!(params["cancel_http_readonly_queries_on_client_close"], "1");
+            assert_eq!(params["skip_unavailable_shards"], "0");
+            assert_eq!(params["max_execution_time_leaf"], "1");
+            assert!(params.contains_key("query_id"));
+            assert!(!sql.contains("KILL"));
+            if sql.contains("system.processes") {
+                assert!(sql.contains("q1") && sql.contains("q2"));
+                probes += 1;
+            }
+        }
+        assert_eq!(probes, 2);
+        assert_eq!(maximum.load(Ordering::SeqCst), 1);
+        let weak = Arc::downgrade(&verifier.0);
+        drop(verifier);
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while weak.upgrade().is_some() {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .unwrap();
+        server.abort();
+    }
+}

--- a/crates/superbank-rpc/src/clickhouse/disconnect/initialization_tests.rs
+++ b/crates/superbank-rpc/src/clickhouse/disconnect/initialization_tests.rs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Deterministic failure sequencing; real protocol coverage lives in integration_tests.
+use super::*;
+use std::sync::atomic::AtomicU8;
+use tokio::sync::Semaphore;
+
+struct Fixture {
+    verifier: DisconnectVerifier,
+    mode: Arc<AtomicU8>,
+    requests: Arc<std::sync::atomic::AtomicUsize>,
+    entered: Arc<Notify>,
+    server: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        self.server.abort();
+    }
+}
+
+impl Fixture {
+    async fn new(mode: u8) -> Self {
+        use axum::response::IntoResponse;
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let mode = Arc::new(AtomicU8::new(mode));
+        let requests = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let entered = Arc::new(Notify::new());
+        let app = axum::Router::new().fallback({
+            let (mode, requests, entered) = (mode.clone(), requests.clone(), entered.clone());
+            move |body: String| {
+                let (mode, requests, entered) = (mode.clone(), requests.clone(), entered.clone());
+                async move {
+                    requests.fetch_add(1, Ordering::SeqCst);
+                    entered.notify_one();
+                    if mode.load(Ordering::SeqCst) == 2 {
+                        std::future::pending::<()>().await;
+                    }
+                    if mode.load(Ordering::SeqCst) == 0 && body.contains("system.processes") {
+                        return (
+                            axum::http::StatusCode::FORBIDDEN,
+                            "process inspection denied",
+                        )
+                            .into_response();
+                    }
+                    let mut bytes = vec![5, b'n', b'o', b'd', b'e', b'1'];
+                    if body.contains("AS coordinator") {
+                        bytes.extend_from_slice(&1_u64.to_le_bytes());
+                        bytes.push(1);
+                    } else {
+                        assert!(body.contains("system.processes"));
+                        bytes.push(0);
+                    }
+                    bytes.into_response()
+                }
+            }
+        });
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let client = HttpClient::default()
+            .with_url(url)
+            .with_validation(false)
+            .with_compression(clickhouse::Compression::None);
+        Self {
+            verifier: DisconnectVerifier::new(client, None),
+            mode,
+            requests,
+            entered,
+            server,
+        }
+    }
+
+    async fn assert_backoff(&self, permits: &Arc<Semaphore>, expected_requests: usize) {
+        let mut tasks = tokio::task::JoinSet::new();
+        for i in 0..32 {
+            let verifier = self.verifier.clone();
+            let permit = permits.clone().try_acquire_owned().unwrap();
+            tasks.spawn(async move { verifier.arm(format!("retry-{i}"), permit).await.is_err() });
+        }
+        while let Some(result) = tasks.join_next().await {
+            assert!(result.unwrap());
+        }
+        assert_eq!(self.requests.load(Ordering::SeqCst), expected_requests);
+        assert_eq!(permits.available_permits(), 64);
+        assert!(self.verifier.0.topology.get().is_none());
+        assert!(self.verifier.0.pending.lock().unwrap().is_empty());
+    }
+
+    async fn assert_recovery(&self, permits: &Arc<Semaphore>, expected_requests: usize) {
+        self.mode.store(1, Ordering::SeqCst);
+        tokio::time::sleep(INITIALIZATION_BACKOFF + Duration::from_millis(20)).await;
+        let mut guard = self
+            .verifier
+            .arm(
+                "recovered".into(),
+                permits.clone().try_acquire_owned().unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(self.verifier.0.topology.get().is_some());
+        guard.disarm();
+        assert_eq!(self.requests.load(Ordering::SeqCst), expected_requests);
+        assert_eq!(permits.available_permits(), 64);
+    }
+}
+
+#[tokio::test]
+async fn permission_failure_blocks_initialization_and_shared_retries_then_recovers() {
+    let fixture = Fixture::new(0).await;
+    let permits = Arc::new(Semaphore::new(64));
+    assert!(
+        fixture
+            .verifier
+            .arm("first".into(), permits.clone().try_acquire_owned().unwrap())
+            .await
+            .is_err()
+    );
+    fixture.assert_backoff(&permits, 2).await;
+    fixture.assert_recovery(&permits, 4).await;
+}
+
+#[tokio::test]
+async fn cancelled_initialization_backs_off_and_releases_admission() {
+    let fixture = Fixture::new(2).await;
+    let permits = Arc::new(Semaphore::new(64));
+    let verifier = fixture.verifier.clone();
+    let permit = permits.clone().try_acquire_owned().unwrap();
+    let task = tokio::spawn(async move { verifier.arm("cancelled".into(), permit).await });
+    tokio::time::timeout(PROBE_TIMEOUT, fixture.entered.notified())
+        .await
+        .unwrap();
+    task.abort();
+    assert!(matches!(task.await, Err(error) if error.is_cancelled()));
+    fixture.assert_backoff(&permits, 1).await;
+    fixture.assert_recovery(&permits, 3).await;
+}

--- a/crates/superbank-rpc/src/clickhouse/disconnect/integration_tests.rs
+++ b/crates/superbank-rpc/src/clickhouse/disconnect/integration_tests.rs
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Real protocol tests run by test-clickhouse-http-disconnect.py, never against production.
+
+use super::*;
+use crate::clickhouse::{
+    ClickHouseClient, ClickHouseClientOptions, RoutingPolicy, RoutingScope, RoutingTransport,
+};
+use tokio::sync::Semaphore;
+
+struct Fixture {
+    url: String,
+    control: String,
+    client: HttpClient,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let url = fixture_url("SUPERBANK_DISCONNECT_TEST_URL");
+        let control = fixture_url("SUPERBANK_DISCONNECT_TEST_CONTROL_URL");
+        let client = super::super::client::build_clickhouse_http_client(
+            &url,
+            "default",
+            "",
+            "",
+            Duration::from_secs(2),
+        );
+        // Keep production validation and compression. Do not replace this with
+        // an unvalidated synthetic RowBinary response or a JSON-only client.
+        Self {
+            url,
+            control,
+            client,
+        }
+    }
+
+    fn verifier(&self) -> DisconnectVerifier {
+        DisconnectVerifier::new(self.client.clone(), Some("{cluster}".into()))
+    }
+
+    async fn control(&self, action: &str) {
+        reqwest::Client::builder()
+            .no_proxy()
+            .build()
+            .unwrap()
+            .post(format!("{}/{}", self.control, action))
+            .timeout(Duration::from_secs(15))
+            .send()
+            .await
+            .unwrap()
+            .error_for_status()
+            .unwrap();
+    }
+
+    async fn active_nodes(&self, id: &str) -> HashSet<String> {
+        let sql = format!(
+            "SELECT DISTINCT hostName() AS node FROM \
+            clusterAllReplicas('fixture',system.processes) WHERE \
+            query_id={} OR initial_query_id={}",
+            quoted(id),
+            quoted(id)
+        );
+        self.client
+            .query(&sql)
+            .fetch_all::<NodeRow>()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|row| row.node)
+            .collect()
+    }
+
+    async fn wait_active(&self, id: &str) {
+        tokio::time::timeout(Duration::from_secs(10), async {
+            while self.active_nodes(id).await.len() != 3 {
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        })
+        .await
+        .expect("query must run on coordinator and both remote nodes");
+    }
+
+    async fn terminals(&self, id: &str) -> Vec<TerminalRow> {
+        let sql = format!(
+            "SELECT hostName() AS node,toString(type) AS kind,exception_code AS code,exception,\
+            is_initial_query AS initial,toUInt8(Settings['readonly']) AS readonly,\
+            toUInt8(Settings['cancel_http_readonly_queries_on_client_close']) AS cancel \
+            FROM clusterAllReplicas('fixture',system.query_log) WHERE \
+            initial_query_id={} AND type!='QueryStart'",
+            quoted(id)
+        );
+        self.client
+            .query(&sql)
+            .fetch_all::<TerminalRow>()
+            .await
+            .unwrap()
+    }
+
+    async fn assert_cancelled(&self, id: &str) {
+        let rows = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let rows = self.terminals(id).await;
+                if rows.len() == 3 {
+                    break rows;
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        })
+        .await
+        .expect("all participating executions must have terminal evidence");
+        assert_eq!(
+            rows.iter()
+                .map(|row| &row.node)
+                .collect::<HashSet<_>>()
+                .len(),
+            3
+        );
+        assert_eq!(rows.iter().filter(|row| row.initial == 1).count(), 1);
+        for row in rows {
+            assert_ne!(
+                row.kind, "QueryFinish",
+                "slow fixture must cancel, not finish"
+            );
+            assert!(
+                row.cancelled_by_disconnect(),
+                "unexpected terminal: {row:?}"
+            );
+            assert_eq!((row.readonly, row.cancel), (2, 1));
+        }
+    }
+}
+
+fn fixture_url(name: &str) -> String {
+    let value = std::env::var(name).expect("run through the isolated Python fixture");
+    let url = reqwest::Url::parse(&value).unwrap();
+    assert_eq!(url.scheme(), "http");
+    assert_eq!(
+        url.host_str(),
+        Some("127.0.0.1"),
+        "fixture must be loopback-only"
+    );
+    value.trim_end_matches('/').to_owned()
+}
+
+#[derive(clickhouse::Row, Deserialize)]
+struct NodeRow {
+    node: String,
+}
+
+#[derive(clickhouse::Row, Deserialize, Debug)]
+struct TerminalRow {
+    node: String,
+    kind: String,
+    code: i32,
+    exception: String,
+    initial: u8,
+    readonly: u8,
+    cancel: u8,
+}
+
+impl TerminalRow {
+    fn cancelled_by_disconnect(&self) -> bool {
+        if matches!(self.code, 394 | 735) {
+            return true;
+        }
+        // A streaming leaf can observe the coordinator closing its native
+        // socket before it reads the cancellation packet. Restrict this race
+        // to explicit socket-close errors on leaves; the coordinator must
+        // still report cancellation, and all executions must end promptly.
+        self.initial == 0
+            && self.code == 210
+            && self.exception.contains("while writing to socket")
+            && (self.exception.contains("Connection reset by peer")
+                || self.exception.contains("Broken pipe"))
+    }
+}
+
+#[derive(clickhouse::Row, Deserialize)]
+struct SumRow {
+    total: u64,
+}
+
+#[derive(clickhouse::Row, Deserialize)]
+struct StreamRow {
+    number: u64,
+    delay: u8,
+    padding: String,
+}
+
+async fn wait_released(semaphore: &Semaphore) {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while semaphore.available_permits() != 1 {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("verified termination must release admission within five seconds");
+}
+
+fn slow_query(client: &HttpClient, sql: &str, id: &str) -> clickhouse::query::Query {
+    client
+        .query(sql)
+        .with_setting("query_id", id)
+        .with_setting("readonly", "2")
+        .with_setting("cancel_http_readonly_queries_on_client_close", "1")
+        .with_setting("max_threads", "1")
+        .with_setting("max_block_size", "1")
+        .with_setting("max_parallel_replicas", "1")
+        .with_setting("use_hedged_requests", "0")
+        .with_setting("max_execution_time", "35")
+        .with_setting("max_execution_time_leaf", "35")
+        .with_setting("wait_end_of_query", "0")
+        .with_setting("buffer_size", "1")
+        .with_setting("log_query_settings", "1")
+}
+
+#[tokio::test]
+#[ignore = "requires isolated pinned three-node ClickHouse fixture"]
+async fn real_protocol_discovery_probe_and_status_results() {
+    let fixture = Fixture::new();
+    let verifier = fixture.verifier();
+    let semaphore = Arc::new(Semaphore::new(1));
+    let id = next_required_query_id("native_integration_discovery");
+    let mut guard = verifier
+        .arm(id.clone(), semaphore.clone().acquire_owned().await.unwrap())
+        .await
+        .expect("real discovery, macro, and capability rows must deserialize");
+    assert_eq!(verifier.0.topology.get().unwrap().nodes.len(), 3);
+    assert!(probe(&verifier.0, &[id]).await.unwrap().is_empty());
+    guard.disarm();
+    assert_eq!(semaphore.available_permits(), 1);
+
+    let options = ClickHouseClientOptions::new(
+        RoutingPolicy {
+            transport: RoutingTransport::Http,
+            scope: RoutingScope::Distributed,
+        },
+        None,
+        Vec::new(),
+        String::new(),
+        String::new(),
+    )
+    .with_query_cleanup_cluster("{cluster}".into());
+    let mut client = ClickHouseClient::new(&fixture.url, "default", "", "", options);
+    client.signature_statuses_table = "default.fixture_signatures".into();
+    client.bucket_moduli.signatures = 32;
+    let known = bs58::encode([0x11; 64]).into_string();
+    let missing = bs58::encode([0x22; 64]).into_string();
+    let failed = bs58::encode([0x33; 64]).into_string();
+    let (rows, _) = client
+        .get_signature_statuses(&[known.clone(), missing.clone(), failed.clone()])
+        .await
+        .expect("real StatusRow schema and native settings must work");
+    assert_eq!(rows.len(), 2);
+    let hit = rows.iter().find(|row| row.signature == known).unwrap();
+    assert_eq!(hit.slot, 17);
+    assert!(hit.err.is_none());
+    let failed = rows.iter().find(|row| row.signature == failed).unwrap();
+    assert_eq!(failed.slot, 19);
+    assert_eq!(failed.err, Some(serde_json::json!("BlockhashNotFound")));
+    assert!(
+        client
+            .get_signature_statuses(&[missing])
+            .await
+            .unwrap()
+            .0
+            .is_empty()
+    );
+    let mut held = Vec::new();
+    for _ in 0..4 {
+        held.push(
+            tokio::time::timeout(
+                Duration::from_secs(1),
+                client.acquire_signature_status_permits(),
+            )
+            .await
+            .expect("successful status responses must release all source admission")
+            .unwrap(),
+        );
+    }
+    assert_eq!(held.len(), 4);
+}
+
+async fn cancel_real_query(fixture: &Fixture, streaming: bool) {
+    let verifier = fixture.verifier();
+    let semaphore = Arc::new(Semaphore::new(1));
+    let id = next_required_query_id("native_integration_cancel");
+    let guard = verifier
+        .arm(id.clone(), semaphore.clone().acquire_owned().await.unwrap())
+        .await
+        .unwrap();
+    if streaming {
+        // Repeated bytes remain buffered after LZ4 compression. Deterministic
+        // hash text produces enough wire bytes to decode a row while work runs.
+        let sql = concat!(
+            "SELECT number,delay,arrayStringConcat(arrayMap(x -> ",
+            "hex(SHA512(concat(toString(number), ':', toString(x)))), ",
+            "range(2048))) AS padding FROM slow_all"
+        );
+        let mut cursor = slow_query(&fixture.client, sql, &id)
+            .fetch::<StreamRow>()
+            .unwrap();
+        let row = tokio::time::timeout(Duration::from_secs(5), cursor.next())
+            .await
+            .expect("a compressed, validated row must arrive before cancellation")
+            .unwrap()
+            .unwrap();
+        assert!(row.number < 600);
+        assert_eq!(row.delay, 0);
+        assert_eq!(row.padding.len(), 262144);
+        fixture.wait_active(&id).await;
+        drop(cursor);
+    } else {
+        let query = slow_query(
+            &fixture.client,
+            "SELECT sum(delay) AS total FROM slow_all",
+            &id,
+        )
+        // Hold the complete aggregate response, including validated schema
+        // headers, so this exercises dropping before HTTP response headers.
+        .with_setting("wait_end_of_query", "1")
+        .with_setting("send_progress_in_http_headers", "0");
+        let task = tokio::spawn(async move {
+            let rows = query.fetch_all::<SumRow>().await?;
+            Ok::<_, clickhouse::error::Error>(rows.into_iter().map(|row| row.total).sum::<u64>())
+        });
+        fixture.wait_active(&id).await;
+        assert!(
+            !task.is_finished(),
+            "query must still be waiting for headers"
+        );
+        task.abort();
+        assert!(task.await.unwrap_err().is_cancelled());
+    }
+    drop(guard);
+    wait_released(&semaphore).await;
+    assert!(fixture.active_nodes(&id).await.is_empty());
+    fixture.assert_cancelled(&id).await;
+}
+
+#[tokio::test]
+#[ignore = "requires isolated pinned three-node ClickHouse fixture"]
+async fn real_protocol_cancellation_before_headers_and_streaming() {
+    let fixture = Fixture::new();
+    cancel_real_query(&fixture, false).await;
+    cancel_real_query(&fixture, true).await;
+    fixture.control("block-ddl").await;
+    cancel_real_query(&fixture, false).await;
+    cancel_real_query(&fixture, true).await;
+    fixture.control("assert-ddl-blocked").await;
+}
+
+#[tokio::test]
+#[ignore = "requires isolated pinned three-node ClickHouse fixture"]
+async fn real_protocol_replica_outage_retains_admission_until_recovery() {
+    let fixture = Fixture::new();
+    let verifier = fixture.verifier();
+    let semaphore = Arc::new(Semaphore::new(1));
+    let id = next_required_query_id("native_integration_outage");
+    let guard = verifier
+        .arm(id, semaphore.clone().acquire_owned().await.unwrap())
+        .await
+        .unwrap();
+    fixture.control("pause-replica").await;
+    drop(guard);
+    tokio::time::sleep(Duration::from_secs(6)).await;
+    assert_eq!(
+        semaphore.available_permits(),
+        0,
+        "unreachable replica must retain admission"
+    );
+    fixture.control("resume-replica").await;
+    wait_released(&semaphore).await;
+}

--- a/crates/superbank-rpc/src/clickhouse/mod.rs
+++ b/crates/superbank-rpc/src/clickhouse/mod.rs
@@ -7,6 +7,7 @@ mod blocks;
 mod cache;
 mod client;
 mod constants;
+mod disconnect;
 mod gsfa;
 mod queries;
 mod rows;

--- a/crates/superbank-rpc/src/clickhouse/signatures.rs
+++ b/crates/superbank-rpc/src/clickhouse/signatures.rs
@@ -363,7 +363,6 @@ impl ClickHouseClient {
 
             let signature_filter = self.signature_status_filter(signatures)?;
             let signature_statuses_table = &self.signature_statuses_table;
-            let settings_clause = self.signature_status_settings(deadline)?;
             let query = format!(
                 "SELECT
                     signature,
@@ -377,14 +376,14 @@ impl ClickHouseClient {
                     PREWHERE ({signature_filter}){cache_scope}
                     GROUP BY signature
                  )
-                 {settings_clause}",
+                 ",
                 cache_scope = self.cache_slot_predicate(),
                 signature_statuses_table = signature_statuses_table,
-                signature_filter = signature_filter,
-                settings_clause = settings_clause
+                signature_filter = signature_filter
             );
-            let (query, query_id, mut cleanup) =
-                self.annotate_signature_status_query(query, source_permit);
+            let (query, query_id, mut cleanup) = self
+                .prepare_signature_status_query(query, source_permit, deadline)
+                .await?;
 
             #[derive(Deserialize, clickhouse::Row)]
             struct StatusRow {
@@ -394,9 +393,12 @@ impl ClickHouseClient {
             }
 
             let start = Instant::now();
-            let mut cursor = http_query_with_id(&self.client, &query, query_id)
-                .fetch::<StatusRow>()
-                .map_err(|e| ProcessingError::database(e.to_string(), e))?;
+            let mut cursor = super::client::SignatureStatusCleanup::before_submission(
+                self.signature_status_http_query(&query, query_id)
+                    .fetch::<StatusRow>()
+                    .map_err(|error| ProcessingError::database(error.to_string(), error)),
+                &mut cleanup,
+            )?;
 
             let mut results = Vec::new();
             while let Some(row) = cursor
@@ -415,7 +417,7 @@ impl ClickHouseClient {
                 });
             }
 
-            super::client::HttpQueryCleanup::disarm_optional(&mut cleanup);
+            super::client::SignatureStatusCleanup::disarm_optional(&mut cleanup);
             let timings = QueryTimings {
                 elapsed_ms: start.elapsed().as_millis() as u64,
                 received_bytes: cursor.received_bytes(),
@@ -428,6 +430,28 @@ impl ClickHouseClient {
             Ok((results, timings))
         })
         .await
+    }
+
+    async fn prepare_signature_status_query(
+        &self,
+        query: String,
+        source_permit: Option<tokio::sync::OwnedSemaphorePermit>,
+        deadline: tokio::time::Instant,
+    ) -> ProcessingResult<(
+        String,
+        Option<String>,
+        Option<super::client::SignatureStatusCleanup>,
+    )> {
+        let (mut query, query_id, mut cleanup) = self
+            .annotate_signature_status_query(query, source_permit)
+            .await?;
+        // Discovery consumes the same operation deadline as admission and execution.
+        let settings = super::client::SignatureStatusCleanup::before_submission(
+            self.signature_status_settings(deadline),
+            &mut cleanup,
+        )?;
+        query.push_str(&settings);
+        Ok((query, query_id, cleanup))
     }
 
     fn signature_status_filter(&self, signatures: &[String]) -> ProcessingResult<String> {
@@ -1044,3 +1068,7 @@ impl ClickHouseClient {
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+#[path = "signatures/settings_tests.rs"]
+mod settings_tests;

--- a/crates/superbank-rpc/src/clickhouse/signatures.rs
+++ b/crates/superbank-rpc/src/clickhouse/signatures.rs
@@ -4,7 +4,7 @@
  */
 
 use std::collections::BTreeMap;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use ch_cityhash102::cityhash64;
 use serde::Deserialize;
@@ -18,8 +18,8 @@ use super::client::{ClickHouseClient, execute_shard_tcp_query_block};
 use super::sharding::ShardTopology;
 use super::types::{QueryTimings, SignatureSlot, SignatureStatusRecord};
 use super::util::{
-    append_max_execution_time_setting, http_query_with_id, parse_err_json,
-    transient_shard_local_error_reason,
+    append_max_execution_time_setting, build_select_settings_clause, http_query_with_id,
+    parse_err_json, transient_shard_local_error_reason,
 };
 
 fn build_signature_filter(
@@ -52,6 +52,48 @@ fn build_signature_filter(
         }
     }
     bucket_clauses.join(" OR ")
+}
+
+fn build_primary_signature_filter(bucketed: BTreeMap<u64, Vec<String>>) -> String {
+    if bucketed.values().map(Vec::len).sum::<usize>() == 1 {
+        return build_signature_filter(bucketed, 1);
+    }
+    let keys = bucketed
+        .into_iter()
+        .flat_map(|(bucket, signatures)| {
+            signatures
+                .into_iter()
+                .map(move |signature| format!("({bucket}, {signature})"))
+        })
+        .collect::<Vec<_>>();
+    format!("(sig_bucket, signature) IN ({})", keys.join(","))
+}
+
+fn primary_signature_status_settings(
+    base: &str,
+    max_threads: usize,
+    remaining: Duration,
+) -> ProcessingResult<String> {
+    // ClickHouse truncates execution limits to microseconds; zero disables the limit.
+    // Leave at least one millisecond rather than submitting an effectively expired query.
+    if remaining < Duration::from_millis(1) {
+        return Err(ProcessingError::timeout_msg(
+            "Signature status query deadline exhausted",
+        ));
+    }
+    let prefix = if base.trim().is_empty() {
+        "SETTINGS".to_string()
+    } else {
+        format!("{base},")
+    };
+    let seconds = remaining.as_secs_f64();
+    Ok(format!(
+        "{prefix} max_threads={max_threads}, max_threads_for_indexes={max_threads}, \
+        use_hedged_requests=0, max_parallel_replicas=1, \
+        max_execution_time={seconds}, max_execution_time_leaf={seconds}, \
+        timeout_overflow_mode='throw', timeout_overflow_mode_leaf='throw', \
+        timeout_before_checking_execution_speed=0"
+    ))
 }
 
 impl ClickHouseClient {
@@ -271,7 +313,8 @@ impl ClickHouseClient {
         &self,
         signatures: &[String],
     ) -> ProcessingResult<(Vec<SignatureStatusRecord>, QueryTimings)> {
-        self.with_http_query_timeout("get_signature_statuses", async {
+        let deadline = tokio::time::Instant::now() + self.query_timeout;
+        self.with_operation_timeout("get_signature_statuses", async {
             if signatures.is_empty() {
                 return Ok((
                     Vec::new(),
@@ -285,6 +328,13 @@ impl ClickHouseClient {
                     },
                 ));
             }
+
+            let admission = self
+                .cache_partition
+                .is_none()
+                .then(crate::metrics::SignatureStatusAdmission::start);
+            let (source_permit, _http_permit) = self.acquire_signature_status_permits().await?;
+            drop(admission);
 
             if self.scope_shard_direct()
                 && let (Some(topology), Some(local_table)) =
@@ -311,34 +361,9 @@ impl ClickHouseClient {
                 }
             }
 
-            let signature_bucket_modulus = self.signatures_bucket_modulus();
-            let mut bucketed_signatures: BTreeMap<u64, Vec<String>> = BTreeMap::new();
-            for sig in signatures {
-                let signature_bytes = bs58::decode(sig)
-                    .into_vec()
-                    .map_err(|e| ProcessingError::deserialization("Invalid signature", e))?;
-                if signature_bytes.len() != 64 {
-                    return Err(ProcessingError::deserialization_msg(format!(
-                        "Invalid signature length {} (expected 64 bytes)",
-                        signature_bytes.len()
-                    )));
-                }
-
-                let bucket = cityhash64(signature_bytes.as_slice()) % signature_bucket_modulus;
-                let signature_hex = hex::encode(signature_bytes).to_uppercase();
-                let signature_literal = format!("toFixedString(unhex('{signature_hex}'), 64)");
-                bucketed_signatures
-                    .entry(bucket)
-                    .or_default()
-                    .push(signature_literal);
-            }
-
-            let signature_filter =
-                build_signature_filter(bucketed_signatures, self.in_clause_chunk);
-
+            let signature_filter = self.signature_status_filter(signatures)?;
             let signature_statuses_table = &self.signature_statuses_table;
-            let settings_clause = self
-                .select_settings_clause("get_signature_statuses", QueryFreshnessClass::Historical);
+            let settings_clause = self.signature_status_settings(deadline)?;
             let query = format!(
                 "SELECT
                     signature,
@@ -359,7 +384,7 @@ impl ClickHouseClient {
                 settings_clause = settings_clause
             );
             let (query, query_id, mut cleanup) =
-                self.annotate_lookup_query(query, "signature_statuses");
+                self.annotate_signature_status_query(query, source_permit);
 
             #[derive(Deserialize, clickhouse::Row)]
             struct StatusRow {
@@ -403,6 +428,61 @@ impl ClickHouseClient {
             Ok((results, timings))
         })
         .await
+    }
+
+    fn signature_status_filter(&self, signatures: &[String]) -> ProcessingResult<String> {
+        let mut bucketed_signatures: BTreeMap<u64, Vec<String>> = BTreeMap::new();
+        for sig in signatures {
+            let signature_bytes = bs58::decode(sig)
+                .into_vec()
+                .map_err(|e| ProcessingError::deserialization("Invalid signature", e))?;
+            if signature_bytes.len() != 64 {
+                return Err(ProcessingError::deserialization_msg(format!(
+                    "Invalid signature length {} (expected 64 bytes)",
+                    signature_bytes.len()
+                )));
+            }
+            let bucket = cityhash64(&signature_bytes) % self.signatures_bucket_modulus();
+            let signature_hex = hex::encode(signature_bytes).to_uppercase();
+            bucketed_signatures
+                .entry(bucket)
+                .or_default()
+                .push(format!("toFixedString(unhex('{signature_hex}'), 64)"));
+        }
+        if self.cache_partition.is_some() {
+            Ok(build_signature_filter(
+                bucketed_signatures,
+                self.in_clause_chunk,
+            ))
+        } else {
+            Ok(build_primary_signature_filter(bucketed_signatures))
+        }
+    }
+
+    fn signature_status_settings(
+        &self,
+        deadline: tokio::time::Instant,
+    ) -> ProcessingResult<String> {
+        if self.cache_partition.is_some() {
+            return Ok(self.select_settings_clause(
+                "get_signature_statuses",
+                QueryFreshnessClass::Historical,
+            ));
+        }
+        let remaining = deadline
+            .checked_duration_since(tokio::time::Instant::now())
+            .filter(|remaining| !remaining.is_zero())
+            .ok_or_else(|| {
+                ProcessingError::timeout_msg("Signature status admission exhausted query deadline")
+            })?;
+        let base = build_select_settings_clause(
+            self.allow_query_settings,
+            QueryFreshnessClass::Historical,
+            &self.query_cache,
+            false,
+            "get_signature_statuses",
+        );
+        primary_signature_status_settings(&base, self.signature_status_max_threads, remaining)
     }
 
     async fn try_signature_slot_by_signature_tcp(
@@ -961,3 +1041,6 @@ impl ClickHouseClient {
         Ok(Some((results, timings)))
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/superbank-rpc/src/clickhouse/signatures/settings_tests.rs
+++ b/crates/superbank-rpc/src/clickhouse/signatures/settings_tests.rs
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use axum::{Router, extract::Query, routing::post};
+use tokio::sync::mpsc;
+
+use crate::clickhouse::{
+    ClickHouseClient, ClickHouseClientOptions, RoutingPolicy, RoutingScope, RoutingTransport,
+};
+
+struct SettingsServer {
+    client: ClickHouseClient,
+    requests: mpsc::UnboundedReceiver<HashMap<String, String>>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for SettingsServer {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+impl SettingsServer {
+    async fn new() -> Self {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let (sender, requests) = mpsc::unbounded_channel();
+        let app = Router::new().route(
+            "/",
+            post(move |Query(params): Query<HashMap<String, String>>| {
+                let sender = sender.clone();
+                async move {
+                    sender.send(params).unwrap();
+                    axum::http::StatusCode::OK
+                }
+            }),
+        );
+        let task = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let mut client = ClickHouseClient::new(
+            &url,
+            "default",
+            "default",
+            "",
+            ClickHouseClientOptions::new(
+                RoutingPolicy {
+                    transport: RoutingTransport::Http,
+                    scope: RoutingScope::Distributed,
+                },
+                None,
+                Vec::new(),
+                "default.gsfa_hot".into(),
+                "default.gsfa_hot_local".into(),
+            ),
+        );
+        client.set_http_client_for_tests(
+            client
+                .client
+                .clone()
+                .with_validation(false)
+                .with_compression(clickhouse::Compression::None),
+        );
+        Self {
+            client,
+            requests,
+            task,
+        }
+    }
+
+    async fn capture(&mut self, query: clickhouse::query::Query) -> HashMap<String, String> {
+        tokio::time::timeout(Duration::from_secs(2), query.execute())
+            .await
+            .unwrap()
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(2), self.requests.recv())
+            .await
+            .unwrap()
+            .unwrap()
+    }
+}
+
+#[tokio::test]
+async fn disconnect_http_settings_are_exclusive_to_primary_distributed_http_status_reads() {
+    let mut server = SettingsServer::new().await;
+    let protected = server
+        .client
+        .signature_status_http_query("SELECT 1", Some("protected".into()));
+    let params = server.capture(protected).await;
+    assert_eq!(params["readonly"], "2");
+    assert_eq!(params["cancel_http_readonly_queries_on_client_close"], "1");
+    assert_eq!(params["query_id"], "protected");
+
+    let mut local_cache = server.client.clone();
+    local_cache.cache_partition = Some((1000, 1));
+    let mut shard_direct = server.client.clone();
+    shard_direct.routing_policy.scope = RoutingScope::ShardDirect;
+    let mut tcp_policy = server.client.clone();
+    tcp_policy.routing_policy.transport = RoutingTransport::Tcp;
+
+    for (label, client) in [
+        ("local_cache", local_cache),
+        ("shard_direct", shard_direct),
+        ("tcp_policy", tcp_policy),
+    ] {
+        let query = client.signature_status_http_query("SELECT 1", Some(label.into()));
+        let params = server.capture(query).await;
+        assert!(!params.contains_key("readonly"), "{label}");
+        assert!(
+            !params.contains_key("cancel_http_readonly_queries_on_client_close"),
+            "{label}"
+        );
+        assert_eq!(params["query_id"], label);
+    }
+
+    let unrelated = server.client.client.query("SELECT 1");
+    let params = server.capture(unrelated).await;
+    assert!(!params.contains_key("readonly"));
+    assert!(!params.contains_key("cancel_http_readonly_queries_on_client_close"));
+}
+
+#[tokio::test]
+async fn protected_status_read_does_not_mutate_shared_http_client_settings() {
+    let mut server = SettingsServer::new().await;
+    server.client.set_http_client_for_tests(
+        server
+            .client
+            .client
+            .clone()
+            .with_setting("readonly", "1")
+            .with_setting("max_threads", "7"),
+    );
+    let before = server.capture(server.client.client.query("SELECT 1")).await;
+    let query = server
+        .client
+        .signature_status_http_query("SELECT 1", Some("protected".into()));
+    let protected = server.capture(query).await;
+    let after = server.capture(server.client.client.query("SELECT 1")).await;
+
+    assert_eq!(protected["readonly"], "2");
+    assert_eq!(
+        protected["cancel_http_readonly_queries_on_client_close"],
+        "1"
+    );
+    assert_eq!(protected["max_threads"], "7");
+    assert_eq!(before, after);
+    assert_eq!(after["readonly"], "1");
+    assert!(!after.contains_key("cancel_http_readonly_queries_on_client_close"));
+}

--- a/crates/superbank-rpc/src/clickhouse/signatures/tests.rs
+++ b/crates/superbank-rpc/src/clickhouse/signatures/tests.rs
@@ -23,6 +23,42 @@ impl Drop for MockClickHouse {
     }
 }
 
+fn discovery_response(sql: &str) -> Option<Body> {
+    if !sql.contains("AS coordinator") {
+        return None;
+    }
+    let mut rows = vec![5];
+    rows.extend_from_slice(b"node1");
+    rows.extend_from_slice(&0_u64.to_le_bytes());
+    rows.push(0);
+    rows.push(5);
+    rows.extend_from_slice(b"node1");
+    rows.extend_from_slice(&1_u64.to_le_bytes());
+    rows.push(1);
+    Some(Body::from(rows))
+}
+
+fn verification_response(sql: &str) -> Option<Body> {
+    discovery_response(sql).or_else(|| {
+        sql.contains("system.processes")
+            .then(|| Body::from(vec![5, b'n', b'o', b'd', b'e', b'1', 0]))
+    })
+}
+
+fn record_query(
+    send: &mpsc::UnboundedSender<(String, String)>,
+    sql: &str,
+    params: &HashMap<String, String>,
+) {
+    if !sql.contains("AS coordinator") {
+        send.send((
+            sql.into(),
+            params.get("query_id").cloned().unwrap_or_default(),
+        ))
+        .unwrap();
+    }
+}
+
 impl MockClickHouse {
     async fn new(response: Vec<u8>, pending_headers: bool, pending_body: bool) -> Self {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -39,11 +75,17 @@ impl MockClickHouse {
                     let body_notify = body_notify.clone();
                     async move {
                         let sql = params.get("query").cloned().unwrap_or(body);
-                        let is_kill = sql.starts_with("KILL QUERY");
-                        send.send((sql, params.get("query_id").cloned().unwrap_or_default()))
-                            .unwrap();
-                        if is_kill {
-                            return Body::empty();
+                        assert_eq!(params.get("readonly").map(String::as_str), Some("2"));
+                        assert_eq!(
+                            params
+                                .get("cancel_http_readonly_queries_on_client_close")
+                                .map(String::as_str),
+                            Some("1")
+                        );
+                        assert!(!sql.contains("KILL QUERY"));
+                        record_query(&send, &sql, &params);
+                        if let Some(body) = verification_response(&sql) {
+                            return body;
                         }
                         if pending_headers {
                             std::future::pending::<()>().await;
@@ -82,10 +124,13 @@ impl MockClickHouse {
             .with_query_cleanup_cluster("rbx2".into())
             .with_signature_status_limits(1, 2),
         );
-        client.client = client
-            .client
-            .with_validation(false)
-            .with_compression(clickhouse::Compression::None);
+        client.set_http_client_for_tests(
+            client
+                .client
+                .clone()
+                .with_validation(false)
+                .with_compression(clickhouse::Compression::None),
+        );
         client.allow_query_settings = false;
         Self {
             client,
@@ -163,6 +208,16 @@ async fn primary_consumes_successful_rows_and_disarms_cleanup() {
     );
 }
 
+async fn assert_two_absent_probes(mock: &mut MockClickHouse, id: &str) {
+    for _ in 0..2 {
+        let (probe, _) = mock.next_query().await;
+        assert!(probe.contains("system.processes"));
+        assert!(probe.contains(&format!("query_id IN ('{id}')")));
+        assert!(probe.contains(&format!("initial_query_id IN ('{id}')")));
+        assert!(!probe.contains("KILL"));
+    }
+}
+
 async fn assert_cancelled_query_cleanup(pending_headers: bool, pending_body: bool) {
     let mut mock = MockClickHouse::new(status_row(), pending_headers, pending_body).await;
     let client = mock.client.clone();
@@ -176,10 +231,7 @@ async fn assert_cancelled_query_cleanup(pending_headers: bool, pending_body: boo
     }
     request.abort();
     assert!(request.await.unwrap_err().is_cancelled());
-    let (kill, _) = mock.next_query().await;
-    assert!(kill.starts_with("KILL QUERY ON CLUSTER 'rbx2'"));
-    assert!(kill.contains(&format!("query_id = '{id}'")));
-    assert!(kill.contains(&format!("initial_query_id = '{id}'")));
+    assert_two_absent_probes(&mut mock, &id).await;
     let _permits = tokio::time::timeout(
         Duration::from_secs(2),
         mock.client.acquire_signature_status_permits(),
@@ -262,8 +314,9 @@ async fn primary_timeout_during_headers_dispatches_cleanup() {
             .is_err()
     );
     let (_, id) = mock.next_query().await;
-    let (kill, _) = mock.next_query().await;
-    assert!(kill.contains(&format!("initial_query_id = '{id}'")));
+    let (probe, _) = mock.next_query().await;
+    assert!(probe.contains(&format!("initial_query_id IN ('{id}')")));
+    assert!(!probe.contains("KILL"));
 }
 
 #[tokio::test]

--- a/crates/superbank-rpc/src/clickhouse/signatures/tests.rs
+++ b/crates/superbank-rpc/src/clickhouse/signatures/tests.rs
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::{Router, body::Body, extract::Query, routing::post};
+use futures_util::StreamExt;
+use tokio::sync::mpsc;
+
+use super::*;
+use crate::clickhouse::{ClickHouseClientOptions, RoutingPolicy, RoutingScope, RoutingTransport};
+
+struct MockClickHouse {
+    client: ClickHouseClient,
+    queries: mpsc::UnboundedReceiver<(String, String)>,
+    server: tokio::task::JoinHandle<()>,
+    body_started: Arc<tokio::sync::Notify>,
+}
+
+impl Drop for MockClickHouse {
+    fn drop(&mut self) {
+        self.server.abort();
+    }
+}
+
+impl MockClickHouse {
+    async fn new(response: Vec<u8>, pending_headers: bool, pending_body: bool) -> Self {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let (send, queries) = mpsc::unbounded_channel();
+        let body_started = Arc::new(tokio::sync::Notify::new());
+        let body_notify = body_started.clone();
+        let app = Router::new().route(
+            "/",
+            post(
+                move |Query(params): Query<HashMap<String, String>>, body: String| {
+                    let send = send.clone();
+                    let response = response.clone();
+                    let body_notify = body_notify.clone();
+                    async move {
+                        let sql = params.get("query").cloned().unwrap_or(body);
+                        let is_kill = sql.starts_with("KILL QUERY");
+                        send.send((sql, params.get("query_id").cloned().unwrap_or_default()))
+                            .unwrap();
+                        if is_kill {
+                            return Body::empty();
+                        }
+                        if pending_headers {
+                            std::future::pending::<()>().await;
+                        }
+                        let chunks = futures_util::stream::once(async move {
+                            body_notify.notify_one();
+                            Ok::<_, std::io::Error>(response)
+                        });
+                        if pending_body {
+                            Body::from_stream(chunks.chain(futures_util::stream::pending()))
+                        } else {
+                            Body::from_stream(chunks)
+                        }
+                    }
+                },
+            ),
+        );
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        let mut client = ClickHouseClient::new(
+            &format!("http://{address}"),
+            "default",
+            "default",
+            "",
+            ClickHouseClientOptions::new(
+                RoutingPolicy {
+                    transport: RoutingTransport::Http,
+                    scope: RoutingScope::Distributed,
+                },
+                None,
+                Vec::new(),
+                "default.gsfa_hot".into(),
+                "default.gsfa_hot_local".into(),
+            )
+            .with_query_cleanup_cluster("rbx2".into())
+            .with_signature_status_limits(1, 2),
+        );
+        client.client = client
+            .client
+            .with_validation(false)
+            .with_compression(clickhouse::Compression::None);
+        client.allow_query_settings = false;
+        Self {
+            client,
+            queries,
+            server,
+            body_started,
+        }
+    }
+
+    async fn next_query(&mut self) -> (String, String) {
+        tokio::time::timeout(Duration::from_secs(2), self.queries.recv())
+            .await
+            .unwrap()
+            .unwrap()
+    }
+}
+
+fn signatures(count: usize) -> Vec<String> {
+    (0..count)
+        .map(|i| {
+            let mut bytes = [0u8; 64];
+            bytes[..8].copy_from_slice(&(i as u64).to_le_bytes());
+            bs58::encode(bytes).into_string()
+        })
+        .collect()
+}
+
+fn status_row() -> Vec<u8> {
+    let mut bytes = vec![0; 64];
+    bytes.extend_from_slice(&123u64.to_le_bytes());
+    bytes.push(1); // Nullable(String): null
+    bytes
+}
+
+#[tokio::test]
+async fn primary_maximum_miss_batch_enforces_settings_with_optional_tuning_disabled() {
+    let mut mock = MockClickHouse::new(Vec::new(), false, false).await;
+    let (rows, _) = mock
+        .client
+        .get_signature_statuses(&signatures(256))
+        .await
+        .unwrap();
+    assert!(rows.is_empty());
+    let (sql, id) = mock.next_query().await;
+    assert!(!id.is_empty());
+    assert!(sql.contains("max_threads_for_indexes=2"));
+    assert!(sql.contains("max_threads=2"));
+    assert!(sql.contains("use_hedged_requests=0"));
+    assert!(sql.contains("max_parallel_replicas=1"));
+    assert!(sql.contains("max_execution_time_leaf="));
+    assert_eq!(sql.matches("unhex(").count(), 256);
+    assert!(
+        tokio::time::timeout(Duration::from_millis(30), mock.queries.recv())
+            .await
+            .is_err()
+    );
+}
+
+#[tokio::test]
+async fn primary_consumes_successful_rows_and_disarms_cleanup() {
+    let mut mock = MockClickHouse::new(status_row(), false, false).await;
+    let mut input = signatures(2);
+    input.push(input[0].clone());
+    let (rows, timings) = mock.client.get_signature_statuses(&input).await.unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].signature, input[0]);
+    assert_eq!(rows[0].slot, 123);
+    assert!(rows[0].err.is_none());
+    assert_eq!(timings.rows_returned, 1);
+    mock.next_query().await;
+    assert!(
+        tokio::time::timeout(Duration::from_millis(30), mock.queries.recv())
+            .await
+            .is_err()
+    );
+}
+
+async fn assert_cancelled_query_cleanup(pending_headers: bool, pending_body: bool) {
+    let mut mock = MockClickHouse::new(status_row(), pending_headers, pending_body).await;
+    let client = mock.client.clone();
+    let request =
+        tokio::spawn(async move { client.get_signature_statuses(&signatures(256)).await });
+    let (_, id) = mock.next_query().await;
+    if pending_body {
+        tokio::time::timeout(Duration::from_secs(2), mock.body_started.notified())
+            .await
+            .unwrap();
+    }
+    request.abort();
+    assert!(request.await.unwrap_err().is_cancelled());
+    let (kill, _) = mock.next_query().await;
+    assert!(kill.starts_with("KILL QUERY ON CLUSTER 'rbx2'"));
+    assert!(kill.contains(&format!("query_id = '{id}'")));
+    assert!(kill.contains(&format!("initial_query_id = '{id}'")));
+    let _permits = tokio::time::timeout(
+        Duration::from_secs(2),
+        mock.client.acquire_signature_status_permits(),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+}
+
+#[tokio::test]
+async fn primary_cancel_during_headers_cleans_up() {
+    assert_cancelled_query_cleanup(true, false).await;
+}
+
+#[tokio::test]
+async fn primary_cancel_during_body_cleans_up() {
+    assert_cancelled_query_cleanup(false, true).await;
+}
+
+#[tokio::test]
+async fn primary_queued_cancel_and_empty_input_submit_nothing() {
+    let mut mock = MockClickHouse::new(Vec::new(), false, false).await;
+    assert!(
+        mock.client
+            .get_signature_statuses(&[])
+            .await
+            .unwrap()
+            .0
+            .is_empty()
+    );
+    let (source, http) = mock
+        .client
+        .acquire_signature_status_permits()
+        .await
+        .unwrap();
+    drop(http);
+    let client = mock.client.clone();
+    let request = tokio::spawn(async move { client.get_signature_statuses(&signatures(1)).await });
+    tokio::task::yield_now().await;
+    request.abort();
+    assert!(request.await.unwrap_err().is_cancelled());
+    drop(source);
+    assert!(mock.queries.try_recv().is_err());
+}
+
+#[test]
+fn remaining_deadline_is_not_rounded_up_or_restarted() {
+    let sql = primary_signature_status_settings("", 2, Duration::from_millis(125)).unwrap();
+    assert!(sql.contains("max_execution_time=0.125,"));
+    assert!(sql.contains("max_execution_time_leaf=0.125,"));
+}
+
+#[tokio::test]
+async fn primary_timeout_while_queued_submits_nothing() {
+    let mut mock = MockClickHouse::new(Vec::new(), false, false).await;
+    mock.client.query_timeout = Duration::from_millis(30);
+    let (_source, http) = mock
+        .client
+        .acquire_signature_status_permits()
+        .await
+        .unwrap();
+    drop(http);
+    assert!(
+        mock.client
+            .get_signature_statuses(&signatures(1))
+            .await
+            .is_err()
+    );
+    assert!(mock.queries.try_recv().is_err());
+}
+
+#[tokio::test]
+async fn primary_timeout_during_headers_dispatches_cleanup() {
+    let mut mock = MockClickHouse::new(Vec::new(), true, false).await;
+    mock.client.query_timeout = Duration::from_millis(50);
+    assert!(
+        mock.client
+            .get_signature_statuses(&signatures(1))
+            .await
+            .is_err()
+    );
+    let (_, id) = mock.next_query().await;
+    let (kill, _) = mock.next_query().await;
+    assert!(kill.contains(&format!("initial_query_id = '{id}'")));
+}
+
+#[tokio::test]
+async fn primary_admission_wait_is_subtracted_from_server_budget() {
+    let mut mock = MockClickHouse::new(Vec::new(), false, false).await;
+    mock.client.query_timeout = Duration::from_secs(1);
+    let (source, http) = mock
+        .client
+        .acquire_signature_status_permits()
+        .await
+        .unwrap();
+    drop(http);
+    let client = mock.client.clone();
+    let (started, waiting) = tokio::sync::oneshot::channel();
+    let request = tokio::spawn(async move {
+        started.send(()).unwrap();
+        client.get_signature_statuses(&signatures(1)).await
+    });
+    waiting.await.unwrap();
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    drop(source);
+    request.await.unwrap().unwrap();
+    let (sql, _) = mock.next_query().await;
+    let remaining: f64 = sql
+        .split_once("max_execution_time=")
+        .unwrap()
+        .1
+        .split(',')
+        .next()
+        .unwrap()
+        .parse()
+        .unwrap();
+    assert!(
+        remaining > 0.0 && remaining < 0.99,
+        "remaining budget: {remaining}"
+    );
+}
+
+#[test]
+fn exhausted_or_submillisecond_budget_never_becomes_an_unlimited_query() {
+    for remaining in [
+        Duration::ZERO,
+        Duration::from_nanos(1),
+        Duration::from_micros(999),
+    ] {
+        assert!(primary_signature_status_settings("", 2, remaining).is_err());
+    }
+    let sql = primary_signature_status_settings("", 2, Duration::from_millis(1)).unwrap();
+    assert!(sql.contains("max_execution_time=0.001,"));
+    assert!(sql.contains("timeout_overflow_mode_leaf='throw'"));
+    assert!(sql.contains("timeout_before_checking_execution_speed=0"));
+}

--- a/crates/superbank-rpc/src/clickhouse/signatures/tests.rs
+++ b/crates/superbank-rpc/src/clickhouse/signatures/tests.rs
@@ -50,7 +50,10 @@ fn record_query(
     sql: &str,
     params: &HashMap<String, String>,
 ) {
-    if !sql.contains("AS coordinator") {
+    if !["AS coordinator", "status_disconnect_preflight"]
+        .iter()
+        .any(|marker| sql.contains(marker))
+    {
         send.send((
             sql.into(),
             params.get("query_id").cloned().unwrap_or_default(),

--- a/crates/superbank-rpc/src/config.rs
+++ b/crates/superbank-rpc/src/config.rs
@@ -86,6 +86,18 @@ pub struct RpcConfig {
     #[arg(long, env = "RPC_BATCH_CONCURRENCY_LIMIT", default_value_t = 8)]
     pub(crate) rpc_batch_concurrency_limit: usize,
 
+    /// Maximum concurrent primary getSignatureStatuses workflows, including cancellation cleanup.
+    #[arg(
+        long,
+        env = "GET_SIGNATURE_STATUSES_MAX_CONCURRENCY",
+        default_value_t = 4
+    )]
+    pub(crate) get_signature_statuses_max_concurrency: usize,
+
+    /// Primary getSignatureStatuses execution and primary-index filtering thread cap.
+    #[arg(long, env = "GET_SIGNATURE_STATUSES_MAX_THREADS", default_value_t = 2)]
+    pub(crate) get_signature_statuses_max_threads: usize,
+
     /// Maximum number of addresses accepted by getInflationReward; zero disables the limit.
     #[arg(
         long,
@@ -369,8 +381,8 @@ pub struct RpcConfig {
     )]
     pub(crate) clickhouse_replica_health_check_interval_ms: u64,
 
-    /// ClickHouse cluster name used to discover shard topology in shard-direct scope.
-    /// Supports macros such as {cluster}.
+    /// ClickHouse cluster used for primary status-query cancellation and shard-direct discovery.
+    /// Supports macros such as {cluster}; empty selects local-only cancellation on standalone nodes.
     #[arg(long, env = "CLICKHOUSE_CLUSTER", default_value = "{cluster}")]
     pub(crate) clickhouse_cluster: String,
 
@@ -851,6 +863,23 @@ mod config_tests {
     }
 
     #[test]
+    fn signature_status_limits_cli_overrides() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let cfg = RpcConfig::parse_from([
+            "superbank-rpc",
+            "--get-signature-statuses-max-concurrency",
+            "3",
+            "--get-signature-statuses-max-threads",
+            "1",
+            "--clickhouse-cluster",
+            "rbx2",
+        ]);
+        assert_eq!(cfg.get_signature_statuses_max_concurrency, 3);
+        assert_eq!(cfg.get_signature_statuses_max_threads, 1);
+        assert_eq!(cfg.clickhouse_cluster, "rbx2");
+    }
+
+    #[test]
     fn clickhouse_query_cache_defaults() {
         let _guard = ENV_LOCK.lock().expect("env lock");
         let cfg = RpcConfig::parse_from(["superbank-rpc"]);
@@ -866,6 +895,8 @@ mod config_tests {
         assert!(!cfg.metrics_capture_x_rpc_node());
         assert!(!cfg.metrics_capture_x_subscription_id());
         assert!(!cfg.metrics_capture_x_account_id());
+        assert_eq!(cfg.get_signature_statuses_max_concurrency, 4);
+        assert_eq!(cfg.get_signature_statuses_max_threads, 2);
         assert_eq!(cfg.get_inflation_reward_max_addresses, 100);
         assert_eq!(cfg.get_inflation_reward_max_concurrency, 20);
         assert_eq!(cfg.get_inflation_reward_query_timeout_ms, 5_000);

--- a/crates/superbank-rpc/src/disk_cache/filler.rs
+++ b/crates/superbank-rpc/src/disk_cache/filler.rs
@@ -462,7 +462,7 @@ pub(super) async fn fill_range(
         .ok_or_else(|| DiskCacheError::Config("transactions schema missing".to_string()))?;
     // Forward the durable fact table first. The block table can use Memory,
     // which cannot deduplicate a retry after a later stage fails.
-    let _mutation = cache.begin_fill(range.start, range.end);
+    let mut mutation = cache.begin_fill(range.start, range.end);
     native_forward(cache, source, transactions, range, cfg.query_timeout).await?;
     cache
         .validate_transaction_counts(range.start, range.end, &expected)
@@ -471,6 +471,9 @@ pub(super) async fn fill_range(
 
     let coverage = coverage_from_metadata(range, &metadata, successor.as_ref());
     let published: HashSet<u64> = coverage.iter().map(|(slot, _)| *slot).collect();
+    cache
+        .update_signature_membership(&mut mutation, range.start, range.end)
+        .await;
     cache.publish_range_coverage(coverage).await?;
     let transactions_written = expected.values().copied().sum();
     crate::metrics::disk_cache_write(

--- a/crates/superbank-rpc/src/disk_cache/key_index.rs
+++ b/crates/superbank-rpc/src/disk_cache/key_index.rs
@@ -8,12 +8,14 @@ use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+mod signatures;
+pub(super) use signatures::{SignatureCandidates, SignatureHash};
+
 const RESERVE: u64 = 64 * 1024 * 1024;
 const ENTRY_OVERHEAD: u64 = 1024;
 
 #[derive(Clone, Copy, Debug)]
 pub(super) enum Family {
-    Signature,
     Address,
     HotAddress,
     Owner,
@@ -21,19 +23,13 @@ pub(super) enum Family {
 impl Family {
     fn table(self) -> (CacheTableKind, &'static str) {
         match self {
-            Self::Signature => (CacheTableKind::Signatures, "signature"),
             Self::Address => (CacheTableKind::Gsfa, "address"),
             Self::HotAddress => (CacheTableKind::GsfaHot, "address"),
             Self::Owner => (CacheTableKind::TokenOwnerActivity, "owner"),
         }
     }
 }
-const FAMILIES: [Family; 4] = [
-    Family::Signature,
-    Family::Address,
-    Family::HotAddress,
-    Family::Owner,
-];
+const FAMILIES: [Family; 3] = [Family::Address, Family::HotAddress, Family::Owner];
 
 struct Bloom {
     bits: Vec<u8>,
@@ -41,25 +37,27 @@ struct Bloom {
 }
 impl Bloom {
     fn new(bytes: usize, cardinality: u64) -> Option<Self> {
+        let hashes = ((bytes as f64 * 8.0 / cardinality.max(1) as f64) * std::f64::consts::LN_2)
+            .round()
+            .clamp(1.0, 16.0) as u32;
+        Self::with_hashes(bytes, hashes)
+    }
+    fn with_hashes(bytes: usize, hashes: u32) -> Option<Self> {
         if bytes == 0 {
             return None;
         }
         let mut bits = Vec::new();
         bits.try_reserve_exact(bytes).ok()?;
         bits.resize(bytes, 0);
-        let hashes = ((bytes as f64 * 8.0 / cardinality.max(1) as f64) * std::f64::consts::LN_2)
-            .round()
-            .clamp(1.0, 16.0) as u32;
         Some(Self { bits, hashes })
     }
     fn positions(&self, key: &[u8]) -> impl Iterator<Item = usize> + use<> {
-        let digest = blake3::hash(key);
-        let mut a = [0; 8];
-        let mut b = [0; 8];
-        a.copy_from_slice(&digest.as_bytes()[..8]);
-        b.copy_from_slice(&digest.as_bytes()[8..16]);
-        let a = u64::from_le_bytes(a);
-        let b = u64::from_le_bytes(b) | 1;
+        self.hash_positions(SignatureHash::new(key))
+    }
+    fn hash_positions(
+        &self,
+        SignatureHash(a, b): SignatureHash,
+    ) -> impl Iterator<Item = usize> + use<> {
         let bits = self.bits.len() as u64 * 8;
         (0..self.hashes)
             .map(move |i| (a.wrapping_add(u64::from(i).wrapping_mul(b)) % bits) as usize)
@@ -76,12 +74,13 @@ impl Bloom {
 }
 struct Entry {
     token: u64,
-    filters: Option<[Option<Bloom>; 4]>,
+    filters: Option<[Option<Bloom>; 3]>,
 }
 #[derive(Default)]
 struct State {
     entries: BTreeMap<u64, Entry>,
-    writers: BTreeMap<u64, (u64, u64)>,
+    writers: BTreeMap<u64, signatures::Writer>,
+    signatures: BTreeMap<u64, signatures::SignatureEntry>,
     serial: u64,
     epoch: u64,
     untracked_writers: usize,
@@ -89,6 +88,7 @@ struct State {
 
 pub(super) struct KeyIndex {
     state: Mutex<State>,
+    allocation: tokio::sync::Mutex<()>,
     width: u64,
     quota: usize,
     max_entries: usize,
@@ -102,7 +102,9 @@ impl Drop for Mutation {
         let mut state = self.index.state.lock().expect("key index lock");
         match self.id {
             Some(id) => {
-                state.writers.remove(&id);
+                if let Some(writer) = state.writers.remove(&id) {
+                    signatures::abandon_update(&mut state, &writer);
+                }
             }
             None => state.untracked_writers -= 1,
         }
@@ -119,6 +121,7 @@ impl KeyIndex {
         let quota = cfg.key_index_max_memory_bytes.saturating_sub(RESERVE) / slots;
         Self {
             state: Mutex::default(),
+            allocation: tokio::sync::Mutex::default(),
             width: cfg.partition_slots,
             quota: usize::try_from(quota.saturating_sub(ENTRY_OVERHEAD)).unwrap_or(0),
             max_entries: usize::try_from(slots.saturating_sub(1)).unwrap_or(0),
@@ -129,6 +132,7 @@ impl KeyIndex {
         // Bound mutation metadata even if many callers concurrently poison slots.
         if state.writers.len() >= 128 {
             state.entries.clear();
+            state.signatures.clear();
             state.epoch += 1;
             state.untracked_writers += 1;
             return Mutation {
@@ -144,7 +148,7 @@ impl KeyIndex {
         if count != state.entries.len() {
             state.epoch += 1;
         }
-        state.writers.insert(id, range);
+        state.writers.insert(id, signatures::Writer::new(range));
         Mutation {
             index: self.clone(),
             id: Some(id),
@@ -183,7 +187,7 @@ impl KeyIndex {
         if state
             .writers
             .values()
-            .any(|(a, b)| (*a..=*b).contains(&partition))
+            .any(|writer| (writer.range.0..=writer.range.1).contains(&partition))
         {
             return None;
         }
@@ -198,7 +202,7 @@ impl KeyIndex {
         );
         Some(token)
     }
-    fn finish(&self, partition: u64, token: u64, filters: Option<[Option<Bloom>; 4]>) {
+    fn finish(&self, partition: u64, token: u64, filters: Option<[Option<Bloom>; 3]>) {
         let mut state = self.state.lock().expect("key index lock");
         if state
             .entries
@@ -250,6 +254,7 @@ impl DiskCache {
         }
     }
     pub(super) async fn build_key_indexes(&self) {
+        self.build_signature_indexes().await;
         let Some((floor, tip)) = self.tip_span() else {
             return;
         };
@@ -314,9 +319,14 @@ impl DiskCache {
         // Include the reserved builder/metadata allowance to report the upper bound.
         crate::metrics::disk_cache_key_index(
             allocated
-                + building * self.inner.key_index.quota as u64
+                + building * self.inner.key_index.address_quota() as u64
+                + state
+                    .signatures
+                    .values()
+                    .map(|entry| entry.bloom.bits.capacity() as u64)
+                    .sum::<u64>()
                 + RESERVE
-                + state.entries.len() as u64 * ENTRY_OVERHEAD,
+                + (state.entries.len() + state.signatures.len()) as u64 * (ENTRY_OVERHEAD / 2),
             indexed,
             total.saturating_sub(indexed),
         );
@@ -324,7 +334,7 @@ impl DiskCache {
     async fn build_partition_filters(
         &self,
         partition: u64,
-    ) -> Result<[Option<Bloom>; 4], DiskCacheError> {
+    ) -> Result<[Option<Bloom>; 3], DiskCacheError> {
         // A separate lane: never consume the interactive query semaphore.
         let client = self
             .inner
@@ -341,7 +351,7 @@ impl DiskCache {
         builder.cache_partition = Some((self.inner.cfg.partition_slots, partition));
         builder.query_timeout = Duration::from_secs(300);
         let snapshot = self.source_schema();
-        let mut cardinalities = [0u64; 4];
+        let mut cardinalities = [0u64; 3];
         for family in FAMILIES {
             let (kind, key) = family.table();
             if !snapshot.has_table(kind) {
@@ -356,14 +366,14 @@ impl DiskCache {
             cardinalities[family as usize] = cardinality(&builder, &sql).await?.max(1);
         }
         let total: u128 = cardinalities.iter().map(|n| u128::from(*n)).sum();
-        let mut filters: [Option<Bloom>; 4] = std::array::from_fn(|_| None);
+        let mut filters: [Option<Bloom>; 3] = std::array::from_fn(|_| None);
         for family in FAMILIES {
             let n = cardinalities[family as usize];
             if n == 0 {
                 continue;
             }
-            let share =
-                (self.inner.key_index.quota as u128 * u128::from(n) / total.max(1)) as usize;
+            let share = (self.inner.key_index.address_quota() as u128 * u128::from(n)
+                / total.max(1)) as usize;
             let target = (n as f64 * 1.2).ceil() as usize;
             let Some(mut bloom) = Bloom::new(share.min(target), n) else {
                 continue;
@@ -375,10 +385,7 @@ impl DiskCache {
                 kind.local_name(),
                 self.inner.cfg.partition_slots
             );
-            match family {
-                Family::Signature => read_keys::<64>(&builder, &sql, &mut bloom).await?,
-                _ => read_keys::<32>(&builder, &sql, &mut bloom).await?,
-            }
+            read_keys::<32>(&builder, &sql, &mut bloom).await?;
             filters[family as usize] = Some(bloom);
         }
         Ok(filters)
@@ -444,6 +451,7 @@ mod tests {
     fn mutation_metadata_is_bounded_under_overload() {
         let index = Arc::new(KeyIndex {
             state: Mutex::default(),
+            allocation: tokio::sync::Mutex::default(),
             width: 10,
             quota: 1024,
             max_entries: 2,
@@ -472,6 +480,7 @@ mod tests {
     fn family_isolation_and_failed_builds_remain_conservative() {
         let index = KeyIndex {
             state: Mutex::default(),
+            allocation: tokio::sync::Mutex::default(),
             width: 10,
             quota: 1024,
             max_entries: 1,
@@ -488,12 +497,13 @@ mod tests {
         index.finish(1, token, Some(filters));
         assert!(!index.may_contain(1, &[Family::Address], b"owner"));
         assert!(index.may_contain(1, &[Family::Address, Family::Owner], b"owner"));
-        assert!(index.may_contain(2, &[Family::Signature], b"unknown"));
+        assert!(index.may_contain(2, &[Family::Address], b"unknown"));
     }
     #[test]
     fn old_build_cannot_replace_new_generation() {
         let index = Arc::new(KeyIndex {
             state: Mutex::default(),
+            allocation: tokio::sync::Mutex::default(),
             width: 10,
             quota: 1024,
             max_entries: 2,
@@ -502,9 +512,9 @@ mod tests {
         drop(index.mutation(10, 19));
         let new = index.begin(1).unwrap();
         index.finish(1, old, Some(std::array::from_fn(|_| Bloom::new(32, 10))));
-        assert!(index.may_contain(1, &[Family::Signature], b"missing"));
+        assert!(index.may_contain(1, &[Family::Address], b"missing"));
         index.finish(1, new, Some(std::array::from_fn(|_| Bloom::new(32, 10))));
-        assert!(!index.may_contain(1, &[Family::Signature], b"missing"));
+        assert!(!index.may_contain(1, &[Family::Address], b"missing"));
     }
 
     #[test]
@@ -522,6 +532,7 @@ mod tests {
     fn invalidation_rejects_in_flight_build_and_admits_unknown_keys() {
         let index = Arc::new(KeyIndex {
             state: Mutex::default(),
+            allocation: tokio::sync::Mutex::default(),
             width: 10,
             quota: 1024,
             max_entries: 4,
@@ -529,7 +540,7 @@ mod tests {
         let token = index.begin(1).unwrap();
         let mutation = index.mutation(10, 19);
         index.finish(1, token, Some(std::array::from_fn(|_| Bloom::new(32, 10))));
-        assert!(index.may_contain(1, &[Family::Signature], b"missing"));
+        assert!(index.may_contain(1, &[Family::Address], b"missing"));
         assert!(index.begin(1).is_none());
         drop(mutation);
         assert!(index.begin(1).is_some());

--- a/crates/superbank-rpc/src/disk_cache/key_index.rs
+++ b/crates/superbank-rpc/src/disk_cache/key_index.rs
@@ -240,62 +240,74 @@ struct KeyRow<const N: usize> {
 impl DiskCache {
     pub(crate) async fn run_key_index(
         self: Arc<Self>,
-        mut shutdown: tokio::sync::broadcast::Receiver<()>,
+        shutdown: tokio::sync::broadcast::Receiver<()>,
     ) {
-        loop {
-            tokio::select! {
-                _ = shutdown.recv() => return,
-                _ = self.build_key_indexes() => {}
-            }
-            tokio::select! {
-                _ = shutdown.recv() => return,
-                _ = tokio::time::sleep(Duration::from_secs(5)) => {}
-            }
-        }
+        run_workers(
+            || self.build_signature_indexes(),
+            || self.build_key_indexes(),
+            shutdown,
+        )
+        .await;
     }
     pub(super) async fn build_key_indexes(&self) {
-        self.build_signature_indexes().await;
+        self.publish_index_metrics();
         let Some((floor, tip)) = self.tip_span() else {
             return;
         };
         let width = self.inner.cfg.partition_slots;
-        self.publish_key_index_metrics(floor, tip);
         for partition in (floor.div_ceil(width)..tip / width).rev() {
+            // Check live state before each build. An already-running address scan
+            // may finish, but cannot delay the independent signature worker.
+            if !self.signature_indexes_ready() {
+                break;
+            }
             let Some(token) = self.inner.key_index.begin(partition) else {
                 continue;
             };
-            let started = std::time::Instant::now();
-            let built = tokio::time::timeout(
-                Duration::from_secs(300),
-                self.build_partition_filters(partition),
-            )
-            .await;
-            let outcome = if matches!(&built, Ok(Ok(_))) {
-                "success"
-            } else {
-                "error"
-            };
-            let filters = match built {
-                Ok(Ok(filters)) => Some(filters),
-                _ => {
-                    crate::metrics::disk_cache_read("key_index_build", "error");
-                    None
-                }
-            };
-            self.inner.key_index.finish(partition, token, filters);
-            crate::metrics::disk_cache_key_seconds(
-                "index_build",
-                outcome,
-                started.elapsed().as_secs_f64(),
-            );
-            tracing::debug!(
-                partition,
-                elapsed_ms = started.elapsed().as_millis(),
-                "disk cache: key index build finished"
-            );
+            self.publish_index_metrics();
+            self.build_address_partition(partition, token).await;
+            self.publish_index_metrics();
         }
     }
-    fn publish_key_index_metrics(&self, floor: u64, tip: u64) {
+    async fn build_address_partition(&self, partition: u64, token: u64) {
+        let started = std::time::Instant::now();
+        let built = tokio::time::timeout(
+            Duration::from_secs(300),
+            self.build_partition_filters(partition),
+        )
+        .await;
+        let outcome = if matches!(&built, Ok(Ok(_))) {
+            "success"
+        } else {
+            "error"
+        };
+        let filters = match built {
+            Ok(Ok(filters)) => Some(filters),
+            _ => {
+                crate::metrics::disk_cache_read("key_index_build", "error");
+                None
+            }
+        };
+        self.inner.key_index.finish(partition, token, filters);
+        crate::metrics::disk_cache_key_seconds(
+            "index_build",
+            outcome,
+            started.elapsed().as_secs_f64(),
+        );
+        tracing::debug!(
+            partition,
+            elapsed_ms = started.elapsed().as_millis(),
+            "disk cache: key index build finished"
+        );
+    }
+    fn publish_index_metrics(&self) {
+        self.publish_signature_index_metrics();
+        self.publish_key_index_metrics();
+    }
+    fn publish_key_index_metrics(&self) {
+        let total = self.key_span().map_or(0, |(floor, tip)| {
+            tip / self.inner.cfg.partition_slots - floor / self.inner.cfg.partition_slots + 1
+        });
         let state = self.inner.key_index.state.lock().expect("key index lock");
         let indexed = state
             .entries
@@ -309,27 +321,24 @@ impl DiskCache {
             .flat_map(|filters| filters.iter().flatten())
             .map(|bloom| bloom.bits.capacity() as u64)
             .sum::<u64>();
-        let total =
-            tip / self.inner.cfg.partition_slots - floor / self.inner.cfg.partition_slots + 1;
+
         let building = state
             .entries
             .values()
             .filter(|entry| entry.filters.is_none())
             .count() as u64;
         // Include the reserved builder/metadata allowance to report the upper bound.
-        crate::metrics::disk_cache_key_index(
-            allocated
-                + building * self.inner.key_index.address_quota() as u64
-                + state
-                    .signatures
-                    .values()
-                    .map(|entry| entry.bloom.bits.capacity() as u64)
-                    .sum::<u64>()
-                + RESERVE
-                + (state.entries.len() + state.signatures.len()) as u64 * (ENTRY_OVERHEAD / 2),
-            indexed,
-            total.saturating_sub(indexed),
-        );
+        let bytes = allocated
+            + building * self.inner.key_index.address_quota() as u64
+            + state
+                .signatures
+                .values()
+                .map(|entry| entry.bloom.bits.capacity() as u64)
+                .sum::<u64>()
+            + RESERVE
+            + (state.entries.len() + state.signatures.len()) as u64 * (ENTRY_OVERHEAD / 2);
+        drop(state);
+        crate::metrics::disk_cache_key_index(bytes, indexed, total.saturating_sub(indexed));
     }
     async fn build_partition_filters(
         &self,
@@ -389,6 +398,31 @@ impl DiskCache {
             filters[family as usize] = Some(bloom);
         }
         Ok(filters)
+    }
+}
+
+// Both loops are owned by the supervisor's existing task. Dropping this future
+// also drops active query cleanup guards; no maintenance task can outlive it.
+async fn run_workers<S, A, SF, AF>(
+    signatures: S,
+    addresses: A,
+    mut shutdown: tokio::sync::broadcast::Receiver<()>,
+) where
+    S: Fn() -> SF,
+    A: Fn() -> AF,
+    SF: std::future::Future<Output = ()>,
+    AF: std::future::Future<Output = ()>,
+{
+    tokio::select! {
+        _ = shutdown.recv() => {},
+        _ = async { tokio::join!(repeat(signatures), repeat(addresses)); } => {},
+    }
+}
+
+async fn repeat<F: std::future::Future<Output = ()>>(work: impl Fn() -> F) {
+    loop {
+        work().await;
+        tokio::time::sleep(Duration::from_secs(5)).await;
     }
 }
 

--- a/crates/superbank-rpc/src/disk_cache/key_index.rs
+++ b/crates/superbank-rpc/src/disk_cache/key_index.rs
@@ -131,6 +131,8 @@ impl KeyIndex {
         let mut state = self.state.lock().expect("key index lock");
         // Bound mutation metadata even if many callers concurrently poison slots.
         if state.writers.len() >= 128 {
+            // Reject allocations already in flight even if the untracked writer finishes first.
+            state.serial += 1;
             state.entries.clear();
             state.signatures.clear();
             state.epoch += 1;

--- a/crates/superbank-rpc/src/disk_cache/key_index/signatures.rs
+++ b/crates/superbank-rpc/src/disk_cache/key_index/signatures.rs
@@ -1,0 +1,438 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+//! Signature membership shares the index budget, but survives ordinary appends.
+use super::{Bloom, KeyIndex, Mutation, State};
+use crate::disk_cache::{DiskCache, DiskCacheError};
+use clickhouse::Row;
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+const UPDATE_BATCH: usize = 128;
+const SIGNATURE_HASHES: u32 = 7;
+
+#[derive(Clone, Copy)]
+pub(in crate::disk_cache) struct SignatureHash(pub(super) u64, pub(super) u64);
+impl SignatureHash {
+    pub(in crate::disk_cache) fn new(key: &[u8]) -> Self {
+        let digest = blake3::hash(key);
+        let mut a = [0; 8];
+        let mut b = [0; 8];
+        a.copy_from_slice(&digest.as_bytes()[..8]);
+        b.copy_from_slice(&digest.as_bytes()[8..16]);
+        Self(u64::from_le_bytes(a), u64::from_le_bytes(b) | 1)
+    }
+}
+
+#[cfg(test)]
+mod tests;
+
+pub(super) struct SignatureEntry {
+    token: u64,
+    pub(super) bloom: Bloom,
+    complete: bool,
+}
+
+pub(super) struct Writer {
+    pub(super) range: (u64, u64),
+    signature_update: bool,
+    repair: bool,
+    updated: bool,
+}
+impl Writer {
+    pub(super) fn new(range: (u64, u64)) -> Self {
+        Self {
+            range,
+            signature_update: false,
+            repair: false,
+            updated: false,
+        }
+    }
+    fn repairing(&self, partition: u64) -> bool {
+        self.repair && !self.updated && (self.range.0..=self.range.1).contains(&partition)
+    }
+}
+
+pub(in crate::disk_cache) struct SignatureCandidates {
+    pub(in crate::disk_cache) partitions: Vec<u64>,
+    pub(in crate::disk_cache) total: u64,
+    unknown: bool,
+}
+impl SignatureCandidates {
+    pub(in crate::disk_cache) fn outcome(&self) -> &'static str {
+        if self.unknown {
+            "unknown"
+        } else if self.partitions.is_empty() {
+            "absent"
+        } else {
+            "possible"
+        }
+    }
+}
+
+fn invalidate(state: &mut State, range: (u64, u64)) {
+    state.serial += 1;
+    for (_, entry) in state.signatures.range_mut(range.0..=range.1) {
+        entry.complete = false;
+        entry.token = state.serial;
+    }
+}
+
+pub(super) fn abandon_update(state: &mut State, writer: &Writer) {
+    if writer.signature_update && !writer.updated {
+        invalidate(state, writer.range);
+    }
+}
+
+impl Mutation {
+    pub(in crate::disk_cache) fn signature_fill(self, repair: bool) -> Self {
+        if let Some(writer) = self
+            .index
+            .state
+            .lock()
+            .expect("key index lock")
+            .writers
+            .get_mut(&self.id.unwrap_or(0))
+        {
+            writer.signature_update = true;
+            writer.repair = repair;
+        }
+        self
+    }
+    fn finish_signatures(&mut self, success: bool) {
+        let mut state = self.index.state.lock().expect("key index lock");
+        let Some(writer) = state.writers.get_mut(&self.id.unwrap_or(0)) else {
+            return;
+        };
+        writer.updated = true;
+        let range = writer.range;
+        if !success {
+            invalidate(&mut state, range);
+        }
+    }
+}
+
+impl KeyIndex {
+    pub(super) fn address_quota(&self) -> usize {
+        self.quota - self.signature_quota()
+    }
+    fn signature_quota(&self) -> usize {
+        self.quota / 3 * 2
+    }
+
+    pub(in crate::disk_cache) fn clear_signatures(&self) {
+        let mut state = self.state.lock().expect("key index lock");
+        state.serial += 1;
+        state.signatures.clear();
+    }
+    pub(in crate::disk_cache) fn evict_signatures(&self, floor: u64) {
+        self.state
+            .lock()
+            .expect("key index lock")
+            .signatures
+            .retain(|p, _| *p >= floor / self.width);
+    }
+
+    async fn ensure_signature_partition(
+        &self,
+        partition: u64,
+        empty: impl FnOnce() -> bool,
+    ) -> Option<u64> {
+        // Only one bitmap allocation may be outside the map at a time. The existing
+        // spare partition allowance accounts for it, even across a concurrent reset.
+        let _allocation = self.allocation.lock().await;
+        let serial = {
+            let state = self.state.lock().expect("key index lock");
+            if state.writers.values().any(|writer| {
+                !writer.signature_update && (writer.range.0..=writer.range.1).contains(&partition)
+            }) {
+                return None;
+            }
+            if let Some(entry) = state.signatures.get(&partition) {
+                return Some(entry.token);
+            }
+            if state.signatures.len() >= self.max_entries || state.untracked_writers > 0 {
+                return None;
+            }
+            state.serial
+        };
+        let bloom = Bloom::with_hashes(self.signature_quota(), SIGNATURE_HASHES)?;
+        let complete = empty();
+        let mut state = self.state.lock().expect("key index lock");
+        if state.serial != serial {
+            return None;
+        }
+        state.serial += 1;
+        let token = state.serial;
+        state.signatures.insert(
+            partition,
+            SignatureEntry {
+                token,
+                bloom,
+                complete,
+            },
+        );
+        Some(token)
+    }
+
+    pub(in crate::disk_cache) fn signature_candidates(
+        &self,
+        floor: u64,
+        tip: u64,
+        hash: SignatureHash,
+    ) -> SignatureCandidates {
+        let state = self.state.lock().expect("key index lock");
+        let mut result = SignatureCandidates {
+            partitions: Vec::new(),
+            total: 0,
+            unknown: false,
+        };
+        for partition in (floor..=tip).rev() {
+            result.total += 1;
+            let entry = state
+                .signatures
+                .get(&partition)
+                .filter(|entry| entry.complete);
+            let repairing = state.writers.values().any(|w| w.repairing(partition));
+            if let Some(entry) = entry.filter(|_| !repairing) {
+                if entry
+                    .bloom
+                    .hash_positions(hash)
+                    .all(|bit| entry.bloom.bits[bit / 8] & (1 << (bit % 8)) != 0)
+                {
+                    result.partitions.push(partition);
+                }
+            } else {
+                result.unknown = true;
+                result.partitions.push(partition);
+            }
+        }
+        result
+    }
+
+    fn insert_signature_hashes(
+        &self,
+        tokens: &BTreeMap<u64, u64>,
+        batch: &[(u64, SignatureHash)],
+    ) -> Result<(), DiskCacheError> {
+        let mut state = self.state.lock().expect("key index lock");
+        // Check even an empty result: a reset or failed overlapping fill must
+        // not turn an obsolete scan into a successful membership update.
+        if !tokens.iter().all(|(partition, token)| {
+            state
+                .signatures
+                .get(partition)
+                .is_some_and(|entry| entry.token == *token)
+        }) {
+            return Err(DiskCacheError::ClickHouse(
+                "signature index generation changed".into(),
+            ));
+        }
+        for &(slot, hash) in batch {
+            let partition = slot / self.width;
+            let entry = state
+                .signatures
+                .get_mut(&partition)
+                .filter(|entry| tokens.get(&partition) == Some(&entry.token))
+                .ok_or_else(|| {
+                    DiskCacheError::ClickHouse("signature index generation changed".into())
+                })?;
+            for bit in entry.bloom.hash_positions(hash) {
+                entry.bloom.bits[bit / 8] |= 1 << (bit % 8);
+            }
+        }
+        Ok(())
+    }
+    fn finish_signature_build(&self, partition: u64, token: u64) {
+        let mut state = self.state.lock().expect("key index lock");
+        if let Some(entry) = state
+            .signatures
+            .get_mut(&partition)
+            .filter(|entry| entry.token == token)
+        {
+            entry.complete = true;
+        }
+    }
+    fn signature_complete(&self, partition: u64) -> bool {
+        self.state
+            .lock()
+            .expect("key index lock")
+            .signatures
+            .get(&partition)
+            .is_some_and(|entry| entry.complete)
+    }
+    fn signature_completeness(&self, floor: u64, tip: u64) -> (u64, u64) {
+        let state = self.state.lock().expect("key index lock");
+        let ready = state
+            .signatures
+            .range(floor..=tip)
+            .filter(|(partition, entry)| {
+                entry.complete && !state.writers.values().any(|w| w.repairing(**partition))
+            })
+            .count() as u64;
+        (ready, (tip - floor + 1).saturating_sub(ready))
+    }
+}
+
+#[derive(Deserialize, Row)]
+struct SignatureRow {
+    slot: u64,
+    key: serde_big_array::Array<u8, 64>,
+}
+
+impl DiskCache {
+    async fn signature_partition(&self, partition: u64) -> Option<u64> {
+        let width = self.inner.cfg.partition_slots;
+        self.inner
+            .key_index
+            .ensure_signature_partition(partition, || {
+                let floor = partition.saturating_mul(width);
+                !self
+                    .inner
+                    .coverage
+                    .read()
+                    .expect("coverage lock")
+                    .intersects(floor, floor.saturating_add(width - 1))
+            })
+            .await
+    }
+
+    pub(in crate::disk_cache) async fn update_signature_membership(
+        &self,
+        mutation: &mut Mutation,
+        start: u64,
+        end: u64,
+    ) {
+        let result = tokio::time::timeout(
+            self.inner.cfg.query_timeout,
+            self.update_signature_range(start, end),
+        )
+        .await;
+        let success = matches!(result, Ok(Ok(())));
+        mutation.finish_signatures(success);
+        if !success {
+            crate::metrics::disk_cache_read("signature_index_update", "error");
+            tracing::warn!(
+                ?result,
+                "disk cache: signature membership update failed; affected filters remain unknown"
+            );
+        }
+    }
+
+    async fn update_signature_range(&self, start: u64, end: u64) -> Result<(), DiskCacheError> {
+        let width = self.inner.cfg.partition_slots;
+        let mut tokens = BTreeMap::new();
+        for partition in start / width..=end / width {
+            let token = self.signature_partition(partition).await.ok_or_else(|| {
+                DiskCacheError::ClickHouse("signature index memory unavailable".into())
+            })?;
+            tokens.insert(partition, token);
+        }
+        let sql = self.source_schema().signature_keys_query(
+            &self.inner.cfg.database,
+            width,
+            start,
+            end,
+        )?;
+        self.stream_signature_hashes(&sql, &tokens, self.inner.cfg.query_timeout)
+            .await
+    }
+
+    pub(super) async fn build_signature_indexes(&self) {
+        let Some((floor, tip)) = self.key_span() else {
+            return;
+        };
+        let width = self.inner.cfg.partition_slots;
+        for partition in (floor / width..=tip / width).rev() {
+            if self.inner.key_index.signature_complete(partition) {
+                continue;
+            }
+            let Some(token) = self.signature_partition(partition).await else {
+                continue;
+            };
+            let sql = format!(
+                "SELECT slot, signature AS key FROM `{}`.signatures WHERE intDiv(slot, {width}) = {partition}",
+                self.inner.cfg.database
+            );
+            let tokens = BTreeMap::from([(partition, token)]);
+            let built = tokio::time::timeout(
+                Duration::from_secs(300),
+                self.stream_signature_hashes(&sql, &tokens, Duration::from_secs(300)),
+            )
+            .await;
+            if matches!(built, Ok(Ok(()))) {
+                self.inner
+                    .key_index
+                    .finish_signature_build(partition, token);
+            }
+            self.publish_signature_index_metrics();
+        }
+        self.publish_signature_index_metrics();
+    }
+
+    pub(in crate::disk_cache) fn publish_signature_index_metrics(&self) {
+        if let Some((floor, tip)) = self.key_span() {
+            let width = self.inner.cfg.partition_slots;
+            let (ready, unknown) = self
+                .inner
+                .key_index
+                .signature_completeness(floor / width, tip / width);
+            crate::metrics::disk_cache_signature_index(ready, unknown);
+        } else {
+            crate::metrics::disk_cache_signature_index(0, 0);
+        }
+    }
+
+    async fn stream_signature_hashes(
+        &self,
+        sql: &str,
+        tokens: &BTreeMap<u64, u64>,
+        timeout: Duration,
+    ) -> Result<(), DiskCacheError> {
+        let mut builder = self.inner.local.clone();
+        builder.cache_partition = Some((
+            self.inner.cfg.partition_slots,
+            *tokens
+                .first_key_value()
+                .expect("nonempty signature range")
+                .0,
+        ));
+        builder.query_timeout = timeout;
+        let (sql, id, mut cleanup) =
+            builder.annotate_lookup_query(sql.into(), "signature_index_keys");
+        let client = builder
+            .client
+            .clone()
+            .with_setting("query_id", id.unwrap_or_default())
+            .with_setting("max_threads", "1")
+            .with_setting("max_memory_usage", "67108864")
+            .with_setting("max_block_size", "8192")
+            .with_setting("preferred_block_size_bytes", "1048576")
+            .with_setting("max_execution_time", timeout.as_secs_f64().to_string());
+        let mut cursor = client
+            .query(&sql)
+            .fetch::<SignatureRow>()
+            .map_err(|e| DiskCacheError::ClickHouse(e.to_string()))?;
+        let mut batch = Vec::with_capacity(UPDATE_BATCH);
+        while let Some(row) = cursor
+            .next()
+            .await
+            .map_err(|e| DiskCacheError::ClickHouse(e.to_string()))?
+        {
+            batch.push((row.slot, SignatureHash::new(&row.key.0)));
+            if batch.len() == UPDATE_BATCH {
+                self.inner
+                    .key_index
+                    .insert_signature_hashes(tokens, &batch)?;
+                batch.clear();
+                tokio::task::yield_now().await;
+            }
+        }
+        self.inner
+            .key_index
+            .insert_signature_hashes(tokens, &batch)?;
+        if let Some(cleanup) = &mut cleanup {
+            cleanup.disarm();
+        }
+        Ok(())
+    }
+}

--- a/crates/superbank-rpc/src/disk_cache/key_index/signatures.rs
+++ b/crates/superbank-rpc/src/disk_cache/key_index/signatures.rs
@@ -242,7 +242,7 @@ impl KeyIndex {
         }
         Ok(())
     }
-    fn finish_signature_build(&self, partition: u64, token: u64) {
+    fn finish_signature_build(&self, partition: u64, token: u64) -> bool {
         let mut state = self.state.lock().expect("key index lock");
         if let Some(entry) = state
             .signatures
@@ -250,7 +250,17 @@ impl KeyIndex {
             .filter(|entry| entry.token == token)
         {
             entry.complete = true;
+            return true;
         }
+        false
+    }
+    fn signature_generation_matches(&self, partition: u64, token: u64) -> bool {
+        self.state
+            .lock()
+            .expect("key index lock")
+            .signatures
+            .get(&partition)
+            .is_some_and(|entry| entry.token == token)
     }
     fn signature_complete(&self, partition: u64) -> bool {
         self.state
@@ -337,7 +347,23 @@ impl DiskCache {
             .await
     }
 
-    pub(super) async fn build_signature_indexes(&self) {
+    pub(in crate::disk_cache) fn signature_indexes_ready(&self) -> bool {
+        let width = self.inner.cfg.partition_slots;
+        self.ready()
+            && self.key_span().is_some_and(|(floor, tip)| {
+                self.inner
+                    .key_index
+                    .signature_completeness(floor / width, tip / width)
+                    .1
+                    == 0
+            })
+    }
+
+    pub(in crate::disk_cache) async fn build_signature_indexes(&self) {
+        self.publish_index_metrics();
+        if !self.ready() {
+            return;
+        }
         let Some((floor, tip)) = self.key_span() else {
             return;
         };
@@ -346,27 +372,68 @@ impl DiskCache {
             if self.inner.key_index.signature_complete(partition) {
                 continue;
             }
-            let Some(token) = self.signature_partition(partition).await else {
-                continue;
-            };
-            let sql = format!(
-                "SELECT slot, signature AS key FROM `{}`.signatures WHERE intDiv(slot, {width}) = {partition}",
-                self.inner.cfg.database
-            );
-            let tokens = BTreeMap::from([(partition, token)]);
-            let built = tokio::time::timeout(
-                Duration::from_secs(300),
-                self.stream_signature_hashes(&sql, &tokens, Duration::from_secs(300)),
-            )
-            .await;
-            if matches!(built, Ok(Ok(()))) {
-                self.inner
-                    .key_index
-                    .finish_signature_build(partition, token);
-            }
-            self.publish_signature_index_metrics();
+            self.build_signature_partition(partition).await;
+            self.publish_index_metrics();
         }
-        self.publish_signature_index_metrics();
+    }
+
+    async fn build_signature_partition(&self, partition: u64) {
+        let Some(token) = self.signature_partition(partition).await else {
+            crate::metrics::disk_cache_read("signature_index_build", "deferred");
+            tracing::debug!(partition, "disk cache: signature index allocation deferred");
+            return;
+        };
+        self.publish_index_metrics();
+        let width = self.inner.cfg.partition_slots;
+        let sql = format!(
+            "SELECT slot, signature AS key FROM `{}`.signatures WHERE intDiv(slot, {width}) = {partition}",
+            self.inner.cfg.database
+        );
+        let tokens = BTreeMap::from([(partition, token)]);
+        let started = std::time::Instant::now();
+        let built = tokio::time::timeout(
+            Duration::from_secs(300),
+            self.stream_signature_hashes(&sql, &tokens, Duration::from_secs(300)),
+        )
+        .await;
+        let outcome = match &built {
+            Ok(Ok(()))
+                if self
+                    .inner
+                    .key_index
+                    .finish_signature_build(partition, token) =>
+            {
+                "success"
+            }
+            _ if !self
+                .inner
+                .key_index
+                .signature_generation_matches(partition, token) =>
+            {
+                "superseded"
+            }
+            Err(_) => "timeout",
+            _ => "error",
+        };
+        crate::metrics::disk_cache_key_seconds(
+            "signature_index_build",
+            outcome,
+            started.elapsed().as_secs_f64(),
+        );
+        if matches!(outcome, "error" | "timeout") {
+            tracing::warn!(
+                partition,
+                outcome,
+                ?built,
+                "disk cache: signature index build failed"
+            );
+        } else {
+            tracing::debug!(
+                partition,
+                outcome,
+                "disk cache: signature index build finished"
+            );
+        }
     }
 
     pub(in crate::disk_cache) fn publish_signature_index_metrics(&self) {

--- a/crates/superbank-rpc/src/disk_cache/key_index/signatures.rs
+++ b/crates/superbank-rpc/src/disk_cache/key_index/signatures.rs
@@ -103,7 +103,10 @@ impl Mutation {
         let Some(writer) = state.writers.get_mut(&self.id.unwrap_or(0)) else {
             return;
         };
-        writer.updated = true;
+        writer.updated = success;
+        // Failed fills may still publish coverage. Keep the partition unknown
+        // until guard drop, which also invalidates entries allocated meanwhile.
+        writer.repair |= !success;
         let range = writer.range;
         if !success {
             invalidate(&mut state, range);

--- a/crates/superbank-rpc/src/disk_cache/key_index/signatures.rs
+++ b/crates/superbank-rpc/src/disk_cache/key_index/signatures.rs
@@ -161,7 +161,8 @@ impl KeyIndex {
         let bloom = Bloom::with_hashes(self.signature_quota(), SIGNATURE_HASHES)?;
         let complete = empty();
         let mut state = self.state.lock().expect("key index lock");
-        if state.serial != serial {
+        // Publication requires the original generation and no untracked writers.
+        if (state.serial, state.untracked_writers) != (serial, 0) {
             return None;
         }
         state.serial += 1;

--- a/crates/superbank-rpc/src/disk_cache/key_index/signatures/tests.rs
+++ b/crates/superbank-rpc/src/disk_cache/key_index/signatures/tests.rs
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+use super::*;
+use std::sync::{Arc, Mutex};
+
+// Scale key count and bytes together. Full-retention memory and RPC behavior
+// still require the separate deployment benchmark in tests/k6/README.md.
+#[tokio::test]
+#[ignore = "run explicitly with --release --ignored --nocapture"]
+async fn signature_membership_latency_and_false_positives() {
+    let index = Arc::new(KeyIndex {
+        state: Mutex::default(),
+        allocation: tokio::sync::Mutex::default(),
+        width: 50_000,
+        quota: 225_000,
+        max_entries: 80,
+    });
+    for partition in 0..80 {
+        let token = index
+            .ensure_signature_partition(partition, || true)
+            .await
+            .unwrap();
+        let tokens = BTreeMap::from([(partition, token)]);
+        for first in (0u64..50_000).step_by(UPDATE_BATCH) {
+            let batch: Vec<_> = (first..(first + UPDATE_BATCH as u64).min(50_000))
+                .map(|offset| {
+                    let key = partition * 50_000 + offset;
+                    (key, SignatureHash::new(&key.to_le_bytes()))
+                })
+                .collect();
+            index.insert_signature_hashes(&tokens, &batch).unwrap();
+        }
+        for offset in 0..1000 {
+            let key = partition * 50_000 + offset;
+            assert_eq!(
+                index
+                    .signature_candidates(
+                        partition,
+                        partition,
+                        SignatureHash::new(&key.to_le_bytes())
+                    )
+                    .outcome(),
+                "possible"
+            );
+        }
+    }
+    let (p99, false_positives) = measure(&index);
+    let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let writer = concurrent_updates(index.clone(), stop.clone());
+    let (contended_p99, _) = measure(&index);
+    stop.store(true, std::sync::atomic::Ordering::Relaxed);
+    writer.join().unwrap();
+    eprintln!(
+        "80 partitions, 4M keys, 24 bits/key: p99={p99:?}, p99 with continuous 128-key updates={contended_p99:?}, aggregate false positives={false_positives}/20000"
+    );
+    assert!(
+        false_positives <= 200,
+        "aggregate false positives exceeded 1%"
+    );
+    assert!(p99 < Duration::from_micros(100));
+    assert!(contended_p99 < Duration::from_micros(100));
+}
+
+fn measure(index: &KeyIndex) -> (Duration, usize) {
+    let mut times = Vec::with_capacity(20_000);
+    let mut false_positives = 0;
+    for key in 4_000_000u64..4_020_000 {
+        let started = std::time::Instant::now();
+        let result = index.signature_candidates(0, 79, SignatureHash::new(&key.to_le_bytes()));
+        times.push(started.elapsed());
+        false_positives += usize::from(!result.partitions.is_empty());
+    }
+    times.sort_unstable();
+    (times[19_799], false_positives)
+}
+
+fn concurrent_updates(
+    index: Arc<KeyIndex>,
+    stop: Arc<std::sync::atomic::AtomicBool>,
+) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        let token = index
+            .state
+            .lock()
+            .unwrap()
+            .signatures
+            .get(&79)
+            .unwrap()
+            .token;
+        let tokens = BTreeMap::from([(79, token)]);
+        let batch: Vec<_> = (3_950_000u64..3_950_128)
+            .map(|key| (key, SignatureHash::new(&key.to_le_bytes())))
+            .collect();
+        while !stop.load(std::sync::atomic::Ordering::Relaxed) {
+            index.insert_signature_hashes(&tokens, &batch).unwrap();
+            std::thread::yield_now();
+        }
+    })
+}
+
+fn index() -> Arc<KeyIndex> {
+    Arc::new(KeyIndex {
+        state: Mutex::default(),
+        allocation: tokio::sync::Mutex::default(),
+        width: 10,
+        quota: 1536,
+        max_entries: 4,
+    })
+}
+fn candidates(index: &KeyIndex, key: &[u8]) -> SignatureCandidates {
+    index.signature_candidates(1, 1, SignatureHash::new(key))
+}
+async fn insert(index: &KeyIndex, key: &[u8]) -> u64 {
+    let token = index.ensure_signature_partition(1, || true).await.unwrap();
+    index
+        .insert_signature_hashes(
+            &BTreeMap::from([(1, token)]),
+            &[(15, SignatureHash::new(key))],
+        )
+        .unwrap();
+    token
+}
+
+#[tokio::test]
+async fn appends_preserve_complete_filters_and_partial_eviction_keeps_bits() {
+    let index = index();
+    insert(&index, b"old").await;
+    let mut fill = index.mutation(16, 18).signature_fill(false);
+    assert_eq!(candidates(&index, b"absent").outcome(), "absent");
+    insert(&index, b"new").await;
+    fill.finish_signatures(true);
+    drop(fill);
+    index.evict_signatures(17);
+    assert_eq!(candidates(&index, b"new").outcome(), "possible");
+    assert_eq!(candidates(&index, b"old").outcome(), "possible");
+    assert_eq!(candidates(&index, b"absent").outcome(), "absent");
+    index.evict_signatures(20);
+    assert_eq!(candidates(&index, b"old").outcome(), "unknown");
+}
+
+#[tokio::test]
+async fn repairs_are_unknown_until_their_delta_is_applied() {
+    let index = index();
+    let token = insert(&index, b"old").await;
+    let mut repair = index.mutation(15, 15).signature_fill(true);
+    index.finish_signature_build(1, token);
+    assert_eq!(candidates(&index, b"new").outcome(), "unknown");
+    assert_eq!(index.signature_completeness(1, 1), (0, 1));
+    insert(&index, b"new").await;
+    repair.finish_signatures(true);
+    assert_eq!(candidates(&index, b"new").outcome(), "possible");
+    assert_eq!(candidates(&index, b"absent").outcome(), "absent");
+}
+
+#[tokio::test]
+async fn cancelled_or_failed_fills_reject_stale_builds_even_for_empty_results() {
+    let index = index();
+    let token = insert(&index, b"old").await;
+    drop(index.mutation(15, 15).signature_fill(false));
+    index.finish_signature_build(1, token);
+    assert_eq!(candidates(&index, b"absent").outcome(), "unknown");
+    assert!(
+        index
+            .insert_signature_hashes(&BTreeMap::from([(1, token)]), &[])
+            .is_err()
+    );
+    let token = insert(&index, b"new").await;
+    let mut fill = index.mutation(16, 16).signature_fill(false);
+    fill.finish_signatures(false);
+    index.finish_signature_build(1, token);
+    assert_eq!(candidates(&index, b"new").outcome(), "unknown");
+    let token = insert(&index, b"new").await;
+    index.finish_signature_build(1, token);
+    assert_eq!(candidates(&index, b"old").outcome(), "possible");
+}
+
+#[tokio::test]
+async fn reset_rejects_allocations_and_builds_from_the_old_generation() {
+    let index = index();
+    assert!(
+        index
+            .ensure_signature_partition(1, || {
+                index.clear_signatures();
+                true
+            })
+            .await
+            .is_none()
+    );
+    let token = insert(&index, b"old").await;
+    let reset = index.mutation(0, u64::MAX);
+    index.clear_signatures();
+    assert!(index.ensure_signature_partition(1, || true).await.is_none());
+    drop(reset);
+    index.ensure_signature_partition(1, || false).await.unwrap();
+    index.finish_signature_build(1, token);
+    assert_eq!(candidates(&index, b"old").outcome(), "unknown");
+}
+
+#[tokio::test]
+async fn edges_holes_and_budget_exhaustion_remain_conservative() {
+    let index = index();
+    for partition in 1..=4 {
+        index
+            .ensure_signature_partition(partition, || true)
+            .await
+            .unwrap();
+    }
+    assert_eq!(
+        index
+            .signature_candidates(1, 4, SignatureHash::new(b"absent"))
+            .outcome(),
+        "absent"
+    );
+    assert!(index.ensure_signature_partition(5, || true).await.is_none());
+    assert_eq!(
+        index
+            .signature_candidates(1, 5, SignatureHash::new(b"absent"))
+            .partitions,
+        [5]
+    );
+    let guards: Vec<_> = (0..129)
+        .map(|_| index.mutation(10, 19).signature_fill(false))
+        .collect();
+    assert_eq!(candidates(&index, b"absent").outcome(), "unknown");
+    assert!(index.ensure_signature_partition(1, || true).await.is_none());
+    drop(guards);
+}

--- a/crates/superbank-rpc/src/disk_cache/key_index/signatures/tests.rs
+++ b/crates/superbank-rpc/src/disk_cache/key_index/signatures/tests.rs
@@ -168,9 +168,91 @@ async fn cancelled_or_failed_fills_reject_stale_builds_even_for_empty_results() 
     fill.finish_signatures(false);
     index.finish_signature_build(1, token);
     assert_eq!(candidates(&index, b"new").outcome(), "unknown");
+    drop(fill);
     let token = insert(&index, b"new").await;
     index.finish_signature_build(1, token);
     assert_eq!(candidates(&index, b"old").outcome(), "possible");
+}
+
+#[tokio::test]
+async fn failed_fill_keeps_concurrently_allocated_filter_unknown_through_publication() {
+    let index = index();
+    let mut coverage = crate::disk_cache::coverage::CoverageMap::new();
+    let mut failed = index.mutation(10, 14).signature_fill(false);
+
+    // Deterministically interleave an unrelated mutation with the allocation.
+    // Fill A's transactions exist, but its membership update has no entry.
+    assert!(
+        index
+            .ensure_signature_partition(1, || {
+                drop(index.mutation(20, 29));
+                !coverage.intersects(10, 19)
+            })
+            .await
+            .is_none()
+    );
+    failed.finish_signatures(false);
+
+    // Fill B allocates before A's awaited coverage publication completes.
+    let mut successful = index.mutation(15, 19).signature_fill(false);
+    let token = index
+        .ensure_signature_partition(1, || !coverage.intersects(10, 19))
+        .await
+        .unwrap();
+    index
+        .insert_signature_hashes(
+            &BTreeMap::from([(1, token)]),
+            &[(15, SignatureHash::new(b"fill-b"))],
+        )
+        .unwrap();
+    successful.finish_signatures(true);
+    coverage.insert_range(10, 19);
+    drop(successful);
+
+    assert!(coverage.contains(10));
+    assert_eq!(candidates(&index, b"fill-a").outcome(), "unknown");
+    assert_eq!(index.signature_completeness(1, 1), (0, 1));
+    // A rebuild finishing before the failed writer drops must not expose it.
+    assert!(index.finish_signature_build(1, token));
+    assert_eq!(candidates(&index, b"fill-a").outcome(), "unknown");
+    drop(failed);
+    assert_eq!(candidates(&index, b"fill-a").outcome(), "unknown");
+    assert!(!index.finish_signature_build(1, token));
+
+    // Only a scan including the now-covered A keys restores completeness.
+    let rebuilt = index
+        .ensure_signature_partition(1, || !coverage.intersects(10, 19))
+        .await
+        .unwrap();
+    index
+        .insert_signature_hashes(
+            &BTreeMap::from([(1, rebuilt)]),
+            &[(10, SignatureHash::new(b"fill-a"))],
+        )
+        .unwrap();
+    assert!(index.finish_signature_build(1, rebuilt));
+    assert_eq!(candidates(&index, b"fill-a").outcome(), "possible");
+    assert_eq!(candidates(&index, b"fill-b").outcome(), "possible");
+    assert_eq!(candidates(&index, b"absent").outcome(), "absent");
+    assert_eq!(index.signature_completeness(1, 1), (1, 0));
+}
+
+#[tokio::test]
+async fn successful_overlapping_fills_preserve_complete_membership() {
+    let index = index();
+    let mut first = index.mutation(15, 15).signature_fill(false);
+    let mut second = index.mutation(15, 15).signature_fill(false);
+    insert(&index, b"fill-a").await;
+    first.finish_signatures(true);
+    insert(&index, b"fill-b").await;
+    second.finish_signatures(true);
+    drop(first);
+    drop(second);
+
+    assert_eq!(candidates(&index, b"fill-a").outcome(), "possible");
+    assert_eq!(candidates(&index, b"fill-b").outcome(), "possible");
+    assert_eq!(candidates(&index, b"absent").outcome(), "absent");
+    assert_eq!(index.signature_completeness(1, 1), (1, 0));
 }
 
 #[tokio::test]

--- a/crates/superbank-rpc/src/disk_cache/key_index/signatures/tests.rs
+++ b/crates/superbank-rpc/src/disk_cache/key_index/signatures/tests.rs
@@ -224,3 +224,97 @@ async fn edges_holes_and_budget_exhaustion_remain_conservative() {
     assert!(index.ensure_signature_partition(1, || true).await.is_none());
     drop(guards);
 }
+
+#[tokio::test]
+async fn signature_retries_progress_while_address_build_is_stalled() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use tokio::sync::{Notify, broadcast};
+
+    let index = index();
+    insert(&index, b"old").await;
+    let entered = Arc::new(Notify::new());
+    let released = Arc::new(Notify::new());
+    let recovered = Arc::new(Notify::new());
+    let invalidated = Arc::new(AtomicBool::new(false));
+    let (shutdown, receiver) = broadcast::channel(1);
+    let worker = {
+        let (index, entered, released, recovered, invalidated) = (
+            index.clone(),
+            entered.clone(),
+            released.clone(),
+            recovered.clone(),
+            invalidated.clone(),
+        );
+        tokio::spawn(async move {
+            super::super::run_workers(
+                || async {
+                    if invalidated.load(Ordering::Relaxed) {
+                        let token = insert(&index, b"new").await;
+                        assert!(index.finish_signature_build(1, token));
+                        recovered.notify_one();
+                    }
+                },
+                || async {
+                    entered.notify_one();
+                    released.notified().await;
+                },
+                receiver,
+            )
+            .await;
+        })
+    };
+    entered.notified().await;
+    drop(index.mutation(15, 15).signature_fill(false));
+    assert_eq!(candidates(&index, b"absent").outcome(), "unknown");
+    invalidated.store(true, Ordering::Relaxed);
+    tokio::time::timeout(Duration::from_secs(8), recovered.notified())
+        .await
+        .expect("signature retry must not wait for the stalled address scan");
+    assert_eq!(candidates(&index, b"absent").outcome(), "absent");
+    assert_eq!(candidates(&index, b"new").outcome(), "possible");
+    // Leave the address future stalled: shutdown must cancel it, too.
+    shutdown.send(()).unwrap();
+    tokio::time::timeout(Duration::from_secs(1), worker)
+        .await
+        .unwrap()
+        .unwrap();
+}
+
+#[tokio::test]
+async fn failed_build_retries_without_publishing_partial_keys() {
+    let index = index();
+    let old = index.ensure_signature_partition(1, || false).await.unwrap();
+    index
+        .insert_signature_hashes(
+            &BTreeMap::from([(1, old)]),
+            &[(15, SignatureHash::new(b"first"))],
+        )
+        .unwrap();
+    assert_eq!(candidates(&index, b"missing").outcome(), "unknown");
+    // A failed scan leaves its partial bits conservative and reusable.
+    let retry = index.ensure_signature_partition(1, || false).await.unwrap();
+    index
+        .insert_signature_hashes(
+            &BTreeMap::from([(1, retry)]),
+            &[(16, SignatureHash::new(b"second"))],
+        )
+        .unwrap();
+    assert!(index.finish_signature_build(1, retry));
+    assert_eq!(candidates(&index, b"first").outcome(), "possible");
+    assert_eq!(candidates(&index, b"second").outcome(), "possible");
+    drop(index.mutation(15, 15).signature_fill(false));
+    assert!(!index.finish_signature_build(1, old));
+    assert!(!index.signature_generation_matches(1, old));
+}
+
+#[test]
+fn concurrent_builds_fit_the_existing_spare_partition_budget() {
+    let cfg = crate::disk_cache::key_tests::config(String::new(), String::new());
+    let index = KeyIndex::new(&cfg);
+    // Address builds are reserved by entries; one signature allocation can be
+    // outside the map. Both shares together fit the existing spare allowance.
+    let partitions = index.max_entries as u64;
+    let bitmaps = (partitions + 1) * (index.address_quota() + index.signature_quota()) as u64;
+    let metadata = (partitions + 1) * super::super::ENTRY_OVERHEAD;
+    assert!(bitmaps + metadata + super::super::RESERVE <= cfg.key_index_max_memory_bytes);
+}

--- a/crates/superbank-rpc/src/disk_cache/key_index/signatures/tests.rs
+++ b/crates/superbank-rpc/src/disk_cache/key_index/signatures/tests.rs
@@ -278,6 +278,57 @@ async fn reset_rejects_allocations_and_builds_from_the_old_generation() {
 }
 
 #[tokio::test]
+async fn writer_overflow_rejects_inflight_signature_allocation_until_recovery() {
+    let index = index();
+    let writers: Vec<_> = (100..228).map(|slot| index.mutation(slot, slot)).collect();
+    let mut untracked = None;
+    let allocation = index
+        .ensure_signature_partition(1, || {
+            // The 129th writer resets the index while a bitmap is outside the map.
+            untracked = Some(index.mutation(10, 19).signature_fill(false));
+            true
+        })
+        .await;
+    assert!(allocation.is_none());
+
+    // A failed untracked fill may still publish coverage, but never a negative filter.
+    untracked.as_mut().unwrap().finish_signatures(false);
+    assert_eq!(candidates(&index, b"fill").outcome(), "unknown");
+    assert!(index.ensure_signature_partition(1, || true).await.is_none());
+    drop(untracked);
+    drop(writers);
+
+    let token = index.ensure_signature_partition(1, || false).await.unwrap();
+    assert_eq!(candidates(&index, b"fill").outcome(), "unknown");
+    index
+        .insert_signature_hashes(
+            &BTreeMap::from([(1, token)]),
+            &[(10, SignatureHash::new(b"fill"))],
+        )
+        .unwrap();
+    assert!(index.finish_signature_build(1, token));
+    assert_eq!(candidates(&index, b"fill").outcome(), "possible");
+    assert_eq!(candidates(&index, b"absent").outcome(), "absent");
+}
+
+#[tokio::test]
+async fn writer_overflow_rejects_allocation_even_after_untracked_writer_finishes() {
+    let index = index();
+    let _writers: Vec<_> = (100..228).map(|slot| index.mutation(slot, slot)).collect();
+    assert!(
+        index
+            .ensure_signature_partition(1, || {
+                // The writer can finish before the allocator reacquires the state lock.
+                drop(index.mutation(10, 19).signature_fill(false));
+                true
+            })
+            .await
+            .is_none()
+    );
+    assert_eq!(candidates(&index, b"fill").outcome(), "unknown");
+}
+
+#[tokio::test]
 async fn edges_holes_and_budget_exhaustion_remain_conservative() {
     let index = index();
     for partition in 1..=4 {

--- a/crates/superbank-rpc/src/disk_cache/key_reads.rs
+++ b/crates/superbank-rpc/src/disk_cache/key_reads.rs
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //! Ordered, partition-scoped reads under one cache-attempt deadline.
 use super::{
-    DiskCache, DiskGsfaPage, DiskSigStatus, clamp_until_to_floor, index::DiskTfaQuery,
-    key_index::Family, lower_bound_reaches_floor, upper_bound_reaches_tip,
+    DiskCache, DiskGsfaPage, DiskSigStatus, clamp_until_to_floor,
+    index::DiskTfaQuery,
+    key_index::{Family, SignatureCandidates, SignatureHash},
+    lower_bound_reaches_floor, upper_bound_reaches_tip,
 };
 use crate::clickhouse::{
     ClickHouseClient, NumericFilter, PaginationToken, SignatureRecord, SignatureSlot, SlotBoundary,
@@ -129,7 +131,7 @@ impl DiskCache {
         client.query_timeout = read.deadline.saturating_duration_since(Instant::now());
         client
     }
-    fn key_span(&self) -> Option<(u64, u64)> {
+    pub(super) fn key_span(&self) -> Option<(u64, u64)> {
         self.inner
             .coverage
             .read()
@@ -156,6 +158,28 @@ impl DiskCache {
             if candidate { "probed" } else { "skipped" },
         );
         candidate
+    }
+    fn signature_candidates(
+        &self,
+        floor: u64,
+        tip: u64,
+        signature: &Signature,
+    ) -> SignatureCandidates {
+        let started = std::time::Instant::now();
+        let width = self.inner.cfg.partition_slots;
+        let candidates = self.inner.key_index.signature_candidates(
+            floor / width,
+            tip / width,
+            SignatureHash::new(signature.as_ref()),
+        );
+        let elapsed = started.elapsed().as_secs_f64();
+        crate::metrics::disk_cache_signature_membership(candidates.outcome(), elapsed);
+        crate::metrics::disk_cache_read_count(
+            "key_partition",
+            "skipped",
+            candidates.total - candidates.partitions.len() as u64,
+        );
+        candidates
     }
     async fn attempt<T>(
         &self,
@@ -189,14 +213,17 @@ impl DiskCache {
         let Some((floor, tip)) = self.key_span() else {
             return Ok(None);
         };
+        let candidates = self.signature_candidates(floor, tip, &signature);
+        if candidates.partitions.is_empty() {
+            return Ok(None);
+        }
         let base = self.query_client();
-        for partition in self.partitions(floor, tip, SortOrder::Desc) {
+        let signature = signature.to_string();
+        for partition in candidates.partitions {
             read.check()?;
-            if !self.candidate(partition, &[Family::Signature], signature.as_ref()) {
-                continue;
-            }
+            crate::metrics::disk_cache_read("key_partition", "probed");
             let client = self.scoped_client(&base, partition, read);
-            if let (Some(position), _) = client.get_signature_slot(&signature.to_string()).await? {
+            if let (Some(position), _) = client.get_signature_slot(&signature).await? {
                 return Ok(self.covers_slot(position.slot).then_some(position));
             }
         }
@@ -237,9 +264,11 @@ impl DiskCache {
             return vec![None; signatures.len()];
         };
         let mut found = HashMap::new();
+        let mut encoded = HashMap::new();
         let result = self
             .attempt("signature_statuses", &read, async {
-                self.find_statuses(&signatures, &read, &mut found).await?;
+                self.find_statuses(&signatures, &read, &mut found, &mut encoded)
+                    .await?;
                 Ok(found.values().any(Option::is_some).then_some(()))
             })
             .await;
@@ -249,31 +278,62 @@ impl DiskCache {
         }
         signatures
             .iter()
-            .map(|signature| found.get(&signature.to_string()).cloned().flatten())
+            .map(|signature| {
+                encoded
+                    .get(signature)
+                    .and_then(|key| found.get(key))
+                    .cloned()
+                    .flatten()
+            })
             .collect()
     }
+    fn status_candidates(
+        &self,
+        floor: u64,
+        tip: u64,
+        signatures: &[Signature],
+        encoded: &mut HashMap<Signature, String>,
+    ) -> std::collections::BTreeMap<u64, Vec<String>> {
+        let mut by_partition = std::collections::BTreeMap::<u64, Vec<String>>::new();
+        for signature in signatures {
+            let candidates = self.signature_candidates(floor, tip, signature);
+            if candidates.partitions.is_empty() {
+                continue;
+            }
+            let key = encoded
+                .entry(*signature)
+                .or_insert_with(|| signature.to_string());
+            for partition in candidates.partitions {
+                by_partition.entry(partition).or_default().push(key.clone());
+            }
+        }
+        by_partition
+    }
+
     async fn find_statuses(
         &self,
         signatures: &[Signature],
         read: &Read,
         found: &mut HashMap<String, Option<DiskSigStatus>>,
+        encoded: &mut HashMap<Signature, String>,
     ) -> ProcessingResult<()> {
         let Some((floor, tip)) = self.key_span() else {
             return Ok(());
         };
-        let base = self.query_client();
-        for partition in self.partitions(floor, tip, SortOrder::Desc) {
+        let by_partition = self.status_candidates(floor, tip, signatures, encoded);
+        let mut base = None;
+        for (partition, mut pending) in by_partition.into_iter().rev() {
             read.check()?;
-            let pending: Vec<_> = signatures
-                .iter()
-                .filter(|s| !found.contains_key(&s.to_string()))
-                .filter(|s| self.candidate(partition, &[Family::Signature], s.as_ref()))
-                .map(ToString::to_string)
-                .collect();
+            pending.retain(|signature| !found.contains_key(signature));
             if pending.is_empty() {
                 continue;
             }
-            let client = self.scoped_client(&base, partition, read);
+            crate::metrics::disk_cache_read_count("key_partition", "probed", pending.len() as u64);
+            let client = self.scoped_client(
+                base.get_or_insert_with(|| self.query_client()),
+                partition,
+                read,
+            );
             let (records, _) = client.get_signature_statuses(&pending).await?;
             for record in records {
                 found.insert(

--- a/crates/superbank-rpc/src/disk_cache/key_tests.rs
+++ b/crates/superbank-rpc/src/disk_cache/key_tests.rs
@@ -5,10 +5,37 @@ use crate::clickhouse::{NumericFilter, SortOrder, TransactionStatusFilter};
 use crate::solana_sdk::{pubkey::Pubkey, signature::Signature};
 
 fn signature(slot: u64) -> Signature {
+    named_signature("sig", slot)
+}
+fn named_signature(prefix: &str, slot: u64) -> Signature {
     let mut key = [0; 64];
-    let value = format!("sig-{slot}");
+    let value = format!("{prefix}-{slot}");
     key[..value.len()].copy_from_slice(value.as_bytes());
     Signature::from(key)
+}
+fn signature_candidate(cache: &DiskCache, partition: u64, signature: Signature) -> bool {
+    !cache
+        .inner
+        .key_index
+        .signature_candidates(
+            partition,
+            partition,
+            key_index::SignatureHash::new(signature.as_ref()),
+        )
+        .partitions
+        .is_empty()
+}
+
+async fn assert_absent_without_admission(cache: &DiskCache) {
+    let client = cache.query_client();
+    let _permits = client.http_query_sem.acquire_many(2).await.unwrap();
+    tokio::time::timeout(Duration::from_millis(50), async {
+        assert!(cache.get_tx(signature(500)).await.is_none());
+        assert!(cache.signature_position(signature(500)).await.is_none());
+        assert!(cache.get_sig_statuses(vec![signature(500)]).await[0].is_none());
+    })
+    .await
+    .expect("complete negative must not wait for admission");
 }
 fn address(value: &str) -> Pubkey {
     let mut key = [0; 32];
@@ -97,7 +124,7 @@ async fn fixture(client: &clickhouse::Client, database: &str) {
     execute(client, &format!("INSERT INTO {database}.blocks_metadata (slot,parent_slot,blockhash,parent_blockhash,block_time,block_height,executed_transaction_count) SELECT number,number-1,toFixedString('hash',32),toFixedString('hash',32),1700000000+number,number,1 FROM numbers(10,40)")).await;
 }
 async fn insert_transactions(client: &clickhouse::Client, database: &str) {
-    execute(client, &format!("INSERT INTO {database}.transactions (signature, slot, slot_idx, tx_signatures, tx_account_keys, tx_num_required_signatures, meta_status_ok, meta_post_token_balances_present, meta_post_token_account_index, meta_post_token_mint, meta_post_token_owner, meta_post_token_program_id, meta_post_token_amount, meta_post_token_decimals, meta_post_token_ui_amount, meta_post_token_ui_amount_string) SELECT toFixedString(concat('sig-', toString(number)),64), number, 0, [toFixedString(concat('sig-', toString(number)),64)], [toFixedString('address',32)], 1, 1, 1, [0], [toFixedString('mint',32)], [toFixedString('owner',32)], [toFixedString('program',32)], ['1'], [0], [1.0], ['1'] FROM numbers(10,40)")).await;
+    execute(client, &format!("INSERT INTO {database}.transactions (signature, slot, slot_idx, tx_signatures, tx_account_keys, tx_num_required_signatures, meta_status_ok, meta_post_token_balances_present, meta_post_token_account_index, meta_post_token_mint, meta_post_token_owner, meta_post_token_program_id, meta_post_token_amount, meta_post_token_decimals, meta_post_token_ui_amount, meta_post_token_ui_amount_string) SELECT toFixedString(concat('sig-', toString(number)),64), number, 0, [toFixedString(concat('sig-', toString(number)),64),toFixedString(concat('secondary-', toString(number)),64)], [toFixedString('address',32),toFixedString('signer',32)], 2, 1, 1, [0], [toFixedString('mint',32)], [toFixedString('owner',32)], [toFixedString('program',32)], ['1'], [0], [1.0], ['1'] FROM numbers(10,40)")).await;
 }
 fn tfa(order: SortOrder, tokens: TokenAccountsFilter) -> index::DiskTfaQuery {
     index::DiskTfaQuery {
@@ -192,6 +219,44 @@ async fn assert_cancellation(client: &clickhouse::Client, cache: &DiskCache) {
     wait_for_query(client, &id, false).await;
 }
 
+async fn assert_signature_fill_updates(cache: &DiskCache, source: &ClickHouseClient) {
+    // First fill, append within the same partition, then repair covered slots.
+    for (start, end) in [(10, 14), (15, 19), (15, 19)] {
+        filler::fill_range(
+            cache,
+            source,
+            filler::SlotRange { start, end },
+            &filler::FillerConfig::default(),
+        )
+        .await
+        .unwrap();
+        assert!(signature_candidate(cache, 1, signature(10)));
+        assert!(signature_candidate(
+            cache,
+            1,
+            named_signature("secondary", end)
+        ));
+        assert_eq!(
+            cache
+                .signature_position(named_signature("secondary", end))
+                .await
+                .unwrap()
+                .slot,
+            end
+        );
+        assert_eq!(
+            cache
+                .get_sig_statuses(vec![named_signature("secondary", end)])
+                .await[0]
+                .as_ref()
+                .unwrap()
+                .slot,
+            end
+        );
+        assert_absent_without_admission(cache).await;
+    }
+}
+
 async fn assert_migration(
     client: &clickhouse::Client,
     source: &ClickHouseClient,
@@ -221,14 +286,7 @@ async fn assert_migration(
         .unwrap();
     assert_eq!(count, 0);
     assert!(reopened.tip_span().is_none());
-    filler::fill_range(
-        &reopened,
-        source,
-        filler::SlotRange { start: 10, end: 19 },
-        &filler::FillerConfig::default(),
-    )
-    .await
-    .unwrap();
+    assert_signature_fill_updates(&reopened, source).await;
     assert!(reopened.covers_slot(15));
     assert_eq!(reopened.get_tx(signature(15)).await.unwrap().slot, 15);
     let restarted = DiskCache::open(cfg.clone(), source).await.unwrap();
@@ -371,16 +429,9 @@ async fn key_routing_clickhouse_integration() {
         .await
         .unwrap();
     cache.build_key_indexes().await;
-    assert!(!cache.inner.key_index.may_contain(
-        1,
-        &[key_index::Family::Signature],
-        signature(35).as_ref()
-    ));
-    assert!(cache.inner.key_index.may_contain(
-        1,
-        &[key_index::Family::Signature],
-        signature(15).as_ref()
-    ));
+    assert_absent_without_admission(&cache).await;
+    assert!(!signature_candidate(&cache, 1, signature(35)));
+    assert!(signature_candidate(&cache, 1, signature(15)));
     assert_eq!(
         cache.signature_position(signature(15)).await.unwrap().slot,
         15
@@ -447,16 +498,21 @@ async fn key_routing_clickhouse_integration() {
     );
     assert_pagination(&cache).await;
     assert_pruning(&client, &cache_database).await;
-    assert_migration(&client, &source, &cfg).await;
+    // Poll migration separately so nested debug lookup futures do not consume
+    // the fixture task's stack as well as their own.
+    let migration_client = client.clone();
+    let migration_source = source.clone();
+    let migration_cfg = cfg.clone();
+    tokio::spawn(async move {
+        assert_migration(&migration_client, &migration_source, &migration_cfg).await;
+    })
+    .await
+    .unwrap();
     assert_cancellation(&client, &cache).await;
     assert_cross_partition_duplicates(&client, &cache).await;
     cache.poison_slot(15).await;
     assert!(cache.get_tx(signature(15)).await.is_none());
-    assert!(cache.inner.key_index.may_contain(
-        1,
-        &[key_index::Family::Signature],
-        signature(500).as_ref()
-    ));
+    assert!(!signature_candidate(&cache, 1, signature(500)));
     let mut reopened_cfg = cfg;
     reopened_cfg.query_timeout = Duration::from_millis(50);
     let reopened = DiskCache::open(reopened_cfg, &source).await.unwrap();

--- a/crates/superbank-rpc/src/disk_cache/key_tests.rs
+++ b/crates/superbank-rpc/src/disk_cache/key_tests.rs
@@ -37,6 +37,29 @@ async fn assert_absent_without_admission(cache: &DiskCache) {
     .await
     .expect("complete negative must not wait for admission");
 }
+async fn assert_address_priority_recovery(cache: &DiskCache) {
+    let mut repair = cache.begin_fill(25, 25);
+    assert!(!cache.signature_indexes_ready());
+    cache.build_key_indexes().await;
+    assert!(
+        cache
+            .inner
+            .key_index
+            .may_contain(2, &[key_index::Family::Address], b"absent")
+    );
+    cache.update_signature_membership(&mut repair, 25, 25).await;
+    drop(repair);
+    assert!(cache.signature_indexes_ready());
+    cache.build_key_indexes().await;
+    assert!(
+        !cache
+            .inner
+            .key_index
+            .may_contain(2, &[key_index::Family::Address], b"absent")
+    );
+    assert_absent_without_admission(cache).await;
+}
+
 fn address(value: &str) -> Pubkey {
     let mut key = [0; 32];
     key[..value.len()].copy_from_slice(value.as_bytes());
@@ -429,6 +452,23 @@ async fn key_routing_clickhouse_integration() {
         .await
         .unwrap();
     cache.build_key_indexes().await;
+    assert!(
+        cache
+            .inner
+            .key_index
+            .may_contain(2, &[key_index::Family::Address], b"absent")
+    );
+    assert!(!cache.signature_indexes_ready());
+    cache.build_signature_indexes().await;
+    assert!(cache.signature_indexes_ready());
+    cache.build_key_indexes().await;
+    assert!(
+        !cache
+            .inner
+            .key_index
+            .may_contain(2, &[key_index::Family::Address], b"absent")
+    );
+    assert_address_priority_recovery(&cache).await;
     assert_absent_without_admission(&cache).await;
     assert!(!signature_candidate(&cache, 1, signature(35)));
     assert!(signature_candidate(&cache, 1, signature(15)));

--- a/crates/superbank-rpc/src/disk_cache/mod.rs
+++ b/crates/superbank-rpc/src/disk_cache/mod.rs
@@ -455,6 +455,7 @@ impl DiskCache {
         self.set_ready(false);
         self.inner.key_index.invalidate_reads();
         let _mutation = self.inner.key_index.mutation(0, u64::MAX);
+        self.inner.key_index.clear_signatures();
         let result = async {
             schema::initialize_cache_schema(&self.inner.admin, &snapshot, &schema_config).await?;
             let mut query_client = self.inner.local.clone();
@@ -796,16 +797,19 @@ impl DiskCache {
     }
 
     fn begin_fill(&self, start: u64, end: u64) -> key_index::Mutation {
-        if self
+        let repair = self
             .inner
             .coverage
             .read()
             .expect("coverage lock")
-            .intersects(start, end)
-        {
+            .intersects(start, end);
+        if repair {
             self.inner.key_index.invalidate_reads();
         }
-        self.inner.key_index.mutation(start, end)
+        self.inner
+            .key_index
+            .mutation(start, end)
+            .signature_fill(repair)
     }
 
     pub(crate) async fn publish_range_coverage(
@@ -854,6 +858,7 @@ impl DiskCache {
             drop(coverage);
             self.inner.min_retained.store(floor, Ordering::Relaxed);
             self.publish_coverage_metrics();
+            self.publish_signature_index_metrics();
         }
         Ok(())
     }
@@ -966,6 +971,7 @@ impl DiskCache {
         self.inner.key_index.invalidate_reads();
         let _mutation = self.inner.key_index.mutation(0, new_floor - 1);
         self.drop_partitions_below(new_floor).await?;
+        self.inner.key_index.evict_signatures(new_floor);
         self.inner.min_retained.store(new_floor, Ordering::Relaxed);
         self.inner
             .coverage

--- a/crates/superbank-rpc/src/disk_cache/schema.rs
+++ b/crates/superbank-rpc/src/disk_cache/schema.rs
@@ -151,6 +151,32 @@ pub(crate) struct SourceSchemaSnapshot {
 }
 
 impl SourceSchemaSnapshot {
+    /// Project the same signature keys as the forwarding view, with the input
+    /// restricted before ARRAY JOIN or other view expressions are evaluated.
+    pub(crate) fn signature_keys_query(
+        &self,
+        database: &str,
+        width: u64,
+        start: u64,
+        end: u64,
+    ) -> Result<String, SchemaError> {
+        let signatures = self
+            .table(CacheTableKind::Signatures)
+            .and_then(|table| table.view_select.as_deref())
+            .ok_or_else(|| SchemaError::Invalid("signatures view unavailable".into()))?;
+        let transactions = self
+            .table(CacheTableKind::Transactions)
+            .ok_or_else(|| SchemaError::Invalid("transactions schema unavailable".into()))?;
+        let local = quote_table(database, "transactions");
+        let bounded = format!(
+            "(SELECT * FROM {local} WHERE intDiv(slot, {width}) BETWEEN {} AND {} AND slot BETWEEN {start} AND {end})",
+            start / width,
+            end / width
+        );
+        let select = replace_table_reference(signatures, &transactions.storage_name, &bounded)?;
+        Ok(format!("SELECT slot, signature AS key FROM ({select})"))
+    }
+
     pub(crate) fn table(&self, kind: CacheTableKind) -> Option<&SourceTableSchema> {
         self.tables.iter().find(|table| table.kind == kind)
     }

--- a/crates/superbank-rpc/src/handlers/signatures.rs
+++ b/crates/superbank-rpc/src/handlers/signatures.rs
@@ -109,6 +109,8 @@ pub(crate) async fn handle_get_signature_statuses(
         ));
     }
 
+    metrics::signature_status_batch_size("input", signatures.len());
+
     let search_transaction_history = match params.get(1).filter(|value| !value.is_null()) {
         Some(config_value) => {
             match serde_json::from_value::<GetSignatureStatusesConfig>(config_value.clone()) {
@@ -259,6 +261,7 @@ pub(crate) async fn handle_get_signature_statuses(
                 .cloned()
                 .collect();
 
+            metrics::signature_status_batch_size("primary_fallback", to_query.len());
             if to_query.is_empty() {
                 HashMap::new()
             } else {

--- a/crates/superbank-rpc/src/metrics.rs
+++ b/crates/superbank-rpc/src/metrics.rs
@@ -570,6 +570,12 @@ pub struct Metrics {
     #[cfg(feature = "disk-cache")]
     disk_cache_key_seconds: Family<DiskCacheReadLabels, Histogram>,
     #[cfg(feature = "disk-cache")]
+    disk_cache_signature_membership_seconds: Family<DiskCacheReadLabels, Histogram>,
+    #[cfg(feature = "disk-cache")]
+    disk_cache_signature_index_partitions: Gauge,
+    #[cfg(feature = "disk-cache")]
+    disk_cache_signature_index_unknown_partitions: Gauge,
+    #[cfg(feature = "disk-cache")]
     disk_cache_key_index_bytes: Gauge,
     #[cfg(feature = "disk-cache")]
     disk_cache_key_index_partitions: Gauge,
@@ -697,6 +703,13 @@ impl Metrics {
         #[cfg(feature = "disk-cache")]
         let disk_cache_key_seconds =
             Family::new_with_constructor(latency_histogram as fn() -> Histogram);
+        #[cfg(feature = "disk-cache")]
+        let disk_cache_signature_membership_seconds =
+            Family::new_with_constructor(signature_membership_histogram as fn() -> Histogram);
+        #[cfg(feature = "disk-cache")]
+        let disk_cache_signature_index_partitions = Gauge::default();
+        #[cfg(feature = "disk-cache")]
+        let disk_cache_signature_index_unknown_partitions = Gauge::default();
         #[cfg(feature = "disk-cache")]
         let disk_cache_key_index_bytes = Gauge::default();
         #[cfg(feature = "disk-cache")]
@@ -1012,6 +1025,21 @@ impl Metrics {
         #[cfg(feature = "disk-cache")]
         {
             registry.register(
+                "disk_cache_signature_membership_seconds",
+                "In-memory signature membership latency and outcomes",
+                disk_cache_signature_membership_seconds.clone(),
+            );
+            registry.register(
+                "disk_cache_signature_index_partitions",
+                "Complete signature membership partitions",
+                disk_cache_signature_index_partitions.clone(),
+            );
+            registry.register(
+                "disk_cache_signature_index_unknown_partitions",
+                "Unknown signature membership partitions",
+                disk_cache_signature_index_unknown_partitions.clone(),
+            );
+            registry.register(
                 "disk_cache_key_seconds",
                 "Partition routing index instrumentation",
                 disk_cache_key_seconds.clone(),
@@ -1182,6 +1210,12 @@ impl Metrics {
             superbank_grpc_stream_errors_total,
             #[cfg(feature = "disk-cache")]
             disk_cache_key_seconds,
+            #[cfg(feature = "disk-cache")]
+            disk_cache_signature_membership_seconds,
+            #[cfg(feature = "disk-cache")]
+            disk_cache_signature_index_partitions,
+            #[cfg(feature = "disk-cache")]
+            disk_cache_signature_index_unknown_partitions,
             #[cfg(feature = "disk-cache")]
             disk_cache_key_index_bytes,
             #[cfg(feature = "disk-cache")]
@@ -2001,6 +2035,11 @@ pub(crate) fn disk_cache_set_active(active: bool) {
 
 #[cfg(feature = "disk-cache")]
 pub(crate) fn disk_cache_read(operation: &'static str, outcome: &'static str) {
+    disk_cache_read_count(operation, outcome, 1);
+}
+
+#[cfg(feature = "disk-cache")]
+pub(crate) fn disk_cache_read_count(operation: &'static str, outcome: &'static str, count: u64) {
     if let Some(metrics) = metrics() {
         metrics
             .disk_cache_reads_total
@@ -2008,7 +2047,7 @@ pub(crate) fn disk_cache_read(operation: &'static str, outcome: &'static str) {
                 operation: operation.to_string(),
                 outcome: outcome.to_string(),
             })
-            .inc();
+            .inc_by(count);
     }
 }
 
@@ -2223,6 +2262,38 @@ pub(crate) fn disk_cache_key_index(bytes: u64, indexed: u64, unknown: u64) {
             .set(clamp_i64(indexed));
         metrics
             .disk_cache_key_index_unknown_partitions
+            .set(clamp_i64(unknown));
+    }
+}
+
+#[cfg(feature = "disk-cache")]
+fn signature_membership_histogram() -> Histogram {
+    Histogram::new([
+        0.000001, 0.000005, 0.000010, 0.000025, 0.000050, 0.000100, 0.000250, 0.001, 0.01,
+    ])
+}
+
+#[cfg(feature = "disk-cache")]
+pub(crate) fn disk_cache_signature_membership(outcome: &'static str, seconds: f64) {
+    if let Some(metrics) = metrics() {
+        metrics
+            .disk_cache_signature_membership_seconds
+            .get_or_create(&DiskCacheReadLabels {
+                operation: "signature_membership".into(),
+                outcome: outcome.into(),
+            })
+            .observe(seconds);
+    }
+}
+
+#[cfg(feature = "disk-cache")]
+pub(crate) fn disk_cache_signature_index(ready: u64, unknown: u64) {
+    if let Some(metrics) = metrics() {
+        metrics
+            .disk_cache_signature_index_partitions
+            .set(clamp_i64(ready));
+        metrics
+            .disk_cache_signature_index_unknown_partitions
             .set(clamp_i64(unknown));
     }
 }

--- a/crates/superbank-rpc/src/metrics.rs
+++ b/crates/superbank-rpc/src/metrics.rs
@@ -42,6 +42,43 @@ fn batch_size_histogram() -> Histogram {
     Histogram::new(BATCH_SIZE_BUCKETS)
 }
 
+fn signature_status_batch_histogram() -> Histogram {
+    Histogram::new([0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0])
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct SignatureStatusStageLabels {
+    stage: &'static str,
+}
+
+/// Includes cancelled admission waits; no request identifiers become metric labels.
+pub(crate) struct SignatureStatusAdmission(Instant);
+
+impl SignatureStatusAdmission {
+    pub(crate) fn start() -> Self {
+        Self(Instant::now())
+    }
+}
+
+impl Drop for SignatureStatusAdmission {
+    fn drop(&mut self) {
+        if let Some(metrics) = metrics() {
+            metrics
+                .signature_status_admission_seconds
+                .observe(self.0.elapsed().as_secs_f64());
+        }
+    }
+}
+
+pub(crate) fn signature_status_batch_size(stage: &'static str, size: usize) {
+    if let Some(metrics) = metrics() {
+        metrics
+            .signature_status_batch_size
+            .get_or_create(&SignatureStatusStageLabels { stage })
+            .observe(size as f64);
+    }
+}
+
 const BLOCK_SLOT_COUNT_BUCKETS: [f64; 20] = [
     1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0, 1024.0, 2048.0, 4096.0, 8192.0,
     16384.0, 32768.0, 65536.0, 131072.0, 262144.0, 500000.0,
@@ -510,6 +547,8 @@ pub struct Metrics {
     rpc_batch_requests: Family<BatchLabels, Counter>,
     rpc_batch_items: Family<BatchLabels, Counter>,
     rpc_batch_size: Family<BatchLabels, Histogram>,
+    signature_status_batch_size: Family<SignatureStatusStageLabels, Histogram>,
+    signature_status_admission_seconds: Histogram,
     rpc_batch_rejected: Family<BatchRejectLabels, Counter>,
     rpc_response_overhead_seconds: Family<MethodLabels, Histogram>,
     rpc_blocks_slots_returned: Family<MethodLabels, Histogram>,
@@ -639,6 +678,9 @@ impl Metrics {
         let rpc_batch_items = Family::default();
         let rpc_batch_size =
             Family::new_with_constructor(batch_size_histogram as fn() -> Histogram);
+        let signature_status_batch_size =
+            Family::new_with_constructor(signature_status_batch_histogram as fn() -> Histogram);
+        let signature_status_admission_seconds = latency_histogram();
         let rpc_batch_rejected = Family::default();
         let rpc_response_overhead_seconds =
             Family::new_with_constructor(latency_histogram as fn() -> Histogram);
@@ -798,6 +840,16 @@ impl Metrics {
             "rpc_batch_size",
             "Batch size distribution for JSON-RPC envelopes",
             rpc_batch_size.clone(),
+        );
+        registry.register(
+            "rpc_signature_status_batch_size",
+            "getSignatureStatuses input and unresolved primary-fallback signature counts",
+            signature_status_batch_size.clone(),
+        );
+        registry.register(
+            "rpc_signature_status_admission_seconds",
+            "Primary signature-status source and HTTP admission wait, including cancelled waits",
+            signature_status_admission_seconds.clone(),
         );
         registry.register(
             "rpc_batch_rejected_total",
@@ -1157,6 +1209,8 @@ impl Metrics {
             rpc_batch_requests,
             rpc_batch_items,
             rpc_batch_size,
+            signature_status_batch_size,
+            signature_status_admission_seconds,
             rpc_batch_rejected,
             rpc_response_overhead_seconds,
             rpc_blocks_slots_returned,

--- a/crates/superbank-rpc/src/metrics.rs
+++ b/crates/superbank-rpc/src/metrics.rs
@@ -51,6 +51,32 @@ struct SignatureStatusStageLabels {
     stage: &'static str,
 }
 
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct DisconnectOutcomeLabels {
+    outcome: &'static str,
+}
+
+pub(crate) fn signature_status_disconnect_pending_inc() {
+    if let Some(metrics) = metrics() {
+        metrics.signature_status_disconnect_pending.inc();
+    }
+}
+
+pub(crate) fn signature_status_disconnect_pending_dec() {
+    if let Some(metrics) = metrics() {
+        metrics.signature_status_disconnect_pending.dec();
+    }
+}
+
+pub(crate) fn signature_status_disconnect_verification(outcome: &'static str) {
+    if let Some(metrics) = metrics() {
+        metrics
+            .signature_status_disconnect_verification
+            .get_or_create(&DisconnectOutcomeLabels { outcome })
+            .inc();
+    }
+}
+
 /// Includes cancelled admission waits; no request identifiers become metric labels.
 pub(crate) struct SignatureStatusAdmission(Instant);
 
@@ -549,6 +575,8 @@ pub struct Metrics {
     rpc_batch_size: Family<BatchLabels, Histogram>,
     signature_status_batch_size: Family<SignatureStatusStageLabels, Histogram>,
     signature_status_admission_seconds: Histogram,
+    signature_status_disconnect_pending: Gauge,
+    signature_status_disconnect_verification: Family<DisconnectOutcomeLabels, Counter>,
     rpc_batch_rejected: Family<BatchRejectLabels, Counter>,
     rpc_response_overhead_seconds: Family<MethodLabels, Histogram>,
     rpc_blocks_slots_returned: Family<MethodLabels, Histogram>,
@@ -681,6 +709,8 @@ impl Metrics {
         let signature_status_batch_size =
             Family::new_with_constructor(signature_status_batch_histogram as fn() -> Histogram);
         let signature_status_admission_seconds = latency_histogram();
+        let signature_status_disconnect_pending = Gauge::default();
+        let signature_status_disconnect_verification = Family::default();
         let rpc_batch_rejected = Family::default();
         let rpc_response_overhead_seconds =
             Family::new_with_constructor(latency_histogram as fn() -> Histogram);
@@ -840,6 +870,16 @@ impl Metrics {
             "rpc_batch_size",
             "Batch size distribution for JSON-RPC envelopes",
             rpc_batch_size.clone(),
+        );
+        registry.register(
+            "rpc_signature_status_disconnect_pending",
+            "Abandoned source reads retaining admission until replica absence is confirmed",
+            signature_status_disconnect_pending.clone(),
+        );
+        registry.register(
+            "rpc_signature_status_disconnect_verification",
+            "Abandoned source verification outcomes; unconfirmed is recorded once after five seconds",
+            signature_status_disconnect_verification.clone(),
         );
         registry.register(
             "rpc_signature_status_batch_size",
@@ -1211,6 +1251,8 @@ impl Metrics {
             rpc_batch_size,
             signature_status_batch_size,
             signature_status_admission_seconds,
+            signature_status_disconnect_pending,
+            signature_status_disconnect_verification,
             rpc_batch_rejected,
             rpc_response_overhead_seconds,
             rpc_blocks_slots_returned,

--- a/crates/superbank-rpc/src/server.rs
+++ b/crates/superbank-rpc/src/server.rs
@@ -95,9 +95,6 @@ fn ignored_distributed_shard_settings(args: &RpcConfig) -> Vec<&'static str> {
     }
 
     let mut ignored = Vec::new();
-    if args.clickhouse_cluster.trim() != "{cluster}" {
-        ignored.push("CLICKHOUSE_CLUSTER");
-    }
     if has_nonempty_setting(args.clickhouse_topology_config.as_deref()) {
         ignored.push("CLICKHOUSE_TOPOLOGY_CONFIG");
     }
@@ -196,6 +193,27 @@ fn epoch_schedule_from_config(args: &RpcConfig) -> RpcResult<EpochSchedule> {
     Ok(schedule)
 }
 
+fn validate_query_resource_limits(args: &RpcConfig) -> RpcResult<()> {
+    if args.get_signature_statuses_max_concurrency == 0
+        || args.get_signature_statuses_max_threads == 0
+    {
+        return Err(RpcError::Config(
+            "GET_SIGNATURE_STATUSES_MAX_CONCURRENCY and GET_SIGNATURE_STATUSES_MAX_THREADS must be positive".to_string(),
+        ));
+    }
+    if args.get_inflation_reward_max_threads == 0
+        || args.get_inflation_reward_max_memory_bytes == 0
+        || args.get_inflation_reward_max_bytes_to_read == 0
+        || args.get_inflation_reward_query_timeout_ms == 0
+    {
+        return Err(RpcError::Config(
+            "getInflationReward ClickHouse resource limits must all be greater than zero"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
 pub async fn run_server(args: RpcConfig) -> RpcResult<()> {
     info!("Starting Solana RPC server on {}:{}", args.host, args.port);
     let rpc_parameter_filters =
@@ -231,16 +249,8 @@ pub async fn run_server(args: RpcConfig) -> RpcResult<()> {
                 .to_string(),
         ));
     }
-    if args.get_inflation_reward_max_threads == 0
-        || args.get_inflation_reward_max_memory_bytes == 0
-        || args.get_inflation_reward_max_bytes_to_read == 0
-        || args.get_inflation_reward_query_timeout_ms == 0
-    {
-        return Err(RpcError::Config(
-            "getInflationReward ClickHouse resource limits must all be greater than zero"
-                .to_string(),
-        ));
-    }
+    validate_query_resource_limits(&args)?;
+
     if args.get_inflation_reward_max_addresses == 0 {
         warn!("getInflationReward address admission limit is disabled");
     }
@@ -278,6 +288,11 @@ pub async fn run_server(args: RpcConfig) -> RpcResult<()> {
             args.clickhouse_hot_addresses.clone(),
             args.clickhouse_gsfa_hot_table.clone(),
             args.clickhouse_gsfa_hot_local_table.clone(),
+        )
+        .with_query_cleanup_cluster(args.clickhouse_cluster.clone())
+        .with_signature_status_limits(
+            args.get_signature_statuses_max_concurrency,
+            args.get_signature_statuses_max_threads,
         )
         .with_query_timeout(Duration::from_millis(args.clickhouse_query_timeout_ms))
         .with_tcp_access_check_timeout(Duration::from_millis(
@@ -1032,6 +1047,22 @@ mod tests {
     }
 
     #[test]
+    fn signature_status_limits_require_positive_values() {
+        use clap::Parser;
+
+        let _env_lock = crate::config::ENV_TEST_LOCK.lock().expect("env lock");
+        let mut cfg = RpcConfig::parse_from(["superbank-rpc"]);
+        assert!(super::validate_query_resource_limits(&cfg).is_ok());
+        cfg.get_signature_statuses_max_concurrency = 0;
+        assert!(super::validate_query_resource_limits(&cfg).is_err());
+        cfg.get_signature_statuses_max_concurrency = 1;
+        cfg.get_signature_statuses_max_threads = 0;
+        assert!(super::validate_query_resource_limits(&cfg).is_err());
+        cfg.get_signature_statuses_max_threads = 1;
+        assert!(super::validate_query_resource_limits(&cfg).is_ok());
+    }
+
+    #[test]
     fn distributed_scope_reports_explicit_shard_settings_as_ignored() {
         use clap::Parser;
 
@@ -1057,7 +1088,6 @@ mod tests {
         assert_eq!(
             ignored_distributed_shard_settings(&cfg),
             vec![
-                "CLICKHOUSE_CLUSTER",
                 "CLICKHOUSE_TOPOLOGY_CONFIG",
                 "CLICKHOUSE_GSFA_LOCAL_TABLE",
                 "CLICKHOUSE_SIGNATURES_LOCAL_TABLE",

--- a/scripts/dev/run-local-rpc.sh
+++ b/scripts/dev/run-local-rpc.sh
@@ -78,7 +78,10 @@ fi
 : "${CLICKHOUSE_USER:=default}"
 : "${CLICKHOUSE_PASSWORD:=}"
 : "${CLICKHOUSE_QUERY_TIMEOUT_MS:=8000}"
-: "${CLICKHOUSE_CLUSTER:={cluster}}"
+# Preserve an explicitly empty cluster for standalone cancellation.
+if [[ -z "${CLICKHOUSE_CLUSTER+x}" ]]; then
+  CLICKHOUSE_CLUSTER='{cluster}'
+fi
 : "${CLICKHOUSE_TOPOLOGY_CONFIG:=}"
 : "${CLICKHOUSE_TRANSPORT:=http}"
 : "${CLICKHOUSE_SCOPE:=distributed}"

--- a/scripts/test/report-signature-status-query-log.py
+++ b/scripts/test/report-signature-status-query-log.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Summarize a scoped ClickHouse JSONEachRow query_log export without making requests.
+
+Keep QueryStart and terminal rows from every coordinator and replica. Required fields:
+node, query_id, initial_query_id, is_initial_query, type, query_duration_ms, ProfileEvents.
+Cancellation verification additionally requires externally correlated cancellation records
+and query started_at_ms timestamps. This tool never infers a disconnect from a timeout.
+"""
+import argparse
+import json
+import math
+from collections import defaultdict
+from pathlib import Path
+
+
+TERMINAL = {"QueryFinish", "ExceptionBeforeStart", "ExceptionWhileProcessing"}
+
+
+def percentile(values, fraction):
+    return sorted(values)[max(0, math.ceil(len(values) * fraction) - 1)] if values else None
+
+
+def summarize(rows):
+    durations = [float(row["query_duration_ms"]) for row in rows]
+    cpu = sum(float(row["ProfileEvents"].get(name, 0)) for row in rows
+              for name in ("UserTimeMicroseconds", "SystemTimeMicroseconds")) / 1_000_000
+    return {"queries": len(rows), "cpu_seconds": cpu,
+            "duration_ms": {"p50": percentile(durations, .5),
+                            "p95": percentile(durations, .95),
+                            "p99": percentile(durations, .99),
+                            "max": max(durations, default=None)}}
+
+
+def read_rows(path):
+    rows = [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+    required = {"node", "query_id", "initial_query_id", "is_initial_query",
+                "type", "query_duration_ms", "ProfileEvents"}
+    for row in rows:
+        if not required <= row.keys():
+            raise ValueError(f"Missing required fields: {sorted(required - row.keys())}")
+        if row["type"] not in TERMINAL | {"QueryStart"}:
+            raise ValueError("Export query-log type as its string name")
+        if not math.isfinite(float(row["query_duration_ms"])) or float(row["query_duration_ms"]) < 0:
+            raise ValueError("query_duration_ms must be finite and nonnegative")
+        if row["is_initial_query"] not in (0, 1, "0", "1"):
+            raise ValueError("is_initial_query must be 0 or 1")
+        if not isinstance(row["ProfileEvents"], dict):
+            raise ValueError("ProfileEvents must be a JSON object")
+    return rows
+
+
+def audit(rows, limit_ms, require_leaves):
+    groups = defaultdict(list)
+    for row in rows:
+        groups[(row["node"], row["query_id"])].append(row)
+    terminal = []
+    incomplete = []
+    for key, events in groups.items():
+        ends = [row for row in events if row["type"] in TERMINAL]
+        if len(ends) != 1 or sum(row["type"] == "QueryStart" for row in events) != 1:
+            incomplete.append({"node": key[0], "query_id": key[1]})
+        terminal.extend(ends)
+    coordinators = [row for row in terminal if int(row["is_initial_query"]) == 1]
+    leaves = [row for row in terminal if int(row["is_initial_query"]) == 0]
+    slow = [{"node": row["node"], "query_id": row["query_id"],
+             "query_duration_ms": row["query_duration_ms"]}
+            for row in terminal if float(row["query_duration_ms"]) > limit_ms]
+    passed = bool(coordinators) and not incomplete and not slow and (bool(leaves) or not require_leaves)
+    return {"observed_query_lifetimes_pass": passed, "limit_ms": limit_ms,
+            "nodes_observed": sorted({row["node"] for row in rows}),
+            "coordinator": summarize(coordinators), "leaf": summarize(leaves),
+            "incomplete_or_duplicate_terminal": incomplete, "over_limit": slow,
+            "client_disconnect_cancellation_verified": False}
+
+
+def execution_deadline_failures(rows, deadline):
+    failures = []
+    for row in rows:
+        if row["type"] not in TERMINAL:
+            continue
+        started = float(row["started_at_ms"])
+        end = started + float(row["query_duration_ms"])
+        if not math.isfinite(end) or started < 0 or end > deadline:
+            failures.append({"node": row["node"], "query_id": row["query_id"],
+                             "reason": "Execution exceeded the observed cancellation deadline"})
+    return failures
+
+
+def cancellation_deadline(event, grace_ms):
+    root = event["initial_query_id"]
+    if not isinstance(root, str) or not root:
+        raise ValueError("Cancellation events require a nonempty initial_query_id")
+    cancelled_at = float(event["cancelled_at_ms"])
+    if not math.isfinite(cancelled_at) or cancelled_at < 0:
+        raise ValueError("cancelled_at_ms must be finite and nonnegative")
+    return root, cancelled_at + grace_ms
+
+
+def cancellation_check(rows, events, observed_until_ms, grace_ms, require_leaves):
+    failures = []
+    if not events:
+        return ["No externally correlated cancellation events were supplied"]
+    for event in events:
+        root, deadline = cancellation_deadline(event, grace_ms)
+        if observed_until_ms < deadline:
+            failures.append({"initial_query_id": root, "reason": "Incomplete observation interval"})
+        related = [row for row in rows if row["initial_query_id"] == root or row["query_id"] == root]
+        completeness = audit(related, float("inf"), require_leaves)
+        if not completeness["observed_query_lifetimes_pass"]:
+            failures.append({"initial_query_id": root, "reason": "Missing coordinator, leaf, or terminal evidence"})
+        failures.extend(execution_deadline_failures(related, deadline))
+    return failures
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("export", type=Path)
+    parser.add_argument("--max-query-ms", type=float, default=5000)
+    parser.add_argument("--require-leaves", action="store_true")
+    parser.add_argument("--cancellations", type=Path,
+                        help="JSONEachRow: initial_query_id and actual cancelled_at_ms")
+    parser.add_argument("--observed-until-ms", type=float, default=0,
+                        help="End of complete query-log collection, Unix milliseconds")
+    parser.add_argument("--cancellation-grace-ms", type=float, default=5000)
+    args = parser.parse_args()
+    if not math.isfinite(args.max_query_ms) or args.max_query_ms <= 0:
+        parser.error("--max-query-ms must be finite and positive")
+    if not math.isfinite(args.cancellation_grace_ms) or args.cancellation_grace_ms <= 0:
+        parser.error("--cancellation-grace-ms must be finite and positive")
+    if not math.isfinite(args.observed_until_ms):
+        parser.error("--observed-until-ms must be finite")
+    try:
+        rows = read_rows(args.export)
+        result = audit(rows, args.max_query_ms, args.require_leaves)
+        events = [json.loads(line) for line in args.cancellations.read_text().splitlines()
+                  if line.strip()] if args.cancellations else []
+        failures = cancellation_check(rows, events, args.observed_until_ms,
+                                      args.cancellation_grace_ms, args.require_leaves)
+        result["cancellation_failures"] = failures
+        result["client_disconnect_cancellation_verified"] = not failures
+    except (OSError, ValueError, TypeError, KeyError) as error:
+        parser.error(str(error))
+    print(json.dumps(result, indent=2))
+    raise SystemExit(not (result["observed_query_lifetimes_pass"]
+                          and result["client_disconnect_cancellation_verified"]))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test/report-signature-status-query-log.py
+++ b/scripts/test/report-signature-status-query-log.py
@@ -1,20 +1,34 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: AGPL-3.0-only
-"""Summarize a scoped ClickHouse JSONEachRow query_log export without making requests.
+"""Audit a scoped ClickHouse JSONEachRow query_log export without making requests.
 
-Keep QueryStart and terminal rows from every coordinator and replica. Required fields:
-node, query_id, initial_query_id, is_initial_query, type, query_duration_ms, ProfileEvents.
-Cancellation verification additionally requires externally correlated cancellation records
-and query started_at_ms timestamps. This tool never infers a disconnect from a timeout.
+Required fields: node, query_id, initial_query_id, is_initial_query, type,
+query_duration_ms, ProfileEvents. Verification additionally requires terminal
+event_at_ms (actual event_time_microseconds / 1000, not start + duration),
+exception_code, externally correlated cancellations, expected nodes, clock bounds,
+and an independently collected count manifest after query-log flush on every node.
+All timestamps are Unix milliseconds. Clock offsets are node time minus client time.
+A timely QueryFinish proves observed termination, never disconnect cancellation.
 """
 import argparse
 import json
 import math
-from collections import defaultdict
+from collections import Counter, defaultdict
 from pathlib import Path
 
 
 TERMINAL = {"QueryFinish", "ExceptionBeforeStart", "ExceptionWhileProcessing"}
+EVENT_TYPES = TERMINAL | {"QueryStart"}
+# ClickHouse v26.2.3.2-stable src/Common/ErrorCodes.cpp.
+CANCELLED = {394, 735}
+CANCELLED_BY_CLIENT = 735
+
+
+def finite_number(value, name, minimum=None):
+    number = float(value)
+    if not math.isfinite(number) or (minimum is not None and number < minimum):
+        raise ValueError(f"{name} must be finite and >= {minimum}")
+    return number
 
 
 def percentile(values, fraction):
@@ -26,39 +40,59 @@ def summarize(rows):
     cpu = sum(float(row["ProfileEvents"].get(name, 0)) for row in rows
               for name in ("UserTimeMicroseconds", "SystemTimeMicroseconds")) / 1_000_000
     return {"queries": len(rows), "cpu_seconds": cpu,
+            "terminal_types": dict(Counter(row["type"] for row in rows)),
             "duration_ms": {"p50": percentile(durations, .5),
                             "p95": percentile(durations, .95),
                             "p99": percentile(durations, .99),
                             "max": max(durations, default=None)}}
 
 
-def read_rows(path):
-    rows = [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+def read_jsonl(path):
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def validate_row(row):
     required = {"node", "query_id", "initial_query_id", "is_initial_query",
                 "type", "query_duration_ms", "ProfileEvents"}
+    if not required <= row.keys():
+        raise ValueError(f"Missing required fields: {sorted(required - row.keys())}")
+    if row["type"] not in EVENT_TYPES:
+        raise ValueError("Export query-log type as its string name")
+    finite_number(row["query_duration_ms"], "query_duration_ms", 0)
+    if row["is_initial_query"] not in (0, 1, "0", "1"):
+        raise ValueError("is_initial_query must be 0 or 1")
+    if not isinstance(row["ProfileEvents"], dict):
+        raise ValueError("ProfileEvents must be a JSON object")
+    for field in ("node", "query_id", "initial_query_id"):
+        if not isinstance(row[field], str) or not row[field]:
+            raise ValueError(f"{field} must be a nonempty string")
+
+
+def read_rows(path):
+    rows = read_jsonl(path)
     for row in rows:
-        if not required <= row.keys():
-            raise ValueError(f"Missing required fields: {sorted(required - row.keys())}")
-        if row["type"] not in TERMINAL | {"QueryStart"}:
-            raise ValueError("Export query-log type as its string name")
-        if not math.isfinite(float(row["query_duration_ms"])) or float(row["query_duration_ms"]) < 0:
-            raise ValueError("query_duration_ms must be finite and nonnegative")
-        if row["is_initial_query"] not in (0, 1, "0", "1"):
-            raise ValueError("is_initial_query must be 0 or 1")
-        if not isinstance(row["ProfileEvents"], dict):
-            raise ValueError("ProfileEvents must be a JSON object")
+        validate_row(row)
     return rows
+
+
+def complete_execution(events, ends):
+    if len(ends) != 1:
+        return False
+    expected_starts = int(ends[0]["type"] != "ExceptionBeforeStart")
+    if sum(row["type"] == "QueryStart" for row in events) != expected_starts:
+        return False
+    identities = {(row["initial_query_id"], int(row["is_initial_query"])) for row in events}
+    return len(identities) == 1
 
 
 def audit(rows, limit_ms, require_leaves):
     groups = defaultdict(list)
     for row in rows:
         groups[(row["node"], row["query_id"])].append(row)
-    terminal = []
-    incomplete = []
+    terminal, incomplete = [], []
     for key, events in groups.items():
         ends = [row for row in events if row["type"] in TERMINAL]
-        if len(ends) != 1 or sum(row["type"] == "QueryStart" for row in events) != 1:
+        if not complete_execution(events, ends):
             incomplete.append({"node": key[0], "query_id": key[1]})
         terminal.extend(ends)
     coordinators = [row for row in terminal if int(row["is_initial_query"]) == 1]
@@ -70,20 +104,70 @@ def audit(rows, limit_ms, require_leaves):
     return {"observed_query_lifetimes_pass": passed, "limit_ms": limit_ms,
             "nodes_observed": sorted({row["node"] for row in rows}),
             "coordinator": summarize(coordinators), "leaf": summarize(leaves),
-            "incomplete_or_duplicate_terminal": incomplete, "over_limit": slow,
-            "client_disconnect_cancellation_verified": False}
+            "incomplete_or_duplicate_terminal": incomplete, "over_limit": slow}
 
 
-def execution_deadline_failures(rows, deadline):
+def clock_bounds_for(node, clocks):
+    bounds = clocks[node]
+    lower = finite_number(bounds["min_offset_ms"], "min_offset_ms")
+    upper = finite_number(bounds["max_offset_ms"], "max_offset_ms")
+    if lower > upper:
+        raise ValueError("min_offset_ms must not exceed max_offset_ms")
+    return lower, upper
+
+
+def manifest_node_failures(node, rows, manifest, observed_until_ms):
+    record = manifest[node]
+    counts = record["counts"]
+    if set(counts) != EVENT_TYPES:
+        raise ValueError("Manifest counts must name all four query-log event types, including zeros")
+    if any(type(count) is not int or count < 0 for count in counts.values()):
+        raise ValueError("Manifest counts must be nonnegative integers")
+    actual = Counter(row["type"] for row in rows if row["node"] == node)
+    failures = []
+    if counts != {kind: actual[kind] for kind in EVENT_TYPES}:
+        failures.append(f"Query-log count mismatch for {node}")
+    collected_until = finite_number(record["observed_until_ms"], "manifest observed_until_ms", 0)
+    if collected_until < observed_until_ms:
+        failures.append(f"Incomplete query-log observation interval for {node}")
+    return failures
+
+
+def export_failures(rows, expected_nodes, clocks, manifest, observed_until_ms):
+    if not expected_nodes:
+        return ["Expected nodes were not supplied"]
+    expected = set(expected_nodes)
+    if not clocks or set(clocks) != expected:
+        return ["Clock bounds must cover exactly the expected nodes"]
+    if not manifest or set(manifest) != expected:
+        return ["An independent query-log count manifest must cover exactly the expected nodes"]
+    failures = []
+    if {row["node"] for row in rows} - expected:
+        failures.append("Export contains unexpected nodes")
+    for node in sorted(expected):
+        clock_bounds_for(node, clocks)
+        failures.extend(manifest_node_failures(node, rows, manifest, observed_until_ms))
+    return failures
+
+
+def terminal_interval(row, clocks):
+    ended = finite_number(row["event_at_ms"], "event_at_ms", 0)
+    lower_offset, upper_offset = clock_bounds_for(row["node"], clocks)
+    return ended - upper_offset, ended - lower_offset
+
+
+def execution_deadline_failures(rows, deadline, clocks):
     failures = []
     for row in rows:
         if row["type"] not in TERMINAL:
             continue
-        started = float(row["started_at_ms"])
-        end = started + float(row["query_duration_ms"])
-        if not math.isfinite(end) or started < 0 or end > deadline:
-            failures.append({"node": row["node"], "query_id": row["query_id"],
-                             "reason": "Execution exceeded the observed cancellation deadline"})
+        try:
+            _, latest_end = terminal_interval(row, clocks)
+            reason = "Execution exceeded the observed cancellation deadline" if latest_end > deadline else None
+        except KeyError:
+            reason = "Missing actual terminal event_at_ms or node clock bounds"
+        if reason:
+            failures.append({"node": row["node"], "query_id": row["query_id"], "reason": reason})
     return failures
 
 
@@ -91,29 +175,76 @@ def cancellation_deadline(event, grace_ms):
     root = event["initial_query_id"]
     if not isinstance(root, str) or not root:
         raise ValueError("Cancellation events require a nonempty initial_query_id")
-    cancelled_at = float(event["cancelled_at_ms"])
-    if not math.isfinite(cancelled_at) or cancelled_at < 0:
-        raise ValueError("cancelled_at_ms must be finite and nonnegative")
+    cancelled_at = finite_number(event["cancelled_at_ms"], "cancelled_at_ms", 0)
     return root, cancelled_at + grace_ms
 
 
-def cancellation_check(rows, events, observed_until_ms, grace_ms, require_leaves):
+def cancellation_evidence_failures(rows, cancelled_at, clocks):
     failures = []
-    if not events:
-        return ["No externally correlated cancellation events were supplied"]
-    for event in events:
-        root, deadline = cancellation_deadline(event, grace_ms)
-        if observed_until_ms < deadline:
-            failures.append({"initial_query_id": root, "reason": "Incomplete observation interval"})
-        related = [row for row in rows if row["initial_query_id"] == root or row["query_id"] == root]
-        completeness = audit(related, float("inf"), require_leaves)
-        if not completeness["observed_query_lifetimes_pass"]:
-            failures.append({"initial_query_id": root, "reason": "Missing coordinator, leaf, or terminal evidence"})
-        failures.extend(execution_deadline_failures(related, deadline))
+    for row in rows:
+        if row["type"] not in TERMINAL:
+            continue
+        initial = int(row["is_initial_query"]) == 1
+        # A leaf can finish before the coordinator is cancelled; that is termination,
+        # not cancellation evidence. Every initial execution must be cancelled.
+        if not initial and row["type"] == "QueryFinish":
+            continue
+        allowed = CANCELLED
+        if row.get("exception_code") not in allowed or row["type"] == "QueryFinish":
+            failures.append({"node": row["node"], "query_id": row["query_id"],
+                             "reason": "No client-disconnect cancellation evidence"})
+            continue
+        try:
+            earliest_end, _ = terminal_interval(row, clocks)
+            if earliest_end < cancelled_at:
+                failures.append({"node": row["node"], "query_id": row["query_id"],
+                                 "reason": "Cancellation timestamp precedes or overlaps client disconnect"})
+        except KeyError:
+            failures.append("Missing terminal timestamp or clock bounds for cancellation evidence")
+    if not any(row["type"] in TERMINAL and row.get("exception_code") == CANCELLED_BY_CLIENT
+               for row in rows):
+        failures.append("No QUERY_WAS_CANCELLED_BY_CLIENT event in the correlated query family")
     return failures
 
 
-def main():
+def correlated_check(rows, event, observed_until_ms, grace_ms, require_leaves, clocks):
+    root, deadline = cancellation_deadline(event, grace_ms)
+    failures = []
+    if observed_until_ms < deadline:
+        failures.append({"initial_query_id": root, "reason": "Incomplete observation interval"})
+    related = [row for row in rows if row["initial_query_id"] == root or row["query_id"] == root]
+    if not audit(related, float("inf"), require_leaves)["observed_query_lifetimes_pass"]:
+        failures.append({"initial_query_id": root, "reason": "Missing coordinator, leaf, or terminal evidence"})
+    failures.extend(execution_deadline_failures(related, deadline, clocks))
+    evidence = cancellation_evidence_failures(related, deadline - grace_ms, clocks)
+    return failures, evidence
+
+
+def cancellation_check(rows, events, observed_until_ms, grace_ms, require_leaves,
+                       expected_nodes=None, clocks=None, manifest=None):
+    clocks = clocks or {}
+    failures = export_failures(rows, expected_nodes, clocks, manifest, observed_until_ms)
+    evidence = []
+    if not events:
+        failures.append("No externally correlated cancellation events were supplied")
+    seen = set()
+    for event in events:
+        root, _ = cancellation_deadline(event, grace_ms)
+        if root in seen:
+            failures.append(f"Duplicate cancellation correlation for {root}")
+        seen.add(root)
+        timing, cancellation = correlated_check(rows, event, observed_until_ms, grace_ms, require_leaves, clocks)
+        failures.extend(timing)
+        evidence.extend(cancellation)
+    return {"termination_after_disconnect_verified": not failures,
+            "client_disconnect_cancellation_verified": not failures and not evidence,
+            "cancellation_failures": failures + evidence,
+            "termination_failures": failures,
+            "cancellation_attribution_note": "Requires a controlled test without competing cancellation sources; "
+            "code 735 can describe a replica native-stream close, not only the original HTTP client."}
+
+
+def argument_parser():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("export", type=Path)
     parser.add_argument("--max-query-ms", type=float, default=5000)
@@ -121,24 +252,36 @@ def main():
     parser.add_argument("--cancellations", type=Path,
                         help="JSONEachRow: initial_query_id and actual cancelled_at_ms")
     parser.add_argument("--observed-until-ms", type=float, default=0,
-                        help="End of complete query-log collection, Unix milliseconds")
+                        help="End of complete query-log collection in client-clock Unix milliseconds")
     parser.add_argument("--cancellation-grace-ms", type=float, default=5000)
+    parser.add_argument("--expected-nodes", nargs="+", help="Every possible coordinator/replica, including idle nodes")
+    parser.add_argument("--clock-bounds", type=Path,
+                        help='JSON object: {node: {min_offset_ms: number, max_offset_ms: number}}')
+    parser.add_argument("--count-manifest", type=Path,
+                        help='JSON object: {node: {observed_until_ms: number, counts: {QueryStart: count, '
+                             'QueryFinish: count, ExceptionBeforeStart: count, ExceptionWhileProcessing: count}}}; '
+                             'independent counts of the same flushed export scope, including zero-count nodes')
+    return parser
+
+
+def optional_json(path):
+    return json.loads(path.read_text()) if path else None
+
+
+def main():
+    parser = argument_parser()
     args = parser.parse_args()
-    if not math.isfinite(args.max_query_ms) or args.max_query_ms <= 0:
-        parser.error("--max-query-ms must be finite and positive")
-    if not math.isfinite(args.cancellation_grace_ms) or args.cancellation_grace_ms <= 0:
-        parser.error("--cancellation-grace-ms must be finite and positive")
-    if not math.isfinite(args.observed_until_ms):
-        parser.error("--observed-until-ms must be finite")
     try:
+        finite_number(args.max_query_ms, "--max-query-ms", 0.001)
+        finite_number(args.cancellation_grace_ms, "--cancellation-grace-ms", 0.001)
+        finite_number(args.observed_until_ms, "--observed-until-ms", 0)
         rows = read_rows(args.export)
         result = audit(rows, args.max_query_ms, args.require_leaves)
-        events = [json.loads(line) for line in args.cancellations.read_text().splitlines()
-                  if line.strip()] if args.cancellations else []
-        failures = cancellation_check(rows, events, args.observed_until_ms,
-                                      args.cancellation_grace_ms, args.require_leaves)
-        result["cancellation_failures"] = failures
-        result["client_disconnect_cancellation_verified"] = not failures
+        events = read_jsonl(args.cancellations) if args.cancellations else []
+        result.update(cancellation_check(rows, events, args.observed_until_ms,
+                                         args.cancellation_grace_ms, args.require_leaves,
+                                         args.expected_nodes, optional_json(args.clock_bounds),
+                                         optional_json(args.count_manifest)))
     except (OSError, ValueError, TypeError, KeyError) as error:
         parser.error(str(error))
     print(json.dumps(result, indent=2))

--- a/scripts/test/test-clickhouse-http-disconnect.py
+++ b/scripts/test/test-clickhouse-http-disconnect.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 """Exercise HTTP disconnect cancellation on an isolated three-node ClickHouse cluster.
 
-Requires Docker. Never connects to an existing ClickHouse endpoint. Example:
+Requires Docker and the Rust build prerequisites. Never connects to an existing ClickHouse endpoint. Example:
   python3 scripts/test/test-clickhouse-http-disconnect.py --output /tmp/ch-disconnect
 
 The proxy is deliberately small and transparent; this proves server/proxy mechanics,
@@ -14,10 +14,13 @@ on exit. JSON evidence and generated configuration remain in --output.
 import argparse
 import contextlib
 import http.client
+import http.server
+import os
 import json
 import pathlib
 import select
 import socket
+import socketserver
 import subprocess
 import threading
 import time
@@ -59,6 +62,7 @@ class Cluster:
 <background_pool_size>4</background_pool_size><background_schedule_pool_size>4</background_schedule_pool_size>
 <background_merges_mutations_concurrency_ratio>8</background_merges_mutations_concurrency_ratio>
 <remote_servers><fixture>{shards}</fixture></remote_servers>
+<macros><cluster>fixture</cluster></macros>
 <zookeeper><node><host>{self.nodes[0]}</host><port>9181</port></node></zookeeper>
 <distributed_ddl><path>/fixture/ddl</path><pool_size>1</pool_size></distributed_ddl>
 <query_log><flush_interval_milliseconds>100</flush_interval_milliseconds></query_log>
@@ -81,8 +85,8 @@ class Cluster:
                     f"{common}:/etc/clickhouse-server/config.d/fixture.xml:ro"]
             if i == 0:
                 args += ["-v", f"{keeper}:/etc/clickhouse-server/config.d/keeper.xml:ro"]
-            docker(*args, self.image)
             self.created.append(name)
+            docker(*args, self.image)
             self.ports.append(int(docker("port", name, "8123/tcp").rsplit(":", 1)[1]))
         for i in range(3):
             wait_for(lambda i=i: self.ready(i), 90)
@@ -92,6 +96,16 @@ class Cluster:
         for i in range(3):
             self.sql("CREATE VIEW slow AS "
                      "SELECT number, sleepEachRow(0.05) AS delay FROM numbers(600)", i)
+        for i in range(3):
+            self.sql("CREATE TABLE fixture_signatures_local (signature FixedString(64), "
+                     "sig_bucket UInt64 MATERIALIZED cityHash64(signature)%32,slot UInt64, "
+                     "slot_idx UInt32,err Nullable(String)) ENGINE=MergeTree "
+                     "ORDER BY (sig_bucket,signature,slot,slot_idx)", i)
+        self.sql("CREATE TABLE fixture_signatures AS fixture_signatures_local "
+                 "ENGINE=Distributed(fixture,default,fixture_signatures_local)")
+        self.sql("INSERT INTO fixture_signatures_local (signature,slot,slot_idx,err) VALUES "
+                 f"(unhex('{('11' * 64)}'),17,1,NULL),"
+                 f"(unhex('{('33' * 64)}'),19,2,'\"BlockhashNotFound\"')")
         self.sql("CREATE TABLE slow_all (number UInt64, delay UInt8) "
                  "ENGINE=Distributed(fixture,default,slow)")
 
@@ -129,6 +143,9 @@ class Cluster:
 
     def close(self):
         for name in reversed(self.created):
+            with contextlib.suppress(subprocess.CalledProcessError):
+                docker("cp", f"{name}:/var/log/clickhouse-server/clickhouse-server.err.log",
+                       str(self.output / f"{name}.err.log"))
             with contextlib.suppress(subprocess.CalledProcessError):
                 logs = docker("logs", name)
                 (self.output / f"{name}.log").write_text(logs)
@@ -189,6 +206,105 @@ class Proxy:
         self.thread.join(timeout=2)
         assert not self.thread.is_alive(), "Proxy did not stop"
         assert self.error is None, self.error
+
+
+class GatewayHandler(socketserver.BaseRequestHandler):
+    """Transparent persistent connections, including production binary compression."""
+    def handle(self):
+        try:
+            with socket.create_connection(("127.0.0.1", self.server.upstream_port)) as upstream:
+                sockets = [self.request, upstream]
+                while not self.server.stopping.is_set():
+                    ready, _, _ = select.select(sockets, [], [], 0.1)
+                    for source in ready:
+                        data = source.recv(65536)
+                        if not data:
+                            return
+                        target = upstream if source is self.request else self.request
+                        target.sendall(data)
+        except OSError:
+            return
+
+
+class ControlHandler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, *_args):
+        pass
+
+    def do_POST(self):
+        cluster = self.server.cluster
+        actions = {
+            "/pause-replica": lambda: docker("pause", cluster.nodes[2]),
+            "/resume-replica": lambda: docker("unpause", cluster.nodes[2]),
+            "/block-ddl": lambda: block_ddl(cluster),
+            "/assert-ddl-blocked": lambda: assert_ddl_blocked(cluster),
+        }
+        try:
+            actions[self.path]()
+            self.send_response(200)
+        except (KeyError, AssertionError, RuntimeError, subprocess.CalledProcessError):
+            self.send_response(500)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+
+def rust_test_binary(output, explicit):
+    if explicit:
+        return explicit.resolve()
+    root = pathlib.Path(__file__).resolve().parents[2]
+    command = ["cargo", "test", "-p", "superbank-rpc", "--lib", "--all-features", "--locked",
+               "--no-run", "--message-format=json"]
+    with (output / "rust-build.log").open("w") as log:
+        result = subprocess.run(command, cwd=root, stdout=subprocess.PIPE, stderr=log, text=True)
+    artifacts = [json.loads(line) for line in result.stdout.splitlines() if line.startswith("{")]
+    with (output / "rust-build.log").open("a") as log:
+        for row in artifacts:
+            if row.get("reason") == "compiler-message":
+                log.write(row.get("message", {}).get("rendered") or "")
+    result.check_returncode()
+    executables = {row["executable"] for row in artifacts if row.get("reason") == "compiler-artifact"
+                   and row.get("executable") and row.get("profile", {}).get("test")
+                   and row.get("target", {}).get("name") == "superbank_rpc"
+                   and row.get("target", {}).get("kind") == ["lib"]}
+    assert len(executables) == 1, f"Expected one RPC test executable: {executables}"
+    return pathlib.Path(executables.pop())
+
+
+def validate_rust_test_binary(executable):
+    test_filter = "clickhouse::disconnect::integration_tests::"
+    listed = subprocess.check_output([str(executable), test_filter, "--ignored", "--list"], text=True)
+    assert listed.count(": test") == 3, "All three real protocol tests must be present in the library test binary"
+
+
+def run_rust_integration(cluster, executable):
+    gateway = socketserver.ThreadingTCPServer(("127.0.0.1", 0), GatewayHandler)
+    gateway.daemon_threads = True
+    gateway.upstream_port = cluster.ports[0]
+    gateway.stopping = threading.Event()
+    control = http.server.ThreadingHTTPServer(("127.0.0.1", 0), ControlHandler)
+    control.cluster = cluster
+    workers = [threading.Thread(target=server.serve_forever, daemon=True) for server in (gateway, control)]
+    for worker in workers:
+        worker.start()
+    env = os.environ.copy()
+    env["SUPERBANK_DISCONNECT_TEST_URL"] = f"http://127.0.0.1:{gateway.server_address[1]}"
+    env["SUPERBANK_DISCONNECT_TEST_CONTROL_URL"] = f"http://127.0.0.1:{control.server_address[1]}"
+    test_filter = "clickhouse::disconnect::integration_tests::"
+    command = [str(executable), test_filter, "--ignored", "--nocapture", "--test-threads=1"]
+    try:
+        result = subprocess.run(command, env=env, capture_output=True, text=True, timeout=150)
+        (cluster.output / "rust-integration.log").write_text(result.stdout + result.stderr)
+        result.check_returncode()
+        assert "3 passed; 0 failed" in result.stdout, "No silently skipped protocol tests"
+        return {"passed": True, "tests": 3, "production_validation_and_compression": True}
+    finally:
+        with contextlib.suppress(subprocess.CalledProcessError):
+            docker("unpause", cluster.nodes[2])
+        gateway.stopping.set()
+        for server in (gateway, control):
+            server.shutdown()
+            server.server_close()
+        for worker in workers:
+            worker.join(timeout=2)
 
 
 def request_bytes(query_id, streaming):
@@ -288,6 +404,13 @@ def delayed_forwarding_control(cluster):
         wait_for(lambda: not any(cluster.active(query_id)), 5)
 
 
+def assert_ddl_blocked(cluster):
+    count = int(cluster.sql("SELECT count() FROM system.distributed_ddl_queue "
+                            "WHERE query LIKE '%ddl_queued%' AND status='Inactive'").strip())
+    assert count == 3, "DDL blocker finished before cancellation verification"
+    return count
+
+
 def block_ddl(cluster):
     cluster.sql("CREATE TABLE ddl_blocker ON CLUSTER fixture ENGINE=Memory AS SELECT "
                 "number,sleepEachRow(0.05) delay FROM numbers(800) "
@@ -305,9 +428,12 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--output", type=pathlib.Path, required=True)
     parser.add_argument("--image", default=IMAGE)
+    parser.add_argument("--rust-test-binary", type=pathlib.Path, help="Use a prebuilt RPC test executable")
     args = parser.parse_args()
     args.output = args.output.resolve()
     args.output.mkdir(parents=True, exist_ok=False)
+    executable = rust_test_binary(args.output, args.rust_test_binary)
+    validate_rust_test_binary(executable)
     cluster = Cluster(args.output, args.image)
     report = {"image": args.image, "cases": [], "passed": False}
     try:
@@ -331,6 +457,15 @@ def main():
             "SELECT count() FROM system.distributed_ddl_queue WHERE query LIKE '%ddl_queued%' "
             "AND status='Inactive'").strip())
         assert report["queued_ddl_still_inactive"] == 3, "DDL blocker finished before gate completed"
+        report["kill_queries"] = [int(cluster.sql(
+            "SELECT count() FROM system.query_log WHERE startsWith(query, 'KILL QUERY')", i).strip())
+            for i in range(3)]
+        assert report["kill_queries"] == [0, 0, 0]
+        wait_for(lambda: int(cluster.sql("SELECT count() FROM system.distributed_ddl_queue "
+                                        "WHERE status IN ('Active','Inactive')").strip()) == 0, 50)
+        cluster.sql("DROP TABLE ddl_blocker ON CLUSTER fixture SETTINGS distributed_ddl_task_timeout=10")
+        cluster.sql("DROP TABLE ddl_queued ON CLUSTER fixture SETTINGS distributed_ddl_task_timeout=10")
+        report["rust_integration"] = run_rust_integration(cluster, executable)
         report["kill_queries"] = [int(cluster.sql(
             "SELECT count() FROM system.query_log WHERE startsWith(query, 'KILL QUERY')", i).strip())
             for i in range(3)]

--- a/scripts/test/test-clickhouse-http-disconnect.py
+++ b/scripts/test/test-clickhouse-http-disconnect.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Exercise HTTP disconnect cancellation on an isolated three-node ClickHouse cluster.
+
+Requires Docker. Never connects to an existing ClickHouse endpoint. Example:
+  python3 scripts/test/test-clickhouse-http-disconnect.py --output /tmp/ch-disconnect
+
+The proxy is deliberately small and transparent; this proves server/proxy mechanics,
+not the deployed gateway's behavior. Four positive cases must cancel; two negative
+gateway controls must demonstrate incompatibility for the suite to pass. A gateway
+must discard queued requests when its downstream closes. All containers and the private network are removed
+on exit. JSON evidence and generated configuration remain in --output.
+"""
+import argparse
+import contextlib
+import http.client
+import json
+import pathlib
+import select
+import socket
+import subprocess
+import threading
+import time
+import urllib.parse
+import uuid
+
+
+IMAGE = "clickhouse/clickhouse-server:26.2.3.2"
+CANCELLED = {394, 735}  # QUERY_WAS_CANCELLED / QUERY_WAS_CANCELLED_BY_CLIENT
+
+
+def docker(*args):
+    return subprocess.check_output(["docker", *args], text=True, stderr=subprocess.STDOUT).strip()
+
+
+def wait_for(check, seconds=30):
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        result = check()
+        if result:
+            return result
+        time.sleep(0.1)
+    raise AssertionError("Timed out waiting for fixture condition")
+
+
+class Cluster:
+    def __init__(self, output, image):
+        self.output, self.image = output, image
+        self.name = "ch-disconnect-" + uuid.uuid4().hex[:10]
+        self.nodes = [self.name + f"-{i}" for i in range(3)]
+        self.created = []
+        self.ports = []
+
+    def configuration(self):
+        shards = "".join(f"<shard><replica><host>{node}</host><port>9000</port>"
+                         "</replica></shard>" for node in self.nodes)
+        return f"""<clickhouse>
+<listen_host>0.0.0.0</listen_host><max_thread_pool_size>256</max_thread_pool_size>
+<background_pool_size>4</background_pool_size><background_schedule_pool_size>4</background_schedule_pool_size>
+<background_merges_mutations_concurrency_ratio>8</background_merges_mutations_concurrency_ratio>
+<remote_servers><fixture>{shards}</fixture></remote_servers>
+<zookeeper><node><host>{self.nodes[0]}</host><port>9181</port></node></zookeeper>
+<distributed_ddl><path>/fixture/ddl</path><pool_size>1</pool_size></distributed_ddl>
+<query_log><flush_interval_milliseconds>100</flush_interval_milliseconds></query_log>
+</clickhouse>"""
+
+    def start(self):
+        docker("network", "create", self.name)
+        common = self.output / "cluster.xml"
+        common.write_text(self.configuration())
+        keeper = self.output / "keeper.xml"
+        keeper.write_text("""<clickhouse><keeper_server><tcp_port>9181</tcp_port>
+<server_id>1</server_id><log_storage_path>/var/lib/clickhouse/keeper/log</log_storage_path>
+<snapshot_storage_path>/var/lib/clickhouse/keeper/snapshots</snapshot_storage_path>
+<raft_configuration><server><id>1</id><hostname>localhost</hostname><port>9234</port>
+</server></raft_configuration></keeper_server></clickhouse>""")
+        for i, name in enumerate(self.nodes):
+            args = ["run", "-d", "--name", name, "--hostname", name, "--network", self.name,
+                    "--cpus", "2", "--memory", "2g", "-p", "127.0.0.1::8123",
+                    "-e", "CLICKHOUSE_SKIP_USER_SETUP=1", "-v",
+                    f"{common}:/etc/clickhouse-server/config.d/fixture.xml:ro"]
+            if i == 0:
+                args += ["-v", f"{keeper}:/etc/clickhouse-server/config.d/keeper.xml:ro"]
+            docker(*args, self.image)
+            self.created.append(name)
+            self.ports.append(int(docker("port", name, "8123/tcp").rsplit(":", 1)[1]))
+        for i in range(3):
+            wait_for(lambda i=i: self.ready(i), 90)
+        versions = [self.sql("SELECT version()", i).strip() for i in range(3)]
+        assert len(set(versions)) == 1, versions
+        self.version = versions[0]
+        for i in range(3):
+            self.sql("CREATE VIEW slow AS "
+                     "SELECT number, sleepEachRow(0.05) AS delay FROM numbers(600)", i)
+        self.sql("CREATE TABLE slow_all (number UInt64, delay UInt8) "
+                 "ENGINE=Distributed(fixture,default,slow)")
+
+    def sql(self, query, node=0):
+        connection = http.client.HTTPConnection("127.0.0.1", self.ports[node], timeout=5)
+        try:
+            connection.request("POST", "/", query.encode())
+            response = connection.getresponse()
+            body = response.read().decode()
+            if response.status != 200:
+                raise RuntimeError(body)
+            return body
+        finally:
+            connection.close()
+
+    def ready(self, node):
+        try:
+            return self.sql("SELECT 1", node).strip() == "1"
+        except (OSError, RuntimeError, http.client.HTTPException):
+            return False
+
+    def active(self, query_id):
+        query = ("SELECT count() FROM system.processes WHERE initial_query_id='"
+                 + query_id + "' OR query_id='" + query_id + "'")
+        return [int(self.sql(query, i).strip()) for i in range(3)]
+
+    def terminals(self, query_id):
+        rows = []
+        for i in range(3):
+            query = ("SELECT type,query_id,initial_query_id,is_initial_query,exception_code,"
+                     "query_duration_ms,Settings FROM system.query_log WHERE "
+                     f"initial_query_id='{query_id}' AND type!='QueryStart' FORMAT JSONEachRow")
+            rows.extend(dict(json.loads(line), node=i) for line in self.sql(query, i).splitlines())
+        return rows
+
+    def close(self):
+        for name in reversed(self.created):
+            with contextlib.suppress(subprocess.CalledProcessError):
+                logs = docker("logs", name)
+                (self.output / f"{name}.log").write_text(logs)
+                docker("rm", "-f", name)
+        with contextlib.suppress(subprocess.CalledProcessError):
+            docker("network", "rm", self.name)
+
+
+class Proxy:
+    """One connection; propagate EOF, or deliberately ignore it for the control."""
+    def __init__(self, upstream_port, propagate, forward_delay=0):
+        self.upstream_port, self.propagate = upstream_port, propagate
+        self.forward_delay = forward_delay
+        self.listener = socket.create_server(("127.0.0.1", 0))
+        self.port = self.listener.getsockname()[1]
+        self.stop = threading.Event()
+        self.disconnected = threading.Event()
+        self.error = None
+        self.thread = threading.Thread(target=self.run, daemon=True)
+        self.thread.start()
+
+    def relay(self, client, upstream):
+        downstream = True
+        buffered = bytearray()
+        forward_at = time.monotonic() + self.forward_delay
+        while not self.stop.is_set():
+            if buffered and time.monotonic() >= forward_at:
+                upstream.sendall(buffered)
+                buffered.clear()
+            ready, _, _ = select.select([upstream] + ([client] if downstream else []), [], [], 0.1)
+            for source in ready:
+                data = source.recv(65536)
+                if not data and source is client:
+                    self.disconnected.set()
+                    downstream = False
+                    if self.propagate:
+                        return
+                elif not data:
+                    return
+                elif source is client:
+                    buffered.extend(data)
+                elif downstream:
+                    client.sendall(data)
+
+    def run(self):
+        try:
+            client, _ = self.listener.accept()
+            with client, socket.create_connection(("127.0.0.1", self.upstream_port)) as upstream:
+                self.relay(client, upstream)
+        except OSError as error:
+            if not self.stop.is_set():
+                self.error = repr(error)
+        finally:
+            self.listener.close()
+
+    def close(self):
+        self.stop.set()
+        self.thread.join(timeout=2)
+        assert not self.thread.is_alive(), "Proxy did not stop"
+        assert self.error is None, self.error
+
+
+def request_bytes(query_id, streaming):
+    params = {"query_id": query_id, "readonly": 2,
+              "cancel_http_readonly_queries_on_client_close": 1,
+              "max_threads": 1, "max_block_size": 1, "max_execution_time": 35,
+              "max_execution_time_leaf": 35, "use_hedged_requests": 0,
+              "max_parallel_replicas": 1, "log_query_settings": 1,
+              "wait_end_of_query": 0, "buffer_size": 1}
+    query = "SELECT " + ("number,delay" if streaming else "sum(delay)") + " FROM slow_all FORMAT JSONEachRow"
+    body = query.encode()
+    return (f"POST /?{urllib.parse.urlencode(params)} HTTP/1.1\r\nHost: localhost\r\n"
+            f"Content-Length: {len(body)}\r\nConnection: close\r\n\r\n").encode() + body
+
+
+def receive_stream(client):
+    client.settimeout(5)
+    received = b""
+    while b"\r\n\r\n" not in received or not received.split(b"\r\n\r\n", 1)[1]:
+        chunk = client.recv(65536)
+        assert chunk, "Query finished before streaming abandonment"
+        received += chunk
+    assert b"200 OK" in received.split(b"\r\n", 1)[0], received[:400]
+    return received
+
+
+def validate_terminals(terminals):
+    assert len(terminals) == 3 and {r['node'] for r in terminals} == {0, 1, 2}, terminals
+    assert sum(r['is_initial_query'] for r in terminals) == 1, terminals
+    assert all(r['Settings'].get('readonly') == '2' and
+               r['Settings'].get('cancel_http_readonly_queries_on_client_close') == '1'
+               for r in terminals), terminals
+    assert all(r['type'] != 'QueryFinish' and r['exception_code'] in CANCELLED for r in terminals), terminals
+
+
+def run_case(cluster, name, streaming=False, propagate=True):
+    query_id = "http_disconnect_" + name + "_" + uuid.uuid4().hex[:8]
+    proxy = Proxy(cluster.ports[0], propagate)
+    client = socket.create_connection(("127.0.0.1", proxy.port))
+    received = b""
+    try:
+        client.sendall(request_bytes(query_id, streaming))
+        wait_for(lambda: all(cluster.active(query_id)), 10)
+        if streaming:
+            received = receive_stream(client)
+        else:
+            assert not select.select([client], [], [], 0)[0], "Headers already received"
+        abandoned = time.monotonic()
+        client.close()
+        assert proxy.disconnected.wait(1), "Proxy did not observe actual client close"
+        if propagate:
+            wait_for(lambda: not any(cluster.active(query_id)), 5)
+            elapsed = time.monotonic() - abandoned
+            assert elapsed <= 5, "Observed termination exceeded five seconds"
+            terminals = wait_for(lambda: cluster.terminals(query_id), 5)
+            wait_for(lambda: len(cluster.terminals(query_id)) >= 3, 5)
+            terminals = cluster.terminals(query_id)
+            validate_terminals(terminals)
+        else:
+            time.sleep(5.2)
+            assert all(cluster.active(query_id)), "Negative control unexpectedly stopped"
+            elapsed, terminals = None, []
+        return {"name": name, "query_id": query_id, "streaming": streaming,
+                "proxy_propagates_disconnect": propagate,
+                "cancel_gate_pass": propagate, "stop_after_disconnect_seconds": elapsed,
+                "received_bytes": len(received), "terminals": terminals}
+    finally:
+        client.close()
+        proxy.close()
+        wait_for(lambda: not any(cluster.active(query_id)), 5)
+
+
+def delayed_forwarding_control(cluster):
+    """Expose the unsupported contract: queued HTTP work forwarded after EOF."""
+    query_id = "http_disconnect_delayed_" + uuid.uuid4().hex[:8]
+    proxy = Proxy(cluster.ports[0], False, forward_delay=1.5)
+    client = socket.create_connection(("127.0.0.1", proxy.port))
+    try:
+        client.sendall(request_bytes(query_id, False))
+        client.close()
+        assert proxy.disconnected.wait(1)
+        abandoned = time.monotonic()
+        quiet = []
+        for _ in range(2):
+            assert not any(cluster.active(query_id))
+            quiet.append(time.monotonic() - abandoned)
+            time.sleep(0.25)
+        wait_for(lambda: all(cluster.active(query_id)), 10)
+        return {"name": "negative_delayed_forwarding", "query_id": query_id,
+                "cancel_gate_pass": False, "expected_incompatible_gateway": True,
+                "quiet_observations_seconds": quiet,
+                "appeared_after_disconnect_seconds": time.monotonic() - abandoned,
+                "limitation": "Two quiet probes cannot prove a gateway will not submit work later."}
+    finally:
+        client.close()
+        proxy.close()
+        wait_for(lambda: not any(cluster.active(query_id)), 5)
+
+
+def block_ddl(cluster):
+    cluster.sql("CREATE TABLE ddl_blocker ON CLUSTER fixture ENGINE=Memory AS SELECT "
+                "number,sleepEachRow(0.05) delay FROM numbers(800) "
+                "SETTINGS max_block_size=1,distributed_ddl_task_timeout=0")
+    wait_for(lambda: int(cluster.sql("SELECT count() FROM system.distributed_ddl_queue "
+                                    "WHERE query LIKE 'CREATE TABLE default.ddl_blocker%' "
+                                    "AND status='Active'").strip()) == 3, 10)
+    cluster.sql("CREATE TABLE ddl_queued ON CLUSTER fixture (x UInt8) ENGINE=Memory "
+                "SETTINGS distributed_ddl_task_timeout=0")
+    return wait_for(lambda: int(cluster.sql("SELECT count() FROM system.distributed_ddl_queue "
+                                          "WHERE query LIKE '%ddl_queued%' AND status='Inactive'").strip()) == 3)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=pathlib.Path, required=True)
+    parser.add_argument("--image", default=IMAGE)
+    args = parser.parse_args()
+    args.output = args.output.resolve()
+    args.output.mkdir(parents=True, exist_ok=False)
+    cluster = Cluster(args.output, args.image)
+    report = {"image": args.image, "cases": [], "passed": False}
+    try:
+        cluster.start()
+        report["version"] = cluster.version
+        report["image_digest"] = docker("image", "inspect", args.image, "--format", "{{json .RepoDigests}}")
+        for name, stream, propagate in [("before_headers", False, True), ("streaming", True, True),
+                                         ("negative_gateway", False, False)]:
+            result = run_case(cluster, name, stream, propagate)
+            report["cases"].append(result)
+            print(json.dumps(result), flush=True)
+        delayed = delayed_forwarding_control(cluster)
+        report["cases"].append(delayed)
+        print(json.dumps(delayed), flush=True)
+        block_ddl(cluster)
+        for name, stream in [("ddl_blocked_before_headers", False), ("ddl_blocked_streaming", True)]:
+            result = run_case(cluster, name, stream)
+            report["cases"].append(result)
+            print(json.dumps(result), flush=True)
+        report["queued_ddl_still_inactive"] = int(cluster.sql(
+            "SELECT count() FROM system.distributed_ddl_queue WHERE query LIKE '%ddl_queued%' "
+            "AND status='Inactive'").strip())
+        assert report["queued_ddl_still_inactive"] == 3, "DDL blocker finished before gate completed"
+        report["kill_queries"] = [int(cluster.sql(
+            "SELECT count() FROM system.query_log WHERE startsWith(query, 'KILL QUERY')", i).strip())
+            for i in range(3)]
+        assert report["kill_queries"] == [0, 0, 0]
+        report["passed"] = True
+    finally:
+        (args.output / "report.json").write_text(json.dumps(report, indent=2) + "\n")
+        cluster.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test/test_report_signature_status_query_log.py
+++ b/scripts/test/test_report_signature_status_query_log.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Offline regression tests for cancellation acceptance evidence."""
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from collections import Counter
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("report-signature-status-query-log.py")
+SPEC = importlib.util.spec_from_file_location("report", SCRIPT)
+REPORT = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(REPORT)
+
+
+def row(kind="ExceptionWhileProcessing", node="coordinator", query="root", initial=1, **overrides):
+    result = {"node": node, "query_id": query, "initial_query_id": "root",
+              "is_initial_query": initial, "type": kind, "query_duration_ms": 100,
+              "ProfileEvents": {}, "event_at_ms": 1200, "exception_code": 735}
+    result.update(overrides)
+    return result
+
+
+def execution(**overrides):
+    return [row("QueryStart", **overrides), row(**overrides)]
+
+
+def inputs(rows, nodes=("coordinator", "replica")):
+    clocks = {node: {"min_offset_ms": -20, "max_offset_ms": 20} for node in nodes}
+    manifest = {}
+    for node in nodes:
+        counts = Counter(event["type"] for event in rows if event["node"] == node)
+        manifest[node] = {"observed_until_ms": 7000,
+                          "counts": {kind: counts[kind] for kind in REPORT.EVENT_TYPES}}
+    return {"rows": rows, "events": [{"initial_query_id": "root", "cancelled_at_ms": 1000}],
+            "observed_until_ms": 7000, "grace_ms": 5000, "require_leaves": False,
+            "expected_nodes": list(nodes), "clocks": clocks, "manifest": manifest}
+
+
+class QueryLogAuditTests(unittest.TestCase):
+    def test_exception_before_start_needs_no_start(self):
+        result = REPORT.audit([row("ExceptionBeforeStart")], 5000, False)
+        self.assertTrue(result["observed_query_lifetimes_pass"])
+
+    def test_other_terminals_require_start(self):
+        for kind in ("QueryFinish", "ExceptionWhileProcessing"):
+            with self.subTest(kind=kind):
+                self.assertFalse(REPORT.audit([row(kind)], 5000, False)["observed_query_lifetimes_pass"])
+
+    def test_duplicate_start_or_terminal_fails(self):
+        for rows in (execution() + [row()], execution() + [row("QueryStart")]):
+            self.assertFalse(REPORT.audit(rows, 5000, False)["observed_query_lifetimes_pass"])
+
+    def test_start_and_terminal_must_share_initial_query(self):
+        rows = execution()
+        rows[0]["initial_query_id"] = "another-root"
+        self.assertFalse(REPORT.audit(rows, 5000, False)["observed_query_lifetimes_pass"])
+
+    def test_started_exception_before_start_is_inconsistent(self):
+        rows = [row("QueryStart"), row("ExceptionBeforeStart")]
+        self.assertFalse(REPORT.audit(rows, 5000, False)["observed_query_lifetimes_pass"])
+
+    def test_missing_leaf_fails_when_required(self):
+        self.assertFalse(REPORT.audit(execution(), 5000, True)["observed_query_lifetimes_pass"])
+
+
+class CancellationEvidenceTests(unittest.TestCase):
+    def test_complete_cancelled_execution_with_idle_replica_passes(self):
+        result = REPORT.cancellation_check(**inputs(execution()))
+        self.assertTrue(result["termination_after_disconnect_verified"])
+        self.assertTrue(result["client_disconnect_cancellation_verified"])
+
+    def test_replicas_may_finish_naturally_but_coordinator_must_be_cancelled(self):
+        rows = execution() + [row("QueryStart", node="replica", query="leaf", initial=0),
+                              row("QueryFinish", node="replica", query="leaf", initial=0, exception_code=0)]
+        args = inputs(rows)
+        args["require_leaves"] = True
+        self.assertTrue(REPORT.cancellation_check(**args)["client_disconnect_cancellation_verified"])
+
+    def test_cancelled_leaf_is_accepted(self):
+        rows = execution() + execution(node="replica", query="leaf", initial=0, exception_code=394)
+        self.assertTrue(REPORT.cancellation_check(**inputs(rows))["client_disconnect_cancellation_verified"])
+
+    def test_natural_coordinator_finish_is_only_termination(self):
+        rows = [row("QueryStart"), row("QueryFinish", exception_code=0)]
+        result = REPORT.cancellation_check(**inputs(rows))
+        self.assertTrue(result["termination_after_disconnect_verified"])
+        self.assertFalse(result["client_disconnect_cancellation_verified"])
+
+    def test_distributed_cancellation_may_have_394_coordinator_and_735_leaves(self):
+        rows = execution(exception_code=394) + execution(node="replica", query="leaf", initial=0)
+        result = REPORT.cancellation_check(**inputs(rows))
+        self.assertTrue(result["termination_after_disconnect_verified"])
+        self.assertTrue(result["client_disconnect_cancellation_verified"])
+
+    def test_generic_kill_error_does_not_prove_disconnect_cause(self):
+        result = REPORT.cancellation_check(**inputs(execution(exception_code=394)))
+        self.assertTrue(result["termination_after_disconnect_verified"])
+        self.assertFalse(result["client_disconnect_cancellation_verified"])
+
+    def test_actual_event_timestamp_overrides_short_reported_duration(self):
+        result = REPORT.cancellation_check(**inputs(execution(event_at_ms=7000, started_at_ms=1000)))
+        self.assertFalse(result["termination_after_disconnect_verified"])
+
+    def test_minimum_clock_offset_controls_latest_possible_finish(self):
+        args = inputs(execution(event_at_ms=5990))
+        result = REPORT.cancellation_check(**args)
+        self.assertFalse(result["termination_after_disconnect_verified"])
+        args["clocks"]["coordinator"] = {"min_offset_ms": 0, "max_offset_ms": 20}
+        self.assertTrue(REPORT.cancellation_check(**args)["termination_after_disconnect_verified"])
+
+    def test_cancellation_before_or_overlapping_disconnect_is_unverified(self):
+        result = REPORT.cancellation_check(**inputs(execution(event_at_ms=1010)))
+        self.assertTrue(result["termination_after_disconnect_verified"])
+        self.assertFalse(result["client_disconnect_cancellation_verified"])
+
+    def test_missing_event_timestamp_cannot_use_start_plus_duration(self):
+        rows = execution(started_at_ms=1000)
+        del rows[-1]["event_at_ms"]
+        result = REPORT.cancellation_check(**inputs(rows))
+        self.assertFalse(result["termination_after_disconnect_verified"])
+
+    def test_each_external_evidence_input_is_required(self):
+        for field in ("events", "expected_nodes", "clocks", "manifest"):
+            args = inputs(execution())
+            args[field] = None if field != "events" else []
+            with self.subTest(field=field):
+                self.assertFalse(REPORT.cancellation_check(**args)["client_disconnect_cancellation_verified"])
+
+    def test_missing_expected_node_clock_or_manifest_is_unverified(self):
+        for field in ("clocks", "manifest"):
+            args = inputs(execution())
+            del args[field]["replica"]
+            with self.subTest(field=field):
+                self.assertFalse(REPORT.cancellation_check(**args)["termination_after_disconnect_verified"])
+
+    def test_count_mismatch_catches_truncated_export(self):
+        args = inputs(execution())
+        args["manifest"]["replica"]["counts"]["QueryStart"] = 1
+        self.assertFalse(REPORT.cancellation_check(**args)["termination_after_disconnect_verified"])
+
+    def test_manifest_observation_must_cover_requested_interval_on_every_node(self):
+        args = inputs(execution())
+        args["manifest"]["replica"]["observed_until_ms"] = 5999
+        self.assertFalse(REPORT.cancellation_check(**args)["termination_after_disconnect_verified"])
+
+    def test_observation_must_extend_to_disconnect_deadline(self):
+        args = inputs(execution())
+        args["observed_until_ms"] = 5999
+        self.assertFalse(REPORT.cancellation_check(**args)["termination_after_disconnect_verified"])
+
+    def test_duplicate_external_correlation_fails(self):
+        args = inputs(execution())
+        args["events"] *= 2
+        self.assertFalse(REPORT.cancellation_check(**args)["termination_after_disconnect_verified"])
+
+    def test_unmatched_cancellation_fails(self):
+        args = inputs(execution())
+        args["events"][0]["initial_query_id"] = "unknown"
+        self.assertFalse(REPORT.cancellation_check(**args)["termination_after_disconnect_verified"])
+
+    def test_unexpected_replica_fails(self):
+        rows = execution() + execution(node="unexpected", query="leaf", initial=0)
+        self.assertFalse(REPORT.cancellation_check(**inputs(rows))["termination_after_disconnect_verified"])
+
+    def test_invalid_clock_bounds_rejected(self):
+        for bounds in ({"min_offset_ms": 1, "max_offset_ms": 0},
+                       {"min_offset_ms": float("nan"), "max_offset_ms": 0}):
+            args = inputs(execution())
+            args["clocks"]["coordinator"] = bounds
+            with self.subTest(bounds=bounds), self.assertRaises(ValueError):
+                REPORT.cancellation_check(**args)
+
+    def test_before_start_client_cancellation_can_be_verified(self):
+        result = REPORT.cancellation_check(**inputs([row("ExceptionBeforeStart")]))
+        self.assertTrue(result["client_disconnect_cancellation_verified"])
+
+    def test_non_cancellation_leaf_exception_does_not_pass(self):
+        rows = execution() + execution(node="replica", query="leaf", initial=0, exception_code=159)
+        result = REPORT.cancellation_check(**inputs(rows))
+        self.assertTrue(result["termination_after_disconnect_verified"])
+        self.assertFalse(result["client_disconnect_cancellation_verified"])
+
+
+class CommandLineTests(unittest.TestCase):
+    def test_legacy_inputs_still_report_but_cannot_verify_cancellation(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "queries.jsonl"
+            path.write_text("\n".join(json.dumps(event) for event in execution()))
+            result = subprocess.run([sys.executable, str(SCRIPT), str(path)],
+                                    capture_output=True, text=True, check=False)
+        self.assertEqual(result.returncode, 1, result.stderr)
+        report = json.loads(result.stdout)
+        self.assertTrue(report["observed_query_lifetimes_pass"])
+        self.assertFalse(report["client_disconnect_cancellation_verified"])
+
+    def test_complete_inputs_exit_successfully(self):
+        args = inputs(execution())
+        with tempfile.TemporaryDirectory() as directory:
+            base = Path(directory)
+            for name, value in (("clocks", args["clocks"]), ("manifest", args["manifest"])):
+                (base / name).write_text(json.dumps(value))
+            for name, value in (("rows", args["rows"]), ("events", args["events"])):
+                (base / name).write_text("\n".join(json.dumps(event) for event in value))
+            command = [sys.executable, str(SCRIPT), str(base / "rows"),
+                       "--cancellations", str(base / "events"), "--observed-until-ms", "7000",
+                       "--expected-nodes", "coordinator", "replica", "--clock-bounds", str(base / "clocks"),
+                       "--count-manifest", str(base / "manifest")]
+            result = subprocess.run(command, capture_output=True, text=True, check=False)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(json.loads(result.stdout)["client_disconnect_cancellation_verified"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/k6/README.md
+++ b/tests/k6/README.md
@@ -886,6 +886,14 @@ including misses/timeouts, and compare backlog and ingestion rate before/after. 
 query-log selected-part counts and metrics alongside the k6 summary. A passing k6 process alone
 does not establish the ingestion and all-attempt gates.
 
+For signature-priority scheduling, compare the deployed baseline and candidate at the same rates
+and request mix. Invalidate a signature partition while an address build is running: signature
+recovery must progress independently, no new address build may start until signatures recover,
+and address warming must resume afterward. Also exercise a failed signature scan followed by a
+successful retry. The idle signature worker discovers work within five seconds; scan duration and
+other signature work add to recovery time. Preserve the cold-start and repair timelines separately
+from the 30-minute steady-state results. A small fixture is not a production performance pass.
+
 Repeat cold-start and invalidation tests separately: correctness and the two-second deadline
 must hold while the index is unavailable, but the steady-state latency targets apply after
 index building. `KEY_ROUTING_SMOKE=1` runs for ten seconds at one request/s and skips dataset-size checks; this is

--- a/tests/k6/README.md
+++ b/tests/k6/README.md
@@ -116,6 +116,115 @@ k6 run tests/k6/scenarios/fuzz/fuzz-options-rpc-methods.js -e RPC_URL=http://loc
 
 ## Test Scenarios
 
+### Signature-status miss replay and cancellation evidence
+
+`scenarios/performance/superbank-rpc-signature-statuses-misses.js` sends one
+`getSignatureStatuses` request per iteration with `searchTransactionHistory: true`.
+Defaults are **256 distinct signatures, 2 requests/second, a 1-second HTTP request
+timeout, and 30 minutes**. Arrival rate is independent of response speed. Dropped
+iterations fail the test; timeouts are recorded separately from valid all-null
+responses and unexpected HTTP/JSON-RPC responses. Expected timeouts do not fail
+the replay by themselves, so a successful k6 exit is not an availability or
+backend-cancellation acceptance result.
+
+Use an isolated fixture and a reproducible corpus known to be absent from it.
+This creates 1,000,000 syntactically valid 64-byte signatures without sending traffic.
+The replay never recycles signatures: exhaustion aborts the run, preventing repeated negative
+condition-cache hits from masking fresh-miss cost. The default run needs 921,600 signatures
+plus a small scheduling buffer:
+
+```bash
+python3 - <<'PY' > /tmp/status-misses.txt
+import hashlib
+alphabet = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+for index in range(1_000_000):
+    raw = hashlib.sha512(f'superbank-status-miss-v1:{index}'.encode()).digest()
+    value, encoded = int.from_bytes(raw, 'big'), ''
+    while value:
+        value, digit = divmod(value, 58)
+        encoded = alphabet[digit] + encoded
+    print('1' * (len(raw) - len(raw.lstrip(b'\0'))) + encoded)
+PY
+
+k6 run tests/k6/scenarios/performance/superbank-rpc-signature-statuses-misses.js \
+  -e RPC_URL=http://localhost:8899 \
+  -e MISS_SIGNATURE_FILE=/tmp/status-misses.txt \
+  -e MISS_RUN_LABEL=tuple-in-warm \
+  --summary-export=/tmp/status-misses-summary.json
+```
+
+The scenario cycles through the corpus in batches, preserving the same ordering
+across runs. With the default corpus size, keys repeat every 128 seconds. A corpus
+must contain at least one batch of distinct signatures; completed responses must
+contain exactly that many null statuses. The scenario checks base58 characters and
+length; fixture preparation must ensure signatures decode to 64 bytes and are absent.
+
+| Environment variable | Default | Purpose |
+| --- | --- | --- |
+| `MISS_SIGNATURE_FILE` | required | Whitespace-separated, distinct, known-absent signatures |
+| `MISS_BATCH_SIZE` | `256` | Signatures per request, from 1 through 256 |
+| `MISS_RPS` | `2` | Positive integer requests per second |
+| `MISS_DURATION` | `30m` | Replay duration; use `5s` for a local harness smoke test |
+| `MISS_TIMEOUT_MS` | `1000` | Actual k6 HTTP request timeout, in milliseconds |
+| `MISS_VUS` | rate × timeout, rounded up, plus 2 | Preallocated VUs; increase if iterations drop |
+| `MISS_RUN_LABEL` | `unspecified` | Metric label and JSON-RPC request-ID prefix |
+
+Compare baseline OR and candidate tuple-IN builds against the **same populated
+ClickHouse snapshot, corpus, settings, request rate, and client timeout**. Run each
+for 30 minutes in both cold and warm states. Record table parts, retention, index
+coverage, cache state, and replica topology separately: neither this scenario nor
+an empty local ClickHouse establishes full-retention performance. Cache preparation
+is an explicit fixture operation, not an action performed by this scenario.
+
+Start each isolated RPC process with a distinct `CLICKHOUSE_QUERY_ID_PREFIX`, for
+example `miss-or` and `miss-tuple-in`. `MISS_RUN_LABEL` only labels k6 requests; it
+does **not** establish a mapping to ClickHouse query IDs. Export all start and
+terminal query-log rows for the chosen prefix and exact run window from every
+coordinator and replica. Include these columns, using `system.query_log` locally
+or `clusterAllReplicas('test_cluster', system.query_log)` for a test cluster:
+
+```sql
+SELECT hostName() AS node, query_id, initial_query_id, is_initial_query,
+       toString(type) AS type, query_duration_ms,
+       toUnixTimestamp64Milli(query_start_time_microseconds) AS started_at_ms,
+       ProfileEvents
+FROM system.query_log
+WHERE event_date = '2026-09-11'
+  AND event_time >= '2026-09-11 12:00:00'
+  AND event_time < '2026-09-11 12:31:00'
+  AND startsWith(initial_query_id, 'miss-tuple-in:signature_statuses:')
+FORMAT JSONEachRow
+```
+
+Adjust dates and collection end to the run. Allow asynchronous query-log delivery
+to complete, and retain a `system.processes` snapshot after the cancellation
+deadline as independent evidence of remaining work. Missing logs do not prove
+cancellation. Collect **actual externally observed client-abandonment timestamps
+correlated to exact initial ClickHouse query IDs**, as JSONEachRow records:
+
+```json
+{"initial_query_id":"miss-tuple-in:signature_statuses:1","cancelled_at_ms":1789128001000}
+```
+
+Do not synthesize these timestamps as query start plus the k6 timeout. With complete
+exports and externally established correlation, run the offline report:
+
+```bash
+python3 scripts/test/report-signature-status-query-log.py /tmp/query-log.jsonl \
+  --require-leaves --max-query-ms=5000 \
+  --cancellations=/tmp/cancellations.jsonl \
+  --observed-until-ms=1789129860000 --cancellation-grace-ms=5000
+```
+
+The report keeps coordinator and leaf CPU/duration distributions separate, checks
+observed query lifetimes, and checks whether each correlated execution ended within
+five seconds of the supplied abandonment time. It fails for missing start/terminal
+evidence, missing distributed leaves, incomplete collection intervals, or exceeded
+deadlines. Without cancellation correlation it still prints latency/CPU summaries
+but exits unsuccessfully with cancellation unverified. Collection must include all
+participating replicas; the report cannot detect an omitted server or fabricated
+correlation. No script issues database commands or production requests implicitly.
+
 ### Basic Load Test (`superbank-rpc-get-signatures.js`)
 
 Simple constant-load test with configurable VUs and duration.

--- a/tests/k6/README.md
+++ b/tests/k6/README.md
@@ -898,6 +898,23 @@ DISK_CACHE_TEST_URL=http://127.0.0.1:18123 \
 cargo test -p superbank-rpc --all-features --locked key_routing_clickhouse_integration -- --ignored
 ```
 
+Signature membership also has a reproducible CPU/selectivity check over 80 partitions and
+four million keys at 24 bits/key. It checks sampled inserted keys, aggregate false positives
+at most 1%, and membership p99 below 100 microseconds both idle and during continuous bounded
+updates. Run an optimized build on an otherwise idle machine:
+
+```sh
+cargo test -p superbank-rpc --all-features --locked --release \
+  signature_membership_latency_and_false_positives -- --ignored --nocapture
+```
+
+This scaled check does not establish full-retention memory behavior or RPC latency. For the
+deployment gate above, also require zero unknown signature partitions after warming, membership
+p99 below 100 microseconds, aggregate false positives at most 1%, and immediate negative cache
+lookups while admission is saturated. The local integration fixture holds all cache permits
+while checking absent signatures, and exercises secondary signatures through native fills.
+Measure cold rebuilds, repairs, ingestion backlog, and address latency with the new memory split.
+
 It creates uniquely named `test_key_router_*` databases and removes them on success. Set
 `DISK_CACHE_TEST_KEEP=1` only when retaining the fixture for a local RPC/k6 smoke run.
 

--- a/tests/k6/README.md
+++ b/tests/k6/README.md
@@ -1078,3 +1078,41 @@ For the scoped Rust complexity gate, install `rust-code-analysis-cli` version `0
 have McCabe complexity at most 10; changed existing functions must not increase. After committing,
 pass the branch base revision instead of `HEAD`. Set `RUST_CODE_ANALYSIS` to an explicit tool path
 when it is not on `PATH`.
+
+### ClickHouse HTTP cancellation protocol gate
+
+The mandatory **ClickHouse protocol integration** CI job runs the production Rust
+HTTP client against three disposable ClickHouse **26.2.3.2** nodes through a transparent
+local gateway. It exercises schema validation and compression, cluster macro/discovery
+and process-probe decoding, and the real `get_signature_statuses` path with successful,
+missing, and failed transaction fixtures. Slow distributed queries test cancellation
+before response headers and after a decoded streaming row, including while distributed
+DDL is blocked. The before-headers fixture sets `wait_end_of_query=1` to hold its
+response; the streaming fixture uses deterministic hash text so compression produces
+enough wire bytes to decode an early row. These are test controls, not production
+setting changes. A paused replica must retain admission until observation recovers.
+Cancellation checks require prompt termination on all three nodes and a cancellation
+exception on the coordinator. A streaming leaf may instead report a socket reset or
+broken pipe while writing after its coordinator closes the native connection; other
+network errors and natural query completion fail the gate.
+
+Run the same gate locally with Docker and the normal Rust build prerequisites:
+
+```sh
+python3 scripts/test/test-clickhouse-http-disconnect.py --output /tmp/clickhouse-protocol
+```
+
+The output directory must not exist. The script builds the all-feature RPC test executable
+before starting the cluster; `--rust-test-binary /absolute/path/to/test-executable` reuses
+an existing build. The three Rust integration tests are ignored in ordinary unit-test runs
+because they require this disposable fixture; the dedicated CI job explicitly runs all
+three and fails if any are absent, skipped, or fail. Production validation and compression
+remain enabled. The fixture removes its own containers and network on exit and retains
+`report.json`, `rust-integration.log`, generated configuration, and container logs.
+
+Two gateway controls intentionally demonstrate incompatible behavior: retaining an upstream
+request after downstream disconnect, and forwarding queued work after two quiet process
+observations. These controls must fail the cancellation gate for the overall fixture to pass.
+The production gateway must promptly close the upstream connection and discard queued work
+when the caller disconnects. This local protocol gate does not replace the staged customer
+replay or prove the deployed gateway follows that contract.

--- a/tests/k6/README.md
+++ b/tests/k6/README.md
@@ -153,9 +153,8 @@ k6 run tests/k6/scenarios/performance/superbank-rpc-signature-statuses-misses.js
   --summary-export=/tmp/status-misses-summary.json
 ```
 
-The scenario cycles through the corpus in batches, preserving the same ordering
-across runs. With the default corpus size, keys repeat every 128 seconds. A corpus
-must contain at least one batch of distinct signatures; completed responses must
+The scenario consumes the corpus without reuse, preserving the same ordering
+across runs. A corpus must contain enough distinct signatures for the whole run; completed responses must
 contain exactly that many null statuses. The scenario checks base58 characters and
 length; fixture preparation must ensure signatures decode to 64 bytes and are absent.
 
@@ -168,6 +167,7 @@ length; fixture preparation must ensure signatures decode to 64 bytes and are ab
 | `MISS_TIMEOUT_MS` | `1000` | Actual k6 HTTP request timeout, in milliseconds |
 | `MISS_VUS` | rate × timeout, rounded up, plus 2 | Preallocated VUs; increase if iterations drop |
 | `MISS_RUN_LABEL` | `unspecified` | Metric label and JSON-RPC request-ID prefix |
+| `MISS_LOG_REQUESTS` | `false` | Emit safe per-request start/end JSON with IDs, timestamps, HTTP status and timeout result; no signatures |
 
 Compare baseline OR and candidate tuple-IN builds against the **same populated
 ClickHouse snapshot, corpus, settings, request rate, and client timeout**. Run each
@@ -187,7 +187,8 @@ or `clusterAllReplicas('test_cluster', system.query_log)` for a test cluster:
 SELECT hostName() AS node, query_id, initial_query_id, is_initial_query,
        toString(type) AS type, query_duration_ms,
        toUnixTimestamp64Milli(query_start_time_microseconds) AS started_at_ms,
-       ProfileEvents
+       toUnixTimestamp64Milli(event_time_microseconds) AS event_at_ms,
+       exception_code, ProfileEvents
 FROM system.query_log
 WHERE event_date = '2026-09-11'
   AND event_time >= '2026-09-11 12:00:00'
@@ -213,17 +214,54 @@ exports and externally established correlation, run the offline report:
 python3 scripts/test/report-signature-status-query-log.py /tmp/query-log.jsonl \
   --require-leaves --max-query-ms=5000 \
   --cancellations=/tmp/cancellations.jsonl \
-  --observed-until-ms=1789129860000 --cancellation-grace-ms=5000
+  --observed-until-ms=1789129860000 --cancellation-grace-ms=5000 \
+  --expected-nodes node1 node2 node3 \
+  --clock-bounds=/tmp/clock-bounds.json --count-manifest=/tmp/query-log-counts.json
 ```
 
-The report keeps coordinator and leaf CPU/duration distributions separate, checks
-observed query lifetimes, and checks whether each correlated execution ended within
-five seconds of the supplied abandonment time. It fails for missing start/terminal
-evidence, missing distributed leaves, incomplete collection intervals, or exceeded
-deadlines. Without cancellation correlation it still prints latency/CPU summaries
-but exits unsuccessfully with cancellation unverified. Collection must include all
-participating replicas; the report cannot detect an omitted server or fabricated
-correlation. No script issues database commands or production requests implicitly.
+The report keeps coordinator and leaf CPU/duration distributions separate. Valid
+`ExceptionBeforeStart` events need no `QueryStart`; started executions require a terminal event.
+Timing uses actual `event_at_ms` with independently measured clock bounds, not start plus duration.
+Supply clock offsets as node clock minus client clock, in milliseconds:
+
+```json
+{"node1":{"min_offset_ms":-20,"max_offset_ms":20}}
+```
+
+Include every expected node, even idle nodes, in both the clock file and count manifest.
+Independently count the same query-ID scope and time window after flushing query logs;
+include all four event types, including zero counts. `observed_until_ms` uses client time:
+
+```json
+{"node1":{"observed_until_ms":1789129860000,"counts":{"QueryStart":1,"QueryFinish":0,"ExceptionBeforeStart":0,"ExceptionWhileProcessing":1}}}
+```
+
+Incomplete coverage, mismatched counts, insufficient observation intervals, missing correlation,
+or uncertain clock bounds leave cancellation unverified and fail the gate. Successful natural
+`QueryFinish` establishes termination only. Disconnect cancellation requires a cancelled
+coordinator (394/735) and a 735 event in the correlated family, under a controlled test with no
+competing cancellation source. A replica's 735 can reflect closure of an internal native stream;
+it alone does not identify which external client caused it. Safe k6 start/end records help
+correlation but do not by themselves map requests to ClickHouse query IDs. Missing logs never
+prove cancellation. The reporter makes no network requests.
+
+Run the isolated disconnect fixture (Docker required):
+
+```bash
+python3 scripts/test/test-clickhouse-http-disconnect.py --output /tmp/ch-disconnect
+python3 -m unittest discover -s scripts/test -p 'test_report_signature_status_query_log.py'
+```
+
+It creates three local ClickHouse 26.2.3.2 nodes with Keeper and a proxy, checks cancellation
+before headers and during streaming, and repeats with distributed DDL blocked. Negative proxy
+controls must demonstrate that incompatible gateway behavior fails the acceptance contract.
+It removes its containers/network on exit and leaves evidence in the output directory.
+
+Promotion still requires the actual staging gateway, a populated full-retention snapshot,
+30 minutes at 256 fresh signatures / 2 RPS / 1-second client deadlines after cache warmup,
+complete coordinator/replica evidence, and bounded CPU and active-query counts. Verify read-only
+settings reach ClickHouse, upstream disconnects propagate, and no buffered request is forwarded
+after downstream abandonment. Local fixture success is not a production-performance result.
 
 ### Basic Load Test (`superbank-rpc-get-signatures.js`)
 

--- a/tests/k6/scenarios/performance/superbank-rpc-signature-statuses-misses.js
+++ b/tests/k6/scenarios/performance/superbank-rpc-signature-statuses-misses.js
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Replay a fixed, known-absent corpus. Client timeouts do not prove server cancellation.
+import http from 'k6/http';
+import exec from 'k6/execution';
+import { SharedArray } from 'k6/data';
+import { Counter, Rate, Trend } from 'k6/metrics';
+import { resolveOpenPath } from '../../lib/path.js';
+
+function positiveInteger(name, fallback) {
+  const value = Number(__ENV[name] || fallback);
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return value;
+}
+
+const batchSize = positiveInteger('MISS_BATCH_SIZE', 256);
+const rate = positiveInteger('MISS_RPS', 2);
+const timeoutMs = positiveInteger('MISS_TIMEOUT_MS', 1000);
+const duration = __ENV.MISS_DURATION || '30m';
+const runLabel = __ENV.MISS_RUN_LABEL || 'unspecified';
+const rpcUrl = __ENV.RPC_URL || 'http://localhost:8899';
+if (batchSize > 256) throw new Error('MISS_BATCH_SIZE must be at most 256');
+if (!__ENV.MISS_SIGNATURE_FILE) throw new Error('MISS_SIGNATURE_FILE is required');
+
+const signatures = new SharedArray('known absent signatures', () => {
+  const lines = open(resolveOpenPath(__ENV.MISS_SIGNATURE_FILE)).trim().split(/\s+/);
+  if (lines.length < batchSize || new Set(lines).size !== lines.length) {
+    throw new Error('The corpus must contain at least one batch of distinct signatures');
+  }
+  if (lines.some((signature) => !/^[1-9A-HJ-NP-Za-km-z]{64,88}$/.test(signature))) {
+    throw new Error('The corpus must contain base58 signatures, one per line');
+  }
+  return lines;
+});
+
+const requests = new Counter('status_miss_requests');
+const completedMisses = new Rate('status_miss_completed');
+const clientTimeouts = new Counter('status_miss_client_timeouts');
+const unexpectedResponses = new Counter('status_miss_unexpected_responses');
+const clientElapsed = new Trend('status_miss_client_elapsed_ms', true);
+
+export const options = {
+  scenarios: {
+    status_misses: {
+      executor: 'constant-arrival-rate',
+      rate,
+      timeUnit: '1s',
+      duration,
+      preAllocatedVUs: positiveInteger('MISS_VUS', Math.ceil(rate * timeoutMs / 1000) + 2),
+      gracefulStop: `${timeoutMs + 1000}ms`,
+    },
+  },
+  tags: { workload: 'signature_statuses_misses', run: runLabel },
+  thresholds: {
+    dropped_iterations: ['count==0'],
+    status_miss_requests: ['count>0'],
+    status_miss_unexpected_responses: ['count==0'],
+  },
+};
+
+function isCompleteMiss(response, requestId) {
+  if (response.status !== 200) return false;
+  try {
+    const body = response.json();
+    return body.jsonrpc === '2.0' && body.id === requestId && !body.error
+      && Array.isArray(body.result?.value) && body.result.value.length === batchSize
+      && body.result.value.every((status) => status === null);
+  } catch (_) {
+    return false;
+  }
+}
+
+export default function () {
+  const iteration = exec.scenario.iterationInTest;
+  const offset = iteration * batchSize;
+  if (offset + batchSize > signatures.length) {
+    exec.test.abort('Miss corpus exhausted; supply enough distinct signatures for the entire run');
+    return;
+  }
+  const batch = Array.from({ length: batchSize }, (_, index) => signatures[offset + index]);
+  const requestId = `${runLabel}:${iteration}`;
+  const started = Date.now();
+  const response = http.post(rpcUrl, JSON.stringify({
+    jsonrpc: '2.0', id: requestId, method: 'getSignatureStatuses',
+    params: [batch, { searchTransactionHistory: true }],
+  }), {
+    timeout: `${timeoutMs}ms`,
+    redirects: 0,
+    headers: { 'Content-Type': 'application/json' },
+    tags: { name: 'getSignatureStatuses known misses' },
+  });
+  const timedOut = response.error_code === 1050;
+  const complete = isCompleteMiss(response, requestId);
+  requests.add(1);
+  clientElapsed.add(Date.now() - started);
+  completedMisses.add(complete);
+  clientTimeouts.add(timedOut ? 1 : 0);
+  unexpectedResponses.add(!complete && !timedOut ? 1 : 0);
+}
+
+export function handleSummary(data) {
+  return { stdout: JSON.stringify({
+    workload: 'signature_statuses_misses', run: runLabel,
+    batchSize, corpusSize: signatures.length, rate, duration, timeoutMs,
+    cancellationVerified: false,
+    note: 'Timeouts are expected observations; inspect coordinator and leaf telemetry separately.',
+    metrics: data.metrics,
+  }, null, 2) + '\n' };
+}

--- a/tests/k6/scenarios/performance/superbank-rpc-signature-statuses-misses.js
+++ b/tests/k6/scenarios/performance/superbank-rpc-signature-statuses-misses.js
@@ -19,6 +19,7 @@ const rate = positiveInteger('MISS_RPS', 2);
 const timeoutMs = positiveInteger('MISS_TIMEOUT_MS', 1000);
 const duration = __ENV.MISS_DURATION || '30m';
 const runLabel = __ENV.MISS_RUN_LABEL || 'unspecified';
+const logRequests = __ENV.MISS_LOG_REQUESTS === 'true';
 const rpcUrl = __ENV.RPC_URL || 'http://localhost:8899';
 if (batchSize > 256) throw new Error('MISS_BATCH_SIZE must be at most 256');
 if (!__ENV.MISS_SIGNATURE_FILE) throw new Error('MISS_SIGNATURE_FILE is required');
@@ -81,6 +82,10 @@ export default function () {
   const batch = Array.from({ length: batchSize }, (_, index) => signatures[offset + index]);
   const requestId = `${runLabel}:${iteration}`;
   const started = Date.now();
+  if (logRequests) console.log(JSON.stringify({
+    event: 'status_miss_request_started', requestId, started_at_ms: started,
+    batchSize, corpusOffset: offset, timeoutMs,
+  }));
   const response = http.post(rpcUrl, JSON.stringify({
     jsonrpc: '2.0', id: requestId, method: 'getSignatureStatuses',
     params: [batch, { searchTransactionHistory: true }],
@@ -90,10 +95,15 @@ export default function () {
     headers: { 'Content-Type': 'application/json' },
     tags: { name: 'getSignatureStatuses known misses' },
   });
+  const ended = Date.now();
   const timedOut = response.error_code === 1050;
   const complete = isCompleteMiss(response, requestId);
+  if (logRequests) console.log(JSON.stringify({
+    event: 'status_miss_request_ended', requestId, started_at_ms: started, ended_at_ms: ended,
+    status: response.status, error_code: response.error_code || 0, timedOut, complete,
+  }));
   requests.add(1);
-  clientElapsed.add(Date.now() - started);
+  clientElapsed.add(ended - started);
   completedMisses.add(complete);
   clientTimeouts.add(timedOut ? 1 : 0);
   unexpectedResponses.add(!complete && !timedOut ? 1 : 0);


### PR DESCRIPTION
Fast negative disk-cache lookups can submit primary history queries before callers disconnect. This PR preserves the cache speedups while bounding primary `getSignatureStatuses` work and using native HTTP disconnect cancellation through the existing ClickHouse gateway.

- Check signature membership before local admission and recover signature indexes independently of address scans. Unknown filters remain conservative. Writer-overflow resets invalidate in-flight allocations so incomplete filters cannot be published as complete.
- Limit primary status workflows to four per RPC process and execution/index threads to two; disable hedging and parallel replicas. Admission and coordinator/leaf execution share one operation deadline. Multi-signature queries use tuple-IN filtering.
- Apply `readonly=2` and `cancel_http_readonly_queries_on_client_close=1` only to primary distributed HTTP status reads and verification. Abandoned reads retain their source permits until two complete observations find no matching coordinator or replica execution. Verification uses the gateway and `CLICKHOUSE_CLUSTER`, without direct application-to-node access or distributed DDL kills.
- Normalize discovery's scalar count to non-nullable UInt64 for the production Rust decoder. Initialization validates the actual process-inspection query before submitting source work. Failed or cancelled attempts share a one-second retry backoff; internal logs preserve the phase and SDK cause while external RPC errors remain unchanged.
- Add a non-optional CI job running the production Rust client with validation and compression enabled against three ClickHouse 26.2.3.2 nodes. The runner verifies all integration tests are present before creating the fixture.

**Configuration and limits**

Keep `GET_SIGNATURE_STATUSES_MAX_CONCURRENCY=4`, `GET_SIGNATURE_STATUSES_MAX_THREADS=2`, and `CLICKHOUSE_CLUSTER=rbx2` for RBX2. Cluster macros remain supported; an empty cluster selects standalone verification. No new runtime settings or cache-format migration are required. The application account needs access to the discovery/process tables and per-query settings across the configured replicas.

Unavailable verification retains admission; a topology change requires a process restart. The gateway must propagate upstream disconnects and discard buffered work after abandonment. Two absence observations cannot make a gateway that forwards abandoned requests later safe. Other methods, cache writes, and shard-direct/TCP cleanup retain their existing behavior.

**Validation**

- Workspace tests: 666 passed. RPC all-features: 549 passed, six ignored, including three explicitly run by the separate protocol gate; counts overlap.
- Formatting, workspace/all-feature Clippy, and the changed-function complexity gate passed (51 changed Rust functions). Both cache-overflow regressions failed before the fix and passed afterward.
- Initialization tests cover denied process inspection, concurrent retries, cancellation, permit release, and recovery. Offline query-log reporter: 29 tests passed.
- Basic k6 against the rebuilt RPC and an isolated ClickHouse 26.2.3.2 fixture: 1,788 successful responses, zero HTTP/RPC errors or timeouts.
- Real protocol gate: all three Rust integration tests passed, covering typed discovery/macros/process probes, known/missing/failed status results, four cancellation cases, and replica outage/recovery. All six HTTP controls passed their expected outcomes; positive disconnects drained in 115–229 ms, including blocked DDL, with zero KILL queries. Production validation/compression stayed enabled. A streaming leaf may report an explicit socket-reset/broken-pipe write error after coordinator cancellation; the local controlled test accepts only that narrow case, not arbitrary network failures.

**Staging acceptance remains open.** The previous staging replay failed discovery before submitting any source status queries. These fixes require a new build and replay through the deployed gateway: successful known-signature controls, cancellation before headers/during streaming, replica recovery, and 30 minutes of fresh 256-signature misses at 2 RPS with one-second deadlines after cache warmup. Require actual source execution, complete client/query correlation, coordinator/replica termination evidence, and bounded CPU/active queries. Local fixture results do not establish full-retention performance or deployed gateway compatibility.
