### PR TITLE
fix: serve historical inflation rewards and log final HTTP status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,3 +90,6 @@ jobs:
 
       - name: Test optional features (superbank-rpc)
         run: cargo test -p superbank-rpc --all-features --locked
+
+      - name: Test final HTTP status logs in isolation
+        run: cargo test -p superbank-rpc --all-features --locked http_response_logs_match_final_status -- --ignored --test-threads=1

--- a/crates/superbank-rpc/Cargo.toml
+++ b/crates/superbank-rpc/Cargo.toml
@@ -95,6 +95,7 @@ yellowstone-grpc-proto = { version = "12.6.0", optional = true }
 
 [dev-dependencies]
 base64 = "0.22"
+clickhouse = { version = "0.15", features = ["test-util"] }
 tempfile = "3"
 
 [build-dependencies]

--- a/crates/superbank-rpc/README.md
+++ b/crates/superbank-rpc/README.md
@@ -40,6 +40,8 @@ Notes:
   Missing rewards are returned as `null` only after the address's required partition is available.
   Dedicated address, concurrency, timeout, thread, memory, and read-byte limits are enabled by
   default.
+  Historical non-partitioned rewards do not require block height metadata. Partitioned rewards
+  still require it to locate payout blocks and determine reward availability.
 - Reward objects expose the optional Agave `commissionBps` field when the ingested source supplied
   it. Legacy rows ingested before the basis-point columns were deployed omit the field; Superbank
   does not infer it from the legacy percentage `commission` value.
@@ -222,6 +224,15 @@ eligible item promotes the whole HTTP response to `503`.
 For `getInflationReward`, both boundary-unavailable (`-32004`) and rewards-period-active (`-32017`)
 are data-condition errors and remain HTTP `200`; ClickHouse query, metadata, and integrity failures
 continue to use internal error (`-32603`) and are eligible for HTTP `503`.
+
+The `JSON-RPC HTTP response` log event reports the final envelope `status` after promotion,
+including batch responses, and `http_elapsed_ms`. It is emitted at INFO for server errors or
+slow responses and DEBUG otherwise. Per-method timing and slow-request logs use `handler_status`
+for the status before envelope promotion; that field is not the HTTP status seen by the client.
+For a mixed batch, successful items can have `handler_status=200` while the envelope has
+`status=503`. Queries for final HTTP status should select the envelope event. INFO logs omit fast successful
+responses and cannot provide a total-request denominator. Per-method request metrics continue
+to describe handler outcomes before envelope promotion.
 
 ## Optional gRPC head cache (`grpc-head-cache`)
 

--- a/crates/superbank-rpc/src/clickhouse/blocks.rs
+++ b/crates/superbank-rpc/src/clickhouse/blocks.rs
@@ -1269,14 +1269,6 @@ impl ClickHouseClient {
                 )));
             }
 
-            let boundary_block_height = boundary.block_height.ok_or_else(|| {
-                crate::metrics::inflation_reward_lookup("unknown", "invalid_boundary");
-                ProcessingError::database_msg(format!(
-                    "inflation reward boundary slot {} has no block height",
-                    boundary.slot
-                ))
-            })?;
-
             let num_partitions = match boundary.rewards_num_partitions {
                 Some(num_partitions) => {
                     let num_partitions = usize::try_from(num_partitions).map_err(|_| {
@@ -1400,6 +1392,14 @@ impl ClickHouseClient {
                     timings,
                 ));
             }
+
+            let boundary_block_height = boundary.block_height.ok_or_else(|| {
+                crate::metrics::inflation_reward_lookup("unknown", "invalid_boundary");
+                ProcessingError::database_msg(format!(
+                    "inflation reward boundary slot {} has no block height",
+                    boundary.slot
+                ))
+            })?;
 
             let num_partitions =
                 num_partitions.expect("partitioned boundary has a partition count");

--- a/crates/superbank-rpc/src/handlers/mod.rs
+++ b/crates/superbank-rpc/src/handlers/mod.rs
@@ -856,7 +856,7 @@ async fn dispatch_json_rpc_request(
         let elapsed_ms = start.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
         debug!(
             method = method.as_str(),
-            status = response.status().as_u16(),
+            handler_status = response.status().as_u16(),
             handler_elapsed_ms = elapsed_ms,
             downstream_elapsed_ms = Option::<u64>::None,
             response_overhead_ms = Option::<u64>::None,
@@ -873,7 +873,7 @@ async fn dispatch_json_rpc_request(
                         json_rpc_request_body_for_slow_log(request);
                     info!(
                         method = method.as_str(),
-                        status = response.status().as_u16(),
+                        handler_status = response.status().as_u16(),
                         handler_elapsed_ms = elapsed_ms,
                         downstream_elapsed_ms = Option::<u64>::None,
                         response_overhead_ms = Option::<u64>::None,
@@ -888,7 +888,7 @@ async fn dispatch_json_rpc_request(
                 None => {
                     info!(
                         method = method.as_str(),
-                        status = response.status().as_u16(),
+                        handler_status = response.status().as_u16(),
                         handler_elapsed_ms = elapsed_ms,
                         downstream_elapsed_ms = Option::<u64>::None,
                         response_overhead_ms = Option::<u64>::None,
@@ -1011,7 +1011,7 @@ async fn dispatch_json_rpc_request(
             }
             debug!(
                 method = method.as_str(),
-                status = status.as_u16(),
+                handler_status = status.as_u16(),
                 handler_elapsed_ms = elapsed_ms,
                 downstream_elapsed_ms = downstream_elapsed_ms,
                 response_overhead_ms = response_overhead_ms,
@@ -1028,7 +1028,7 @@ async fn dispatch_json_rpc_request(
                             json_rpc_request_body_for_slow_log(request);
                         info!(
                             method = method.as_str(),
-                            status = status.as_u16(),
+                            handler_status = status.as_u16(),
                             handler_elapsed_ms = elapsed_ms,
                             downstream_elapsed_ms = downstream_elapsed_ms,
                             response_overhead_ms = response_overhead_ms,
@@ -1043,7 +1043,7 @@ async fn dispatch_json_rpc_request(
                     None => {
                         info!(
                             method = method.as_str(),
-                            status = status.as_u16(),
+                            handler_status = status.as_u16(),
                             handler_elapsed_ms = elapsed_ms,
                             downstream_elapsed_ms = downstream_elapsed_ms,
                             response_overhead_ms = response_overhead_ms,
@@ -1059,7 +1059,7 @@ async fn dispatch_json_rpc_request(
         Err(_) => {
             debug!(
                 method = method.as_str(),
-                status = status.as_u16(),
+                handler_status = status.as_u16(),
                 handler_elapsed_ms = elapsed_ms,
                 downstream_elapsed_ms = Option::<u64>::None,
                 response_overhead_ms = Option::<u64>::None,
@@ -1076,7 +1076,7 @@ async fn dispatch_json_rpc_request(
                             json_rpc_request_body_for_slow_log(request);
                         info!(
                             method = method.as_str(),
-                            status = status.as_u16(),
+                            handler_status = status.as_u16(),
                             handler_elapsed_ms = elapsed_ms,
                             downstream_elapsed_ms = Option::<u64>::None,
                             response_overhead_ms = Option::<u64>::None,
@@ -1091,7 +1091,7 @@ async fn dispatch_json_rpc_request(
                     None => {
                         info!(
                             method = method.as_str(),
-                            status = status.as_u16(),
+                            handler_status = status.as_u16(),
                             handler_elapsed_ms = elapsed_ms,
                             downstream_elapsed_ms = Option::<u64>::None,
                             response_overhead_ms = Option::<u64>::None,
@@ -1311,12 +1311,13 @@ pub(crate) async fn handle_json_rpc_with_headers(
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<Response, StatusCode> {
+    let start = Instant::now();
     let emit_http_errors = state.emit_http_errors;
+    let labels = request_header_metric_labels(&headers, &state.metrics_header_capture);
+    let request_metric_labels = labels.clone();
     let response_header_metrics_context = Arc::new(ResponseHeaderMetricsContext::default());
-    let mut response =
+    let result =
         with_response_header_metrics_context(response_header_metrics_context.clone(), async move {
-            let request_metric_labels =
-                request_header_metric_labels(&headers, &state.metrics_header_capture);
             let payload = match serde_json::from_slice::<Value>(&body) {
                 Ok(payload) => payload,
                 Err(_) => {
@@ -1344,11 +1345,58 @@ pub(crate) async fn handle_json_rpc_with_headers(
                 )),
             }
         })
-        .await?;
+        .await;
 
-    response = promote_http_status_for_json_rpc_errors(response, emit_http_errors).await;
-    add_response_metrics_headers(&mut response, response_header_metrics_context.snapshot());
+    let result =
+        finalize_json_rpc_response(result, emit_http_errors, &response_header_metrics_context)
+            .await;
+    log_http_response(&result, start, &labels);
+    result
+}
+
+async fn finalize_json_rpc_response(
+    result: Result<Response, StatusCode>,
+    emit_http_errors: bool,
+    context: &ResponseHeaderMetricsContext,
+) -> Result<Response, StatusCode> {
+    let mut response = promote_http_status_for_json_rpc_errors(result?, emit_http_errors).await;
+    add_response_metrics_headers(&mut response, context.snapshot());
     Ok(response)
+}
+
+fn log_http_response(
+    result: &Result<Response, StatusCode>,
+    start: Instant,
+    labels: &metrics::RequestHeaderMetricLabels,
+) {
+    let status = match result {
+        Ok(response) => response.status(),
+        Err(status) => *status,
+    };
+    let elapsed_ms = start.elapsed().as_millis().min(u128::from(u64::MAX)) as u64;
+    // This event describes the whole HTTP envelope, including mixed batches and timeouts.
+    // Per-method events report handler_status before envelope-level status promotion.
+    if status.is_server_error() || elapsed_ms >= slow_rpc_threshold_ms() {
+        info!(
+            status = status.as_u16(),
+            http_elapsed_ms = elapsed_ms,
+            x_endpoint = labels.x_endpoint_for_logs(),
+            x_rpc_node = labels.x_rpc_node_for_logs(),
+            x_subscription_id = labels.x_subscription_id_for_logs(),
+            x_account_id = labels.x_account_id_for_logs(),
+            "JSON-RPC HTTP response"
+        );
+    } else {
+        debug!(
+            status = status.as_u16(),
+            http_elapsed_ms = elapsed_ms,
+            x_endpoint = labels.x_endpoint_for_logs(),
+            x_rpc_node = labels.x_rpc_node_for_logs(),
+            x_subscription_id = labels.x_subscription_id_for_logs(),
+            x_account_id = labels.x_account_id_for_logs(),
+            "JSON-RPC HTTP response"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/superbank-rpc/src/tests/http_response_logs.rs
+++ b/crates/superbank-rpc/src/tests/http_response_logs.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+/*
+ * Copyright 2025-2026 Triton One Limited. All rights reserved.
+ */
+
+use super::*;
+
+fn capture_response_logs(state: Arc<AppState>, request: &Value) -> (StatusCode, Vec<Value>) {
+    let log_buffer = SharedLogBuffer::default();
+    let subscriber = tracing_subscriber::fmt()
+        .json()
+        .with_max_level(tracing::Level::DEBUG)
+        .without_time()
+        .with_writer(log_buffer.clone())
+        .finish();
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let status = tracing::dispatcher::with_default(&tracing::Dispatch::new(subscriber), || {
+        tracing::callsite::rebuild_interest_cache();
+        runtime
+            .block_on(handle_json_rpc_value(state, request))
+            .status()
+    });
+    let logs = log_buffer
+        .snapshot()
+        .lines()
+        .map(|line| serde_json::from_str(line).expect("JSON log event"))
+        .collect();
+    (status, logs)
+}
+
+#[test]
+#[ignore = "run in isolation: tracing callsite cache can interfere under parallel test execution"]
+fn http_response_logs_match_final_status() {
+    let success = json!({"jsonrpc": "2.0", "id": 1, "method": "getEpochSchedule"});
+    let client_error = json!({"jsonrpc": "2.0", "id": 2, "method": "unknownMethod"});
+    let server_error = json!({"jsonrpc": "2.0", "id": 3, "method": "getInflationReward",
+        "params": [["11111111111111111111111111111111"], {"epoch": 43}]});
+    let cases = [
+        (false, server_error.clone(), StatusCode::OK),
+        (true, server_error.clone(), StatusCode::SERVICE_UNAVAILABLE),
+        (true, success.clone(), StatusCode::OK),
+        (true, client_error.clone(), StatusCode::OK),
+        (
+            true,
+            json!([success, server_error]),
+            StatusCode::SERVICE_UNAVAILABLE,
+        ),
+        (true, json!([client_error]), StatusCode::OK),
+        (true, json!([]), StatusCode::OK),
+    ];
+    for (enabled, request, expected) in cases {
+        let mut state = test_state();
+        Arc::get_mut(&mut state).unwrap().emit_http_errors = enabled;
+        // Force a server-side rejection without relying on a database or a timeout race.
+        let _permit = state
+            .get_inflation_reward_sem
+            .as_ref()
+            .unwrap()
+            .clone()
+            .try_acquire_owned()
+            .unwrap();
+        let (status, events) = capture_response_logs(state, &request);
+        assert_eq!(status, expected);
+        let envelopes: Vec<_> = events
+            .iter()
+            .filter(|event| event["fields"]["message"] == "JSON-RPC HTTP response")
+            .collect();
+        assert_eq!(envelopes.len(), 1, "{events:?}");
+        assert_eq!(envelopes[0]["fields"]["status"], expected.as_u16());
+        for event in events
+            .iter()
+            .filter(|event| event["fields"].get("method").is_some())
+        {
+            assert!(event["fields"].get("status").is_none(), "{event}");
+            assert!(event["fields"].get("handler_status").is_some(), "{event}");
+        }
+    }
+}

--- a/crates/superbank-rpc/src/tests/inflation_rewards.rs
+++ b/crates/superbank-rpc/src/tests/inflation_rewards.rs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+/*
+ * Copyright 2025-2026 Triton One Limited. All rights reserved.
+ */
+
+use super::*;
+use clickhouse::test::{Mock, handlers};
+use serde::Serialize;
+use serde_big_array::Array;
+
+#[derive(Serialize, clickhouse::Row)]
+struct Boundary {
+    slot: u64,
+    parent_slot: u64,
+    parent_blockhash: Array<u8, 32>,
+    block_height: Option<u64>,
+    rewards_num_partitions: Option<u64>,
+}
+
+#[derive(Serialize, clickhouse::Row)]
+struct Reward {
+    pubkey: Array<u8, 32>,
+    effective_slot: u64,
+    lamports: i64,
+    post_balance: u64,
+    commission: Option<u8>,
+    commission_bps: Option<u16>,
+}
+
+fn boundary(partitions: Option<u64>) -> Boundary {
+    Boundary {
+        slot: 19_008_000,
+        parent_slot: 19_007_999,
+        parent_blockhash: Array([1; 32]),
+        block_height: None,
+        rewards_num_partitions: partitions,
+    }
+}
+
+fn request() -> Value {
+    let address = crate::solana_sdk::pubkey::Pubkey::new_from_array([2; 32]).to_string();
+    let missing = crate::solana_sdk::pubkey::Pubkey::new_from_array([3; 32]).to_string();
+    json!({"jsonrpc": "2.0", "id": 1, "method": "getInflationReward",
+        "params": [[address, missing, address], {"epoch": 43}]})
+}
+
+#[tokio::test]
+async fn non_partitioned_rewards_do_not_require_block_height() {
+    let mock = Mock::new();
+    mock.add(handlers::provide([boundary(None)]));
+    mock.add(handlers::provide([Reward {
+        pubkey: Array([2; 32]),
+        effective_slot: 19_008_000,
+        lamports: 42,
+        post_balance: 100,
+        commission: None,
+        commission_bps: None,
+    }]));
+    let state = test_state_with_emit_http_errors(test_state_with_clickhouse_url(mock.url()));
+    let response = handle_json_rpc_value(state, &request()).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = parse_json_value_response(response).await;
+    let reward = json!({"epoch": 43, "effectiveSlot": 19_008_000,
+        "amount": 42, "postBalance": 100, "commission": null});
+    assert_eq!(
+        body,
+        json!({"jsonrpc": "2.0", "id": 1,
+        "result": [reward, null, reward]})
+    );
+}
+
+#[tokio::test]
+async fn partitioned_rewards_still_require_block_height() {
+    let mock = Mock::new();
+    mock.add(handlers::provide([boundary(Some(1))]));
+    mock.add(handlers::provide(Vec::<Reward>::new()));
+    let state = test_state_with_emit_http_errors(test_state_with_clickhouse_url(mock.url()));
+    let response = handle_json_rpc_value(state, &request()).await;
+    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let body = parse_json_value_response(response).await;
+    assert_eq!(body["error"]["code"], -32603);
+}

--- a/crates/superbank-rpc/src/tests/mod.rs
+++ b/crates/superbank-rpc/src/tests/mod.rs
@@ -4,6 +4,8 @@
  */
 
 use crate::solana_sdk;
+mod http_response_logs;
+mod inflation_rewards;
 use crate::solana_sdk::{
     hash::Hash,
     instruction::InstructionError,


### PR DESCRIPTION
Historical `getInflationReward` requests can return internal errors (HTTP 503 when enabled) when a non-partitioned payout boundary lacks block height. Move the height requirement after the non-partitioned return; partitioned reward integrity checks remain enforced. The regression fixture returns rewards in request order, preserves duplicate addresses, and returns null for an address without rewards.

Request logs previously recorded `status=200` before the outer handler promoted the response to 503. Rename the per-method field to `handler_status` and emit a `JSON-RPC HTTP response` event with the final envelope `status`, including mixed batches. Server errors and slow responses log at INFO; other responses log at DEBUG. Document the query migration and that INFO logs cannot provide a total-request denominator. Per-method Prometheus metrics retain their existing handler-level semantics.

Validation:
- Historical-reward regression fails on the original code (503 instead of 200) and passes with the fix; partitioned missing-height regression passes.
- RPC default suite: 386 passed; all-feature suite: 504 passed. Logging regression separately passes in isolation and is explicitly run by CI.
- All-feature/all-target RPC Clippy with warnings denied, formatting, and changed-function cyclomatic complexity gate pass.
- Local ClickHouse 26.3 with repository DDL: historical fixture returns HTTP 200 with the reward; partitioned missing-height fixture returns 503 and logs final `status=503`.
- Basic k6 signature-status smoke against the local RPC: 16,029 iterations, zero failures (1 VU, 5 seconds). This checks local behavior, not production performance or incident recovery.

Related: BLO-554
