### PR TITLE
fix(rpc): preserve getTransaction fallback on disk-cache failures

### DIFF
--- a/GETTRANSACTION_BENCHMARKS.md
+++ b/GETTRANSACTION_BENCHMARKS.md
@@ -1,0 +1,142 @@
+# getTransaction follow-up: correctness and local measurements
+
+These changes preserve the existing ClickHouse schemas, cache format, and retention
+settings. Measurements below use isolated synthetic fixtures.
+
+## Implemented
+
+- Disk transaction reads distinguish found, definitive absence, and unavailable.
+  A timeout or database failure cannot become null merely because a separate coverage
+  query succeeds. Coverage checks share the read deadline and generation validation.
+- A slot must already be covered when the signature search begins before a successful
+  miss can prove absence there. Ordinary appends need not change the epoch, so this
+  separately prevents a coverage-publication race.
+- An index entry with an unavailable payload falls back to primary. Successful
+  pinned-slot misses and skipped slots retain null semantics; unpinned misses fall back.
+- Disk payload reads retain `slot_idx`, sharing the existing primary position lookup
+  and its slot-only stale/legacy fallback. One admission permit covers payload retries.
+  Payload ownership passes directly into the existing hydration path.
+
+No new persistent index, retention extension, cache format, or production setting is
+introduced. The existing primary two-request route remains enabled.
+
+## Benchmark method
+
+Run `python3 scripts/test/benchmark-get-transaction.py --output /tmp/gettx-benchmark`.
+The script creates and removes its own three-node ClickHouse 26.2.3.2 Docker cluster,
+with a transparent local TCP gateway, two CPUs and 8 GiB per node. The initial 2 GiB
+fixture limit failed during ingestion and is not a performance result.
+
+Each payload copy contains three million deterministic synthetic transactions across
+six slot partitions, with signature distribution independent of payload distribution.
+The repository schema and complete transaction projection are used. Payload logs vary
+in size; this is not a sample of production payload distributions. The copies differ
+only in `index_granularity` (8192/1024); `index_granularity_bytes=10485760` and codecs
+are held constant. Ingestion uses 50,000-row batches; both copies maintain equivalent signature materialized
+views. Both payload copies are merged
+before lookup measurements; merge logs and part footprints are retained.
+
+Five runs alternate variant order over the same 50 seeded signatures. Each variant
+has 250 warm and 250 ClickHouse-cache-cleared observations. Cache-cleared means mark
+and uncompressed caches were dropped before each lookup; filesystem caches are
+uncontrolled. Query-result caching is disabled. Full RowBinary payload digests must
+match; the two-request baseline decodes the returned position before its payload query.
+
+HTTP measurements include local gateway/client overhead but exclude Rust admission,
+hydration, and serialization. Logical bytes are not physical I/O. Coordinator CPU
+counters are recorded separately and do not establish total cluster CPU. The optional
+per-request delay and the 100 ms RTT arithmetic model are not measurements of a deployed network.
+
+## Gateway decision
+
+The tested scalar-array SQL candidate resolves a signature and fetches the positioned
+payload in one request. Its result contract fails the stale-position prerequisite:
+an absent signature and an existing signature with a stale position both return an
+empty body, while a slot-only payload lookup still finds the latter transaction.
+Integrating this query as written would either lose the existing fallback or repeat
+signature resolution on empty results. It is therefore **not integrated**.
+
+This rejects the tested candidate, not every possible single-query design. A future
+candidate must return enough position/absence information to preserve fallback and
+then pass pruning, repeated-resolution, cancellation, admission, and performance gates.
+Candidate-specific cancellation and activation work stops at this failed correctness
+gate. The existing cancellation protocol suite was run as a regression check;
+it is not proof of getTransaction cancellation through the deployed gateway.
+
+## Results
+
+[Machine-readable results](docs/benchmarks/gettransaction-2026-09-11.json) include
+plans, settings, merge/part measurements and the raw-report checksum. The raw report is retained locally; rerun the script to generate the complete query telemetry. All 2,500 observations have terminal
+query telemetry, no query errors, and matching full payload digests.
+
+Client times are milliseconds. Read counts are per logical lookup; the two-request
+baseline includes both signature and payload queries.
+
+| Variant | Warm p50 | Warm p95 | Cache-cleared p95 | Mean logical rows | Mean logical MiB |
+|---|---:|---:|---:|---:|---:|
+| Slot only, 8192 | 17.5 | 22.6 | 26.6 | 16,417 | 5.39 |
+| Full position, 8192 | 16.4 | 20.2 | 25.3 | 8,684 | 5.45 |
+| Full position, 1024 | 13.6 | 17.2 | 19.9 | 1,597 | 0.66 |
+| Two gateway requests | 22.5 | 30.7 | 27.4 | 9,209 | 5.49 |
+| Combined SQL candidate | 20.8 | 25.5 | 26.9 | 9,207 | 5.49 |
+
+Full-position lookup reduced logical row accounting but did not materially reduce
+payload bytes at granularity 8192. Its local tail-latency improvement is modest and
+was sensitive to run conditions in exploratory measurements. This does not establish
+a deployed p99 improvement.
+
+Granularity 1024 reduced logical payload bytes by **87.9%** relative to the 8192
+full-position query; warm p95 fell from **20.2 to 17.2 ms**. The local EXPLAIN plans
+include the owning shard and prune to one of its two payload parts. This is useful
+query-shape evidence, not a production sizing or rollout gate.
+
+Across all three nodes, active payload parts occupied **1,011,149,892 bytes** at 8192
+and **1,011,903,737 bytes** at 1024: **+0.075%** in this synthetic dataset. Mark bytes
+rose from **138,365 to 405,580** (~2.9x); reported primary-key memory rose from
+**3,408 to 23,568 bytes** (~6.9x). These small, compressed indexes do not establish
+full-retention memory requirements.
+
+Both ingestion paths maintained equivalent signature views. Three million payload
+rows took **19.4 s** at 8192 versus **22.8 s** at 1024, including per-batch footprint
+sampling. This is one sequential ingestion trial, not a steady-state throughput
+conclusion. Successful payload merge durations summed across nodes were **12.15 s**
+and **11.07 s** respectively; background scheduling prevents a causal merge-speed claim.
+
+Parts awaiting deletion matter for the 2 TB budget: each payload copy still occupied
+about **2.63 GB including inactive parts**, versus about **1.01 GB active**. Sampling
+during ingestion observed **6.19 GB** across both payload and signature copies.
+These are observed footprints, not a guaranteed peak bound. Keep merge/deletion
+headroom; the small active-size delta does not justify filling production disks.
+
+The combined candidate returned zero bytes for both the missing-signature and stale
+position fixtures; slot-only fallback returned the existing **804-byte** payload.
+It therefore fails correctness before performance/cancellation acceptance. Its warm
+p95 was 25.5 ms versus 30.7 ms for two requests, but coordinator CPU counters increased
+~6.6% in cache-cleared measurements and there is no production gateway validation.
+The saved-round-trip sensitivity model is not an adoption result.
+
+**Decision:** retain the two cache fixes. Keep gateway consolidation and granularity
+changes experimental; change neither production routing nor production table settings.
+
+
+## Validation
+
+- `cargo fmt --all -- --check` and both workspace/all-feature RPC Clippy commands passed.
+- `cargo test --workspace --locked`: 666 passed; four opt-in tests ignored.
+- `cargo test -p superbank-rpc --all-features --locked`: 551 passed; six opt-in tests ignored.
+- Explicit disk-cache integration passed, including covered-slot admission timeout,
+  unavailable payload table, in-flight invalidation, concurrent append/coverage,
+  skipped/uncovered slots, pinned mismatch, and stale position fallback.
+- ClickHouse protocol fixture passed, including three production Rust integrations,
+  positive disconnect cases and negative gateway controls.
+- Basic k6 on the final build: 1,244 requests, no failures, over ten seconds.
+- HTTP transaction parity on the final build: 1,041 full-envelope comparisons and
+  1,122 passing checks over 2,122 HTTP requests. The corpus included legacy/v0/v1,
+  a 32 KiB metadata log, all encodings, version errors and request-ID variants.
+  RPC metrics confirmed disk-cache serving of present transactions.
+- The scoped complexity gate passed for all 25 changed/new Rust functions against
+  `89d47aac`: new functions <=10 McCabe; existing functions did not increase.
+
+The benchmark and RPC fixtures are local. Deployed RPC latency, deployed-gateway
+cancellation, full-retention performance and production granularity sizing remain
+unvalidated. These local checks do not validate a deployment.

--- a/crates/superbank-rpc/README.md
+++ b/crates/superbank-rpc/README.md
@@ -427,6 +427,13 @@ ClickHouse instance and pausing its RPC task, an operator can remove the remaini
 (substitute the configured cache database). This deletes the remaining cache data; restart RPC
 to recreate and refill it. Do not recreate an ownership marker over unidentified tables.
 
+`getTransaction` retains the cached `(slot, slot_idx)` for payload lookup, with a
+slot-only retry for stale/legacy positions. A pinned-slot null requires a successful
+signature miss and coverage valid throughout the attempt. Admission timeouts, query
+errors, invalidation, and slots first covered during the lookup fall back to the primary.
+An index entry whose payload is unavailable also falls back. Cache format and retention
+are unchanged.
+
 The `superbank_disk_cache_reads_total` outcomes distinguish misses, query errors, and timeouts.
 `superbank_disk_cache_key_seconds` records complete attempts, admission waits, and index builds;
 `superbank_disk_cache_key_index_bytes` reports reserved index memory, and

--- a/crates/superbank-rpc/src/clickhouse/transactions.rs
+++ b/crates/superbank-rpc/src/clickhouse/transactions.rs
@@ -547,100 +547,147 @@ impl ClickHouseClient {
             let Some(position) = slot_opt else {
                 return Ok((None, timings));
             };
-            let slot = position.slot;
-            let slot_idx = position.slot_idx;
             let _http_permit = self.acquire_http_query_permit().await?;
-
-            let build_query = |table: &str, slot_idx: Option<u32>, settings_clause: &str| {
-                build_get_transaction_by_signature_query(
-                    table,
-                    &signature_literal,
-                    slot,
-                    slot_idx,
-                    settings_clause,
-                )
-            };
-
-            let (mut row_opt, query_timings, used_local) = if self.scope_shard_direct()
-                && self.transport_http()
-                && let (Some(topology), Some(local_table)) =
-                    (&self.shard_topology, &self.transactions_local_table)
-            {
-                let shard = topology.shard_for_hash(slot / SLOT_SHARD_DIVISOR);
-                let settings_clause = topology.get_transaction_settings_clause(
-                    "get_transaction_by_signature_local_http",
-                    QueryFreshnessClass::Historical,
-                );
-                let query = build_query(local_table, Some(slot_idx), &settings_clause);
-
-                match fetch_single_transaction_row(&shard.http_client, &query).await {
-                    Ok(result) => (result.0, result.1, true),
-                    Err(err) => {
-                        if transient_shard_local_error_reason(&err).is_some() {
-                            topology.failover_from(&shard);
-                        }
-                        tracing::warn!(
-                            "Shard {}:{} HTTP query failed; falling back to distributed table: {}",
-                            shard.host,
-                            shard.tcp_port,
-                            err
-                        );
-                        let settings_clause = self.select_get_transaction_settings_clause(
-                            "get_transaction_by_signature_fallback_distributed",
-                            QueryFreshnessClass::Historical,
-                        );
-                        let query =
-                            build_query(&self.transaction_table, Some(slot_idx), &settings_clause);
-                        let result = self.fetch_transaction_lookup(&query).await?;
-                        (result.0, result.1, false)
-                    }
-                }
-            } else {
-                let settings_clause = self.select_get_transaction_settings_clause(
-                    "get_transaction_by_signature_distributed",
-                    QueryFreshnessClass::Historical,
-                );
-                let query = build_query(&self.transaction_table, Some(slot_idx), &settings_clause);
-                let result = self.fetch_transaction_lookup(&query).await?;
-                (result.0, result.1, false)
-            };
-            timings.add(query_timings);
-
-            if used_local && row_opt.is_none() {
-                // The shard-local table is expected to contain the same data as the distributed table,
-                // but fall back to the distributed table to avoid false negatives if local data is
-                // incomplete (e.g. during backfills or replication lag).
-                let settings_clause = self.select_get_transaction_settings_clause(
-                    "get_transaction_by_signature_distributed_retry",
-                    QueryFreshnessClass::Historical,
-                );
-                let query = build_query(&self.transaction_table, Some(slot_idx), &settings_clause);
-                let (fallback_opt, fallback_timings) =
-                    self.fetch_transaction_lookup(&query).await?;
-                timings.add(fallback_timings);
-                row_opt = fallback_opt;
-            }
-
-            if row_opt.is_none() {
-                // Fall back to the legacy query that doesn't require slot_idx to match.
-                let settings_clause = self.select_get_transaction_settings_clause(
-                    "get_transaction_by_signature_legacy_fallback",
-                    QueryFreshnessClass::Historical,
-                );
-                let query = build_query(&self.transaction_table, None, &settings_clause);
-                let (fallback_opt, fallback_timings) =
-                    self.fetch_transaction_lookup(&query).await?;
-                timings.add(fallback_timings);
-                row_opt = fallback_opt;
-            }
-
-            let Some(row) = row_opt else {
-                return Ok((None, timings));
-            };
-
-            Ok((Some(map_transaction_row(row)), timings))
+            let (record, payload_timings) = self
+                .fetch_transaction_at_position(&signature_literal, position)
+                .await?;
+            timings.add(payload_timings);
+            Ok((record, timings))
         })
         .await
+    }
+
+    /// Read an already resolved position without another signature lookup.
+    /// Admission and all position/legacy attempts share one operation deadline.
+    #[cfg(feature = "disk-cache")]
+    pub(crate) async fn get_transaction_by_signature_and_position(
+        &self,
+        signature: &str,
+        position: SignatureSlot,
+    ) -> ProcessingResult<(Option<StoredTransactionRecord>, QueryTimings)> {
+        self.with_http_query_timeout("get_transaction_by_signature_and_position", async {
+            let (_, literal) = decode_transaction_signature(signature)?;
+            self.fetch_transaction_at_position(&literal, position).await
+        })
+        .await
+    }
+
+    // The caller owns HTTP admission and the operation deadline.
+    async fn fetch_transaction_at_position(
+        &self,
+        signature_literal: &str,
+        position: SignatureSlot,
+    ) -> ProcessingResult<(Option<StoredTransactionRecord>, QueryTimings)> {
+        let slot = position.slot;
+        let slot_idx = position.slot_idx;
+
+        let build_query = |table: &str, slot_idx: Option<u32>, settings_clause: &str| {
+            build_get_transaction_by_signature_query(
+                table,
+                signature_literal,
+                slot,
+                slot_idx,
+                settings_clause,
+            )
+        };
+
+        let (mut row_opt, mut timings, used_local) = self
+            .fetch_first_transaction_position(signature_literal, position)
+            .await?;
+
+        if used_local && row_opt.is_none() {
+            // The shard-local table is expected to contain the same data as the distributed table,
+            // but fall back to the distributed table to avoid false negatives if local data is
+            // incomplete (e.g. during backfills or replication lag).
+            let settings_clause = self.select_get_transaction_settings_clause(
+                "get_transaction_by_signature_distributed_retry",
+                QueryFreshnessClass::Historical,
+            );
+            let query = build_query(&self.transaction_table, Some(slot_idx), &settings_clause);
+            let (fallback_opt, fallback_timings) = self.fetch_transaction_lookup(&query).await?;
+            timings.add(fallback_timings);
+            row_opt = fallback_opt;
+        }
+
+        if row_opt.is_none() {
+            // Fall back to the legacy query that doesn't require slot_idx to match.
+            let settings_clause = self.select_get_transaction_settings_clause(
+                "get_transaction_by_signature_legacy_fallback",
+                QueryFreshnessClass::Historical,
+            );
+            let query = build_query(&self.transaction_table, None, &settings_clause);
+            let (fallback_opt, fallback_timings) = self.fetch_transaction_lookup(&query).await?;
+            timings.add(fallback_timings);
+            row_opt = fallback_opt;
+        }
+
+        let Some(row) = row_opt else {
+            return Ok((None, timings));
+        };
+
+        Ok((Some(map_transaction_row(row)), timings))
+    }
+
+    async fn fetch_first_transaction_position(
+        &self,
+        signature_literal: &str,
+        position: SignatureSlot,
+    ) -> ProcessingResult<(Option<TransactionRow>, QueryTimings, bool)> {
+        let slot = position.slot;
+        let slot_idx = position.slot_idx;
+        let build_query = |table: &str, slot_idx: Option<u32>, settings_clause: &str| {
+            build_get_transaction_by_signature_query(
+                table,
+                signature_literal,
+                slot,
+                slot_idx,
+                settings_clause,
+            )
+        };
+        let result = if self.scope_shard_direct()
+            && self.transport_http()
+            && let (Some(topology), Some(local_table)) =
+                (&self.shard_topology, &self.transactions_local_table)
+        {
+            let shard = topology.shard_for_hash(slot / SLOT_SHARD_DIVISOR);
+            let settings_clause = topology.get_transaction_settings_clause(
+                "get_transaction_by_signature_local_http",
+                QueryFreshnessClass::Historical,
+            );
+            let query = build_query(local_table, Some(slot_idx), &settings_clause);
+
+            match fetch_single_transaction_row(&shard.http_client, &query).await {
+                Ok(result) => (result.0, result.1, true),
+                Err(err) => {
+                    if transient_shard_local_error_reason(&err).is_some() {
+                        topology.failover_from(&shard);
+                    }
+                    tracing::warn!(
+                        "Shard {}:{} HTTP query failed; falling back to distributed table: {}",
+                        shard.host,
+                        shard.tcp_port,
+                        err
+                    );
+                    let settings_clause = self.select_get_transaction_settings_clause(
+                        "get_transaction_by_signature_fallback_distributed",
+                        QueryFreshnessClass::Historical,
+                    );
+                    let query =
+                        build_query(&self.transaction_table, Some(slot_idx), &settings_clause);
+                    let result = self.fetch_transaction_lookup(&query).await?;
+                    (result.0, result.1, false)
+                }
+            }
+        } else {
+            let settings_clause = self.select_get_transaction_settings_clause(
+                "get_transaction_by_signature_distributed",
+                QueryFreshnessClass::Historical,
+            );
+            let query = build_query(&self.transaction_table, Some(slot_idx), &settings_clause);
+            let result = self.fetch_transaction_lookup(&query).await?;
+            (result.0, result.1, false)
+        };
+        Ok(result)
     }
 
     pub async fn get_transaction_by_signature_and_slot(

--- a/crates/superbank-rpc/src/disk_cache/key_reads.rs
+++ b/crates/superbank-rpc/src/disk_cache/key_reads.rs
@@ -1,19 +1,21 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 //! Ordered, partition-scoped reads under one cache-attempt deadline.
 use super::{
-    DiskCache, DiskGsfaPage, DiskSigStatus, clamp_until_to_floor,
+    DiskCache, DiskGsfaPage, DiskSigStatus, DiskTransactionResult, SlotStatus,
+    clamp_until_to_floor,
     index::DiskTfaQuery,
     key_index::{Family, SignatureCandidates, SignatureHash},
     lower_bound_reaches_floor, upper_bound_reaches_tip,
 };
 use crate::clickhouse::{
     ClickHouseClient, NumericFilter, PaginationToken, SignatureRecord, SignatureSlot, SlotBoundary,
-    SortOrder, StoredTransactionRecord, TokenAccountsFilter, TransactionsForAddressQuery,
+    SortOrder, TokenAccountsFilter, TransactionsForAddressQuery,
 };
 use crate::processing::{ProcessingError, ProcessingResult};
 use crate::solana_sdk::{pubkey::Pubkey, signature::Signature};
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
+use std::sync::Arc;
 use tokio::time::Instant;
 
 // Slot bounds are conservative for position cursors: SQL resolves the index
@@ -108,6 +110,31 @@ impl Read {
             return Err(ProcessingError::timeout_msg("disk cache deadline exceeded"));
         }
         Ok(())
+    }
+}
+fn transaction_outcome(
+    result: Result<ProcessingResult<DiskTransactionResult>, tokio::time::error::Elapsed>,
+    valid: bool,
+) -> (DiskTransactionResult, &'static str) {
+    match result {
+        Ok(Ok(value)) if valid => {
+            let outcome = if matches!(value, DiskTransactionResult::Found(_)) {
+                "hit"
+            } else {
+                "miss"
+            };
+            (value, outcome)
+        }
+        Ok(Ok(_)) => (DiskTransactionResult::Unavailable, "miss"),
+        Ok(Err(ProcessingError::Timeout { .. })) | Err(_) => {
+            (DiskTransactionResult::Unavailable, "timeout")
+        }
+        Ok(Err(ProcessingError::Database { context, .. }))
+            if context.contains("TIMEOUT_EXCEEDED") =>
+        {
+            (DiskTransactionResult::Unavailable, "timeout")
+        }
+        Ok(Err(_)) => (DiskTransactionResult::Unavailable, "error"),
     }
 }
 impl DiskCache {
@@ -238,23 +265,61 @@ impl DiskCache {
         )
         .await
     }
-    pub(crate) async fn get_tx(&self, signature: Signature) -> Option<StoredTransactionRecord> {
-        let read = self.read()?;
-        self.attempt("get_tx", &read, async {
-            let Some(position) = self.find_position(signature, &read).await? else {
-                return Ok(None);
-            };
+    pub(crate) async fn get_tx(
+        &self,
+        signature: Signature,
+        requested_slot: Option<u64>,
+    ) -> DiskTransactionResult {
+        let Some(read) = self.read() else {
+            return DiskTransactionResult::Unavailable;
+        };
+        let started = Instant::now();
+        let result = tokio::time::timeout_at(
+            read.deadline,
+            self.read_transaction(signature, requested_slot, &read),
+        )
+        .await;
+        let (value, outcome) = transaction_outcome(result, self.valid_read(&read));
+        crate::metrics::disk_cache_read("get_tx", outcome);
+        crate::metrics::disk_cache_key_seconds("get_tx", outcome, started.elapsed().as_secs_f64());
+        value
+    }
+
+    async fn read_transaction(
+        &self,
+        signature: Signature,
+        requested_slot: Option<u64>,
+        read: &Read,
+    ) -> ProcessingResult<DiskTransactionResult> {
+        // Appends need not invalidate the epoch. A slot published after the
+        // signature search began cannot turn that earlier miss into proof.
+        let covered_slot = requested_slot.filter(|slot| self.covers_slot(*slot));
+        if let Some(position) = self.find_position(signature, read).await? {
             let client = self.scoped_client(
                 &self.query_client(),
                 position.slot / self.inner.cfg.partition_slots,
-                &read,
+                read,
             );
             let (record, _) = client
-                .get_transaction_by_signature_and_slot(&signature.to_string(), position.slot)
+                .get_transaction_by_signature_and_position(&signature.to_string(), position)
                 .await?;
-            Ok(record.filter(|record| self.covers_slot(record.slot)))
-        })
-        .await
+            // An index entry without its payload is inconsistent, not proof of absence.
+            return Ok(
+                match record.filter(|record| self.covers_slot(record.slot)) {
+                    Some(record) => DiskTransactionResult::Found(Arc::new(record)),
+                    None => DiskTransactionResult::Unavailable,
+                },
+            );
+        }
+        if let Some(slot) = covered_slot
+            && matches!(
+                self.slot_status(slot).await,
+                SlotStatus::Covered { .. } | SlotStatus::Skipped
+            )
+        {
+            return Ok(DiskTransactionResult::Absent);
+        }
+        Ok(DiskTransactionResult::Unavailable)
     }
     pub(crate) async fn get_sig_statuses(
         &self,
@@ -527,6 +592,26 @@ impl DiskCache {
 mod window_tests {
     use super::*;
     use crate::clickhouse::{ResolvedSignatureFilter, TransactionStatusFilter};
+
+    #[test]
+    fn invalidated_absence_is_unavailable() {
+        let (value, _) = transaction_outcome(Ok(Ok(DiskTransactionResult::Absent)), false);
+        assert!(matches!(value, DiskTransactionResult::Unavailable));
+        let (value, _) = transaction_outcome(Ok(Ok(DiskTransactionResult::Absent)), true);
+        assert!(matches!(value, DiskTransactionResult::Absent));
+    }
+
+    #[test]
+    fn transaction_errors_never_prove_absence() {
+        for error in [
+            ProcessingError::timeout_msg("admission"),
+            ProcessingError::database_msg("TIMEOUT_EXCEEDED"),
+            ProcessingError::database_msg("unavailable table"),
+        ] {
+            let (value, _) = transaction_outcome(Ok(Err(error)), true);
+            assert!(matches!(value, DiskTransactionResult::Unavailable));
+        }
+    }
 
     #[test]
     fn gsfa_cursors_skip_newer_partitions_and_preserve_boundary_slots() {

--- a/crates/superbank-rpc/src/disk_cache/key_tests.rs
+++ b/crates/superbank-rpc/src/disk_cache/key_tests.rs
@@ -4,6 +4,13 @@ use super::*;
 use crate::clickhouse::{NumericFilter, SortOrder, TransactionStatusFilter};
 use crate::solana_sdk::{pubkey::Pubkey, signature::Signature};
 
+fn found_transaction(result: DiskTransactionResult) -> Arc<StoredTransactionRecord> {
+    match result {
+        DiskTransactionResult::Found(record) => record,
+        other => panic!("expected transaction, got {other:?}"),
+    }
+}
+
 fn signature(slot: u64) -> Signature {
     named_signature("sig", slot)
 }
@@ -26,11 +33,179 @@ fn signature_candidate(cache: &DiskCache, partition: u64, signature: Signature) 
         .is_empty()
 }
 
+async fn transaction_response(
+    source: &ClickHouseClient,
+    cache: Option<&DiskCache>,
+    signature: Signature,
+    config: serde_json::Value,
+) -> serde_json::Value {
+    let mut state = Arc::try_unwrap(crate::tests::test_state()).ok().unwrap();
+    state.clickhouse = source.clone();
+    state.disk_cache = cache.map(|cache| {
+        Arc::new(tokio::sync::OnceCell::new_with(Some(Arc::new(
+            cache.clone(),
+        ))))
+    });
+    let response = Box::pin(crate::handlers::transactions::handle_get_transaction(
+        Arc::new(state),
+        serde_json::json!("transaction-regression"),
+        Some(vec![serde_json::json!(signature.to_string()), config]),
+    ))
+    .await
+    .unwrap();
+    assert_eq!(response.status(), axum::http::StatusCode::OK);
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+async fn assert_transaction_fallback(source: &ClickHouseClient, cache: &DiskCache) {
+    for encoding in ["json", "jsonParsed", "base58", "base64"] {
+        let config = serde_json::json!({"slot": 45, "encoding": encoding, "maxSupportedTransactionVersion": 1});
+        let expected = transaction_response(source, None, signature(45), config.clone()).await;
+        assert!(expected.get("error").is_none(), "{expected}");
+        assert_eq!(expected["result"]["slot"], 45);
+        let actual = transaction_response(source, Some(cache), signature(45), config).await;
+        assert_eq!(actual, expected);
+    }
+}
+
+async fn assert_transaction_invalidation(cache: &DiskCache) {
+    let permits = cache
+        .inner
+        .local
+        .http_query_sem
+        .acquire_many(2)
+        .await
+        .unwrap();
+    let read = cache.get_tx(signature(45), Some(45));
+    tokio::pin!(read);
+    assert!(
+        tokio::time::timeout(Duration::from_millis(10), &mut read)
+            .await
+            .is_err()
+    );
+    cache.inner.key_index.invalidate_reads();
+    drop(permits);
+    assert!(matches!(read.await, DiskTransactionResult::Unavailable));
+}
+
+async fn assert_transaction_append_race(client: &clickhouse::Client, cache: &DiskCache) {
+    cache.inner.key_index.clear_signatures();
+    let permits = cache
+        .inner
+        .local
+        .http_query_sem
+        .acquire_many(2)
+        .await
+        .unwrap();
+    let read = cache.get_tx(signature(50), Some(50));
+    tokio::pin!(read);
+    assert!(
+        tokio::time::timeout(Duration::from_millis(10), &mut read)
+            .await
+            .is_err()
+    );
+    execute(client, &format!("INSERT INTO {}.transactions (signature,slot,slot_idx,tx_signatures) VALUES (toFixedString('sig-50',64),50,7,[toFixedString('sig-50',64)])", cache.inner.cfg.database)).await;
+    cache
+        .publish_range_coverage(vec![(50, SlotStatus::Covered { tx_count: 1 })])
+        .await
+        .unwrap();
+    drop(permits);
+    assert!(matches!(read.await, DiskTransactionResult::Unavailable));
+    let found = found_transaction(cache.get_tx(signature(50), Some(50)).await);
+    assert_eq!(found.slot, 50);
+    cache
+        .publish_range_coverage(vec![(51, SlotStatus::Skipped)])
+        .await
+        .unwrap();
+    assert!(matches!(
+        cache.get_tx(signature(500), Some(51)).await,
+        DiskTransactionResult::Absent
+    ));
+    cache.build_signature_indexes().await;
+}
+
+async fn assert_transaction_positions(cache: &DiskCache) {
+    let mut client = cache.query_client();
+    client.cache_partition = Some((
+        cache.inner.cfg.partition_slots,
+        45 / cache.inner.cfg.partition_slots,
+    ));
+    for slot_idx in [0, 999] {
+        let (record, _) = client
+            .get_transaction_by_signature_and_position(
+                &signature(45).to_string(),
+                crate::clickhouse::SignatureSlot { slot: 45, slot_idx },
+            )
+            .await
+            .unwrap();
+        assert_eq!(record.unwrap().slot, 45);
+    }
+    assert!(
+        client
+            .get_transaction_by_signature_and_position(
+                &signature(500).to_string(),
+                crate::clickhouse::SignatureSlot {
+                    slot: 45,
+                    slot_idx: 0
+                },
+            )
+            .await
+            .unwrap()
+            .0
+            .is_none()
+    );
+}
+
+async fn assert_transaction_reads(
+    client: &clickhouse::Client,
+    source: &ClickHouseClient,
+    cache: &DiskCache,
+) {
+    assert_transaction_positions(cache).await;
+    assert_transaction_invalidation(cache).await;
+    assert_transaction_append_race(client, cache).await;
+    assert!(matches!(
+        cache.get_tx(signature(500), Some(45)).await,
+        DiskTransactionResult::Absent
+    ));
+    assert!(matches!(
+        cache.get_tx(signature(500), Some(500)).await,
+        DiskTransactionResult::Unavailable
+    ));
+    let mismatch = transaction_response(
+        source,
+        Some(cache),
+        signature(45),
+        serde_json::json!({"slot": 44}),
+    )
+    .await;
+    assert!(mismatch["result"].is_null());
+    assert!(mismatch.get("error").is_none());
+    let database = &cache.inner.cfg.database;
+    execute(
+        client,
+        &format!("RENAME TABLE {database}.transactions TO {database}.transactions_unavailable"),
+    )
+    .await;
+    assert_transaction_fallback(source, cache).await;
+    execute(
+        client,
+        &format!("RENAME TABLE {database}.transactions_unavailable TO {database}.transactions"),
+    )
+    .await;
+}
+
 async fn assert_absent_without_admission(cache: &DiskCache) {
     let client = cache.query_client();
     let _permits = client.http_query_sem.acquire_many(2).await.unwrap();
     tokio::time::timeout(Duration::from_millis(50), async {
-        assert!(cache.get_tx(signature(500)).await.is_none());
+        assert!(matches!(
+            cache.get_tx(signature(500), None).await,
+            DiskTransactionResult::Unavailable
+        ));
         assert!(cache.signature_position(signature(500)).await.is_none());
         assert!(cache.get_sig_statuses(vec![signature(500)]).await[0].is_none());
     })
@@ -311,9 +486,15 @@ async fn assert_migration(
     assert!(reopened.tip_span().is_none());
     assert_signature_fill_updates(&reopened, source).await;
     assert!(reopened.covers_slot(15));
-    assert_eq!(reopened.get_tx(signature(15)).await.unwrap().slot, 15);
+    assert_eq!(
+        found_transaction(reopened.get_tx(signature(15), None).await).slot,
+        15
+    );
     let restarted = DiskCache::open(cfg.clone(), source).await.unwrap();
-    assert_eq!(restarted.get_tx(signature(15)).await.unwrap().slot, 15);
+    assert_eq!(
+        found_transaction(restarted.get_tx(signature(15), None).await).slot,
+        15
+    );
     execute(
         client,
         &format!("DROP TABLE {}._cache_meta SYNC", cfg.database),
@@ -324,7 +505,10 @@ async fn assert_migration(
         .err()
         .expect("missing marker must fail closed");
     assert!(error.to_string().contains("ownership check failed"));
-    assert_eq!(restarted.get_tx(signature(15)).await.unwrap().slot, 15);
+    assert_eq!(
+        found_transaction(restarted.get_tx(signature(15), None).await).slot,
+        15
+    );
     drop(cache);
     execute(client, &format!("DROP DATABASE {} SYNC", cfg.database)).await;
 }
@@ -476,7 +660,10 @@ async fn key_routing_clickhouse_integration() {
         cache.signature_position(signature(15)).await.unwrap().slot,
         15
     );
-    assert_eq!(cache.get_tx(signature(15)).await.unwrap().slot, 15);
+    assert_eq!(
+        found_transaction(cache.get_tx(signature(15), None).await).slot,
+        15
+    );
     assert!(cache.signature_position(signature(500)).await.is_none());
     let statuses = cache
         .get_sig_statuses(vec![
@@ -550,8 +737,19 @@ async fn key_routing_clickhouse_integration() {
     .unwrap();
     assert_cancellation(&client, &cache).await;
     assert_cross_partition_duplicates(&client, &cache).await;
+    let tx_client = client.clone();
+    let tx_source = source.clone();
+    let tx_cache = cache.clone();
+    tokio::spawn(async move {
+        assert_transaction_reads(&tx_client, &tx_source, &tx_cache).await;
+    })
+    .await
+    .unwrap();
     cache.poison_slot(15).await;
-    assert!(cache.get_tx(signature(15)).await.is_none());
+    assert!(matches!(
+        cache.get_tx(signature(15), None).await,
+        DiskTransactionResult::Unavailable
+    ));
     assert!(!signature_candidate(&cache, 1, signature(500)));
     let mut reopened_cfg = cfg;
     reopened_cfg.query_timeout = Duration::from_millis(50);
@@ -581,8 +779,22 @@ async fn key_routing_clickhouse_integration() {
         .await
         .unwrap();
     let started = std::time::Instant::now();
-    assert!(reopened.get_tx(signature(45)).await.is_none());
+    assert!(matches!(
+        reopened.get_tx(signature(45), None).await,
+        DiskTransactionResult::Unavailable
+    ));
     assert!(started.elapsed() < Duration::from_millis(200));
+    assert!(matches!(
+        reopened.slot_status(45).await,
+        SlotStatus::Covered { .. }
+    ));
+    let tx_source = source.clone();
+    let tx_cache = reopened.clone();
+    tokio::spawn(async move {
+        assert_transaction_fallback(&tx_source, &tx_cache).await;
+    })
+    .await
+    .unwrap();
     drop(_permits);
     if std::env::var_os("DISK_CACHE_TEST_KEEP").is_some() {
         eprintln!("Kept source database {database} and cache {cache_database}");

--- a/crates/superbank-rpc/src/disk_cache/mod.rs
+++ b/crates/superbank-rpc/src/disk_cache/mod.rs
@@ -146,6 +146,15 @@ pub(crate) enum SlotStatus {
     NotCovered,
 }
 
+/// Only `Absent` authorizes an RPC null response. Unavailable includes ordinary
+/// unpinned cache misses, since the primary may hold older transactions.
+#[derive(Debug)]
+pub(crate) enum DiskTransactionResult {
+    Found(Arc<StoredTransactionRecord>),
+    Absent,
+    Unavailable,
+}
+
 #[derive(Debug)]
 pub(crate) enum DiskBlockResult {
     Found(Box<StoredBlockPayload>),

--- a/crates/superbank-rpc/src/handlers/transactions.rs
+++ b/crates/superbank-rpc/src/handlers/transactions.rs
@@ -380,15 +380,13 @@ pub(crate) async fn handle_get_transaction(
         route.head_cache_read();
     }
 
-    // Disk tier: everything stored is finalized, which satisfies any commitment
-    // accepted above. A hit answers without ClickHouse. A miss proves nothing by
-    // itself (the signature may be older than the window or in a coverage hole) —
-    // EXCEPT when the request pinned a slot that the disk fully covers: then the
-    // transaction conclusively does not exist there.
+    // Disk results are finalized. Only a successful lookup with matching coverage
+    // can prove absence at a pinned slot; unavailable reads must reach the primary.
     #[cfg(feature = "disk-cache")]
     if let Some(disk) = state.disk_cache() {
         route.disk_cache_read();
-        if let Some(record) = disk.get_tx(signature).await {
+        let disk_result = disk.get_tx(signature, requested_slot).await;
+        if let crate::disk_cache::DiskTransactionResult::Found(record) = disk_result {
             if requested_slot.is_some_and(|slot| record.slot != slot) {
                 route.source_disk_cache();
                 route.not_found();
@@ -400,20 +398,17 @@ pub(crate) async fn handle_get_transaction(
                 id,
                 &mut route,
                 signature_str,
-                Arc::new(record),
+                record,
                 encoding,
                 config.max_supported_transaction_version,
                 None,
             )
             .await;
         }
-        if let Some(slot) = requested_slot
-            && matches!(
-                disk.slot_status(slot).await,
-                crate::disk_cache::SlotStatus::Covered { .. }
-                    | crate::disk_cache::SlotStatus::Skipped
-            )
-        {
+        if matches!(
+            disk_result,
+            crate::disk_cache::DiskTransactionResult::Absent
+        ) {
             route.source_disk_cache();
             route.not_found();
             return Ok(json_rpc_null_response(id));

--- a/crates/superbank-rpc/src/tests/mod.rs
+++ b/crates/superbank-rpc/src/tests/mod.rs
@@ -179,7 +179,7 @@ fn test_state_with_token_owner_activity_available(available: bool) -> Arc<AppSta
     })
 }
 
-fn test_state() -> Arc<AppState> {
+pub(crate) fn test_state() -> Arc<AppState> {
     test_state_with_token_owner_activity_available(true)
 }
 

--- a/docs/benchmarks/gettransaction-2026-09-11.json
+++ b/docs/benchmarks/gettransaction-2026-09-11.json
@@ -1,0 +1,871 @@
+{
+  "image": "clickhouse/clickhouse-server:26.2.3.2",
+  "node_memory": "8g",
+  "rows_per_payload_table": 3000000,
+  "host": "macOS-15.7.4-arm64-arm-64bit",
+  "script_sha256": "6ae34af242d963cb0235642ab3f22753343213d27dcf9154f25a08d14db1822b",
+  "settings": "max_threads=2,max_execution_time=10,max_execution_time_leaf=10,optimize_skip_unused_shards=1,use_query_cache=0,log_queries=1,log_profile_events=1,use_hedged_requests=0,max_parallel_replicas=1",
+  "seed": 88,
+  "runs": 5,
+  "samples_per_run": 50,
+  "filesystem_cache": "uncontrolled; cache-cleared means ClickHouse mark/uncompressed caches only",
+  "gateway_integration": "rejected: combined query returns indistinguishable empty responses for an absent signature and a stale position whose payload exists; it cannot preserve fallback without resolving the signature again",
+  "edge_cases": {
+    "absent": {
+      "bytes": 0,
+      "http_ms": 17.742333002388477
+    },
+    "stale_combined": {
+      "bytes": 0,
+      "http_ms": 15.730334002000745
+    },
+    "stale_position": {
+      "bytes": 0,
+      "http_ms": 10.19224999618018
+    },
+    "stale_fallback": {
+      "bytes": 804,
+      "http_ms": 18.558416995801963
+    }
+  },
+  "summary": {
+    "position-cold=False": {
+      "errors": 0,
+      "http_ms": {
+        "p50": 16.352167000150075,
+        "p95": 20.216625001921784,
+        "p99": 21.83195899851853
+      },
+      "means": {
+        "server_ms": 14.716,
+        "read_rows": 8683.52,
+        "read_bytes": 5717459.9,
+        "cpu_us": 8036.98
+      }
+    },
+    "position-cold=True": {
+      "errors": 0,
+      "http_ms": {
+        "p50": 18.167083500884473,
+        "p95": 25.322749999759253,
+        "p99": 31.38995800691191
+      },
+      "means": {
+        "server_ms": 17.148,
+        "read_rows": 8683.52,
+        "read_bytes": 5717459.9,
+        "cpu_us": 9078.316
+      }
+    },
+    "slot_only-cold=False": {
+      "errors": 0,
+      "http_ms": {
+        "p50": 17.477312998380512,
+        "p95": 22.573250003915746,
+        "p99": 28.157250002550427
+      },
+      "means": {
+        "server_ms": 16.032,
+        "read_rows": 16416.768,
+        "read_bytes": 5649912.556,
+        "cpu_us": 8986.976
+      }
+    },
+    "slot_only-cold=True": {
+      "errors": 0,
+      "http_ms": {
+        "p50": 18.937437500426313,
+        "p95": 26.58066699950723,
+        "p99": 51.63008299859939
+      },
+      "means": {
+        "server_ms": 18.06,
+        "read_rows": 16384,
+        "read_bytes": 5649640.14,
+        "cpu_us": 9568.32
+      }
+    },
+    "granularity1024-cold=False": {
+      "errors": 0,
+      "http_ms": {
+        "p50": 13.60708350330242,
+        "p95": 17.171958003018517,
+        "p99": 20.203832995321136
+      },
+      "means": {
+        "server_ms": 11.748,
+        "read_rows": 1597.44,
+        "read_bytes": 691882.62,
+        "cpu_us": 7198.824
+      }
+    },
+    "granularity1024-cold=True": {
+      "errors": 0,
+      "http_ms": {
+        "p50": 15.821333501662593,
+        "p95": 19.909583999833558,
+        "p99": 25.571874997694977
+      },
+      "means": {
+        "server_ms": 14.312,
+        "read_rows": 1597.44,
+        "read_bytes": 691882.62,
+        "cpu_us": 8108.812
+      }
+    },
+    "two_step-cold=False": {
+      "errors": 0,
+      "http_ms": {
+        "p50": 22.5458120003168,
+        "p95": 30.725582997547463,
+        "p99": 32.56637499725912
+      },
+      "means": {
+        "server_ms": 19.436,
+        "read_rows": 9209.368,
+        "read_bytes": 5757901.112,
+        "cpu_us": 11987.552
+      }
+    },
+    "two_step-cold=True": {
+      "errors": 0,
+      "http_ms": {
+        "p50": 22.732354500476504,
+        "p95": 27.36124999501044,
+        "p99": 29.227624996565282
+      },
+      "means": {
+        "server_ms": 19.708,
+        "read_rows": 9207.32,
+        "read_bytes": 5757767.96,
+        "cpu_us": 11977.696
+      }
+    },
+    "combined-cold=False": {
+      "errors": 0,
+      "http_ms": {
+        "p50": 20.783625503099756,
+        "p95": 25.460999997449107,
+        "p99": 31.980874999135267
+      },
+      "means": {
+        "server_ms": 19.408,
+        "read_rows": 9207.32,
+        "read_bytes": 5757767.96,
+        "cpu_us": 12047.8
+      }
+    },
+    "combined-cold=True": {
+      "errors": 0,
+      "http_ms": {
+        "p50": 22.481187497760402,
+        "p95": 26.85958400252275,
+        "p99": 30.312957998830825
+      },
+      "means": {
+        "server_ms": 21.092,
+        "read_rows": 9207.32,
+        "read_bytes": 5757767.96,
+        "cpu_us": 12768.676
+      }
+    }
+  },
+  "ingestion": [
+    {
+      "table": "transactions",
+      "rows": 3000000,
+      "seconds": 19.40292879199842,
+      "sampled_peak_all_table_parts_bytes": 2922025586,
+      "parts": [
+        {
+          "host": "ch-disconnect-1dc2c006af-0",
+          "table": "signatures_local",
+          "rows": 1002143,
+          "disk_bytes": 73594585,
+          "resident_parts_bytes": 430504848,
+          "compressed_bytes": 72029933,
+          "marks_bytes": 46657,
+          "primary_key_memory": 147905,
+          "parts": 224
+        },
+        {
+          "host": "ch-disconnect-1dc2c006af-0",
+          "table": "transactions_local",
+          "rows": 1000000,
+          "disk_bytes": 337166003,
+          "resident_parts_bytes": 539542706,
+          "compressed_bytes": 335758419,
+          "marks_bytes": 124655,
+          "primary_key_memory": 5616,
+          "parts": 10
+        },
+        {
+          "host": "ch-disconnect-1dc2c006af-1",
+          "table": "signatures_local",
+          "rows": 999090,
+          "disk_bytes": 73357307,
+          "resident_parts_bytes": 501649076,
+          "compressed_bytes": 71911505,
+          "marks_bytes": 34609,
+          "primary_key_memory": 129474,
+          "parts": 36
+        },
+        {
+          "host": "ch-disconnect-1dc2c006af-1",
+          "table": "transactions_local",
+          "rows": 1000000,
+          "disk_bytes": 337165735,
+          "resident_parts_bytes": 539542133,
+          "compressed_bytes": 335758150,
+          "marks_bytes": 124656,
+          "primary_key_memory": 5616,
+          "parts": 10
+        },
+        {
+          "host": "ch-disconnect-1dc2c006af-2",
+          "table": "signatures_local",
+          "rows": 998767,
+          "disk_bytes": 73335187,
+          "resident_parts_bytes": 502024145,
+          "compressed_bytes": 71890879,
+          "marks_bytes": 34450,
+          "primary_key_memory": 129410,
+          "parts": 34
+        },
+        {
+          "host": "ch-disconnect-1dc2c006af-2",
+          "table": "transactions_local",
+          "rows": 1000000,
+          "disk_bytes": 337165757,
+          "resident_parts_bytes": 539542571,
+          "compressed_bytes": 335758173,
+          "marks_bytes": 124656,
+          "primary_key_memory": 5616,
+          "parts": 10
+        }
+      ]
+    },
+    {
+      "table": "transactions1024",
+      "rows": 3000000,
+      "seconds": 22.79159441599768,
+      "sampled_peak_all_table_parts_bytes": 6185116124,
+      "parts": [
+        {
+          "host": "ch-disconnect-1dc2c006af-0",
+          "table": "signatures_local",
+          "rows": 1002143,
+          "disk_bytes": 73579319,
+          "resident_parts_bytes": 504084167,
+          "compressed_bytes": 72131721,
+          "marks_bytes": 34419,
+          "primary_key_memory": 129411,
+          "parts": 32
+        },
+        {
+          "host": "ch-disconnect-1dc2c006af-0",
+          "table": "transactions_local",
+          "rows": 1000000,
+          "disk_bytes": 337166003,
+          "resident_parts_bytes": 539542706,
+          "compressed_bytes": 335758419,
+          "marks_bytes": 124655,
+          "primary_key_memory": 5616,
+          "parts": 10
+        },
+        {
+          "host": "ch-disconnect-1dc2c006af-0",
+          "table": "transactions1024_local",
+          "rows": 1000000,
+          "disk_bytes": 337439669,
+          "resident_parts_bytes": 539998952,
+          "compressed_bytes": 335864455,
+          "marks_bytes": 234580,
+          "primary_key_memory": 7920,
+          "parts": 10
+        },
+        {
+          "host": "ch-disconnect-1dc2c006af-0",
+          "table": "signatures1024_local",
+          "rows": 1002143,
+          "disk_bytes": 73592983,
+          "resident_parts_bytes": 437336047,
+          "compressed_bytes": 72039351,
+          "marks_bytes": 45489,
+          "primary_key_memory": 146159,
+          "parts": 206
+        },
+        {
+          "host": "ch-disconnect-1dc2c006af-1",
+          "table": "signatures_local",
+          "rows": 999090,
+          "disk_bytes": 73357307,
+          "resident_parts_bytes": 501649076,
+          "compressed_bytes": 71911505,
+          "marks_bytes": 34609,
+          "primary_key_memory": 129474,
+          "parts": 36
+        },
+        {
+          "host": "ch-disconnect-1dc2c006af-1",
+          "table": "transactions_local",
+          "rows": 1000000,
+          "disk_bytes": 337165735,
+          "resident_parts_bytes": 539542133,
+          "compressed_bytes": 335758150,
+          "marks_bytes": 124656,
+          "primary_key_memory": 5616,
+          "parts": 10
+        },
+        {
+          "host": "ch-disconnect-1dc2c006af-1",
+          "table": "transactions1024_local",
+          "rows": 1000000,
+          "disk_bytes": 337439469,
+          "resident_parts_bytes": 539998407,
+          "compressed_bytes": 335864253,
+          "marks_bytes": 234584,
+          "primary_key_memory": 7920,
+          "parts": 10
+        },
+        {
+          "host": "ch-disconnect-1dc2c006af-1",
+          "table": "signatures1024_local",
+          "rows": 999090,
+          "disk_bytes": 73357307,
+          "resident_parts_bytes": 501649076,
+          "compressed_bytes": 71911505,
+          "marks_bytes": 34609,
+          "primary_key_memory": 129474,
+          "parts": 36
+        },
+        {
+          "host": "ch-disconnect-1dc2c006af-2",
+          "table": "signatures_local",
+          "rows": 998767,
+          "disk_bytes": 73335187,
+          "resident_parts_bytes": 502024145,
+          "compressed_bytes": 71890879,
+          "marks_bytes": 34450,
+          "primary_key_memory": 129410,
+          "parts": 34
+        },
+        {
+          "host": "ch-disconnect-1dc2c006af-2",
+          "table": "transactions_local",
+          "rows": 1000000,
+          "disk_bytes": 337165757,
+          "resident_parts_bytes": 539542571,
+          "compressed_bytes": 335758173,
+          "marks_bytes": 124656,
+          "primary_key_memory": 5616,
+          "parts": 10
+        },
+        {
+          "host": "ch-disconnect-1dc2c006af-2",
+          "table": "transactions1024_local",
+          "rows": 1000000,
+          "disk_bytes": 337439081,
+          "resident_parts_bytes": 539997870,
+          "compressed_bytes": 335863849,
+          "marks_bytes": 234582,
+          "primary_key_memory": 7920,
+          "parts": 10
+        },
+        {
+          "host": "ch-disconnect-1dc2c006af-2",
+          "table": "signatures1024_local",
+          "rows": 998767,
+          "disk_bytes": 73335187,
+          "resident_parts_bytes": 502024145,
+          "compressed_bytes": 71890879,
+          "marks_bytes": 34450,
+          "primary_key_memory": 129410,
+          "parts": 34
+        }
+      ]
+    }
+  ],
+  "before_merge": [
+    {
+      "host": "ch-disconnect-1dc2c006af-0",
+      "table": "signatures_local",
+      "rows": 1002143,
+      "disk_bytes": 73579319,
+      "resident_parts_bytes": 504084167,
+      "compressed_bytes": 72131721,
+      "marks_bytes": 34419,
+      "primary_key_memory": 129411,
+      "parts": 32
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-0",
+      "table": "transactions_local",
+      "rows": 1000000,
+      "disk_bytes": 337166003,
+      "resident_parts_bytes": 539542706,
+      "compressed_bytes": 335758419,
+      "marks_bytes": 124655,
+      "primary_key_memory": 5616,
+      "parts": 10
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-0",
+      "table": "transactions1024_local",
+      "rows": 1000000,
+      "disk_bytes": 337439669,
+      "resident_parts_bytes": 539998952,
+      "compressed_bytes": 335864455,
+      "marks_bytes": 234580,
+      "primary_key_memory": 7920,
+      "parts": 10
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-0",
+      "table": "signatures1024_local",
+      "rows": 1002143,
+      "disk_bytes": 73579319,
+      "resident_parts_bytes": 504084167,
+      "compressed_bytes": 72131721,
+      "marks_bytes": 34419,
+      "primary_key_memory": 129411,
+      "parts": 32
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-1",
+      "table": "signatures_local",
+      "rows": 999090,
+      "disk_bytes": 73357307,
+      "resident_parts_bytes": 501649076,
+      "compressed_bytes": 71911505,
+      "marks_bytes": 34609,
+      "primary_key_memory": 129474,
+      "parts": 36
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-1",
+      "table": "transactions_local",
+      "rows": 1000000,
+      "disk_bytes": 337165735,
+      "resident_parts_bytes": 539542133,
+      "compressed_bytes": 335758150,
+      "marks_bytes": 124656,
+      "primary_key_memory": 5616,
+      "parts": 10
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-1",
+      "table": "transactions1024_local",
+      "rows": 1000000,
+      "disk_bytes": 337439469,
+      "resident_parts_bytes": 539998407,
+      "compressed_bytes": 335864253,
+      "marks_bytes": 234584,
+      "primary_key_memory": 7920,
+      "parts": 10
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-1",
+      "table": "signatures1024_local",
+      "rows": 999090,
+      "disk_bytes": 73357307,
+      "resident_parts_bytes": 501649076,
+      "compressed_bytes": 71911505,
+      "marks_bytes": 34609,
+      "primary_key_memory": 129474,
+      "parts": 36
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-2",
+      "table": "signatures_local",
+      "rows": 998767,
+      "disk_bytes": 73335187,
+      "resident_parts_bytes": 502024145,
+      "compressed_bytes": 71890879,
+      "marks_bytes": 34450,
+      "primary_key_memory": 129410,
+      "parts": 34
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-2",
+      "table": "transactions_local",
+      "rows": 1000000,
+      "disk_bytes": 337165757,
+      "resident_parts_bytes": 539542571,
+      "compressed_bytes": 335758173,
+      "marks_bytes": 124656,
+      "primary_key_memory": 5616,
+      "parts": 10
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-2",
+      "table": "transactions1024_local",
+      "rows": 1000000,
+      "disk_bytes": 337439081,
+      "resident_parts_bytes": 539997870,
+      "compressed_bytes": 335863849,
+      "marks_bytes": 234582,
+      "primary_key_memory": 7920,
+      "parts": 10
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-2",
+      "table": "signatures1024_local",
+      "rows": 998767,
+      "disk_bytes": 73335187,
+      "resident_parts_bytes": 502024145,
+      "compressed_bytes": 71890879,
+      "marks_bytes": 34450,
+      "primary_key_memory": 129410,
+      "parts": 34
+    }
+  ],
+  "after_merge": [
+    {
+      "host": "ch-disconnect-1dc2c006af-0",
+      "table": "signatures_local",
+      "rows": 1002143,
+      "disk_bytes": 73579319,
+      "resident_parts_bytes": 504084167,
+      "compressed_bytes": 72131721,
+      "marks_bytes": 34419,
+      "primary_key_memory": 129411,
+      "parts": 32
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-0",
+      "table": "transactions_local",
+      "rows": 1000000,
+      "disk_bytes": 337050135,
+      "resident_parts_bytes": 876592841,
+      "compressed_bytes": 335735973,
+      "marks_bytes": 46121,
+      "primary_key_memory": 1136,
+      "parts": 2
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-0",
+      "table": "transactions1024_local",
+      "rows": 1000000,
+      "disk_bytes": 337301508,
+      "resident_parts_bytes": 877300460,
+      "compressed_bytes": 335842041,
+      "marks_bytes": 135188,
+      "primary_key_memory": 7856,
+      "parts": 2
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-0",
+      "table": "signatures1024_local",
+      "rows": 1002143,
+      "disk_bytes": 73579319,
+      "resident_parts_bytes": 504084167,
+      "compressed_bytes": 72131721,
+      "marks_bytes": 34419,
+      "primary_key_memory": 129411,
+      "parts": 32
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-1",
+      "table": "signatures_local",
+      "rows": 999090,
+      "disk_bytes": 73357307,
+      "resident_parts_bytes": 501649076,
+      "compressed_bytes": 71911505,
+      "marks_bytes": 34609,
+      "primary_key_memory": 129474,
+      "parts": 36
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-1",
+      "table": "transactions_local",
+      "rows": 1000000,
+      "disk_bytes": 337049867,
+      "resident_parts_bytes": 876592000,
+      "compressed_bytes": 335735704,
+      "marks_bytes": 46122,
+      "primary_key_memory": 1136,
+      "parts": 2
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-1",
+      "table": "transactions1024_local",
+      "rows": 1000000,
+      "disk_bytes": 337301293,
+      "resident_parts_bytes": 877299700,
+      "compressed_bytes": 335841839,
+      "marks_bytes": 135174,
+      "primary_key_memory": 7856,
+      "parts": 2
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-1",
+      "table": "signatures1024_local",
+      "rows": 999090,
+      "disk_bytes": 73357307,
+      "resident_parts_bytes": 501649076,
+      "compressed_bytes": 71911505,
+      "marks_bytes": 34609,
+      "primary_key_memory": 129474,
+      "parts": 36
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-2",
+      "table": "signatures_local",
+      "rows": 998767,
+      "disk_bytes": 73335187,
+      "resident_parts_bytes": 502024145,
+      "compressed_bytes": 71890879,
+      "marks_bytes": 34450,
+      "primary_key_memory": 129410,
+      "parts": 34
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-2",
+      "table": "transactions_local",
+      "rows": 1000000,
+      "disk_bytes": 337049890,
+      "resident_parts_bytes": 876592461,
+      "compressed_bytes": 335735727,
+      "marks_bytes": 46122,
+      "primary_key_memory": 1136,
+      "parts": 2
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-2",
+      "table": "transactions1024_local",
+      "rows": 1000000,
+      "disk_bytes": 337300936,
+      "resident_parts_bytes": 877298806,
+      "compressed_bytes": 335841435,
+      "marks_bytes": 135218,
+      "primary_key_memory": 7856,
+      "parts": 2
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-2",
+      "table": "signatures1024_local",
+      "rows": 998767,
+      "disk_bytes": 73335187,
+      "resident_parts_bytes": 502024145,
+      "compressed_bytes": 71890879,
+      "marks_bytes": 34450,
+      "primary_key_memory": 129410,
+      "parts": 34
+    }
+  ],
+  "final_parts": [
+    {
+      "host": "ch-disconnect-1dc2c006af-0",
+      "table": "signatures_local",
+      "rows": 1002143,
+      "disk_bytes": 73579319,
+      "resident_parts_bytes": 504084167,
+      "compressed_bytes": 72131721,
+      "marks_bytes": 34419,
+      "primary_key_memory": 129411,
+      "parts": 32
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-0",
+      "table": "transactions_local",
+      "rows": 1000000,
+      "disk_bytes": 337050135,
+      "resident_parts_bytes": 876592841,
+      "compressed_bytes": 335735973,
+      "marks_bytes": 46121,
+      "primary_key_memory": 1136,
+      "parts": 2
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-0",
+      "table": "transactions1024_local",
+      "rows": 1000000,
+      "disk_bytes": 337301508,
+      "resident_parts_bytes": 877300460,
+      "compressed_bytes": 335842041,
+      "marks_bytes": 135188,
+      "primary_key_memory": 7856,
+      "parts": 2
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-0",
+      "table": "signatures1024_local",
+      "rows": 1002143,
+      "disk_bytes": 73579319,
+      "resident_parts_bytes": 504084167,
+      "compressed_bytes": 72131721,
+      "marks_bytes": 34419,
+      "primary_key_memory": 129411,
+      "parts": 32
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-1",
+      "table": "signatures_local",
+      "rows": 999091,
+      "disk_bytes": 73358127,
+      "resident_parts_bytes": 501649896,
+      "compressed_bytes": 71911715,
+      "marks_bytes": 34683,
+      "primary_key_memory": 129636,
+      "parts": 37
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-1",
+      "table": "transactions_local",
+      "rows": 1000000,
+      "disk_bytes": 337049867,
+      "resident_parts_bytes": 876592000,
+      "compressed_bytes": 335735704,
+      "marks_bytes": 46122,
+      "primary_key_memory": 1136,
+      "parts": 2
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-1",
+      "table": "transactions1024_local",
+      "rows": 1000000,
+      "disk_bytes": 337301293,
+      "resident_parts_bytes": 877299700,
+      "compressed_bytes": 335841839,
+      "marks_bytes": 135174,
+      "primary_key_memory": 7856,
+      "parts": 2
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-1",
+      "table": "signatures1024_local",
+      "rows": 999090,
+      "disk_bytes": 73357307,
+      "resident_parts_bytes": 501649076,
+      "compressed_bytes": 71911505,
+      "marks_bytes": 34609,
+      "primary_key_memory": 129474,
+      "parts": 36
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-2",
+      "table": "signatures_local",
+      "rows": 998767,
+      "disk_bytes": 73335187,
+      "resident_parts_bytes": 502024145,
+      "compressed_bytes": 71890879,
+      "marks_bytes": 34450,
+      "primary_key_memory": 129410,
+      "parts": 34
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-2",
+      "table": "transactions_local",
+      "rows": 1000000,
+      "disk_bytes": 337049890,
+      "resident_parts_bytes": 876592461,
+      "compressed_bytes": 335735727,
+      "marks_bytes": 46122,
+      "primary_key_memory": 1136,
+      "parts": 2
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-2",
+      "table": "transactions1024_local",
+      "rows": 1000000,
+      "disk_bytes": 337300936,
+      "resident_parts_bytes": 877298806,
+      "compressed_bytes": 335841435,
+      "marks_bytes": 135218,
+      "primary_key_memory": 7856,
+      "parts": 2
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-2",
+      "table": "signatures1024_local",
+      "rows": 998767,
+      "disk_bytes": 73335187,
+      "resident_parts_bytes": 502024145,
+      "compressed_bytes": 71890879,
+      "marks_bytes": 34450,
+      "primary_key_memory": 129410,
+      "parts": 34
+    }
+  ],
+  "merge_wall_seconds": 12.02977379100048,
+  "merges": [
+    {
+      "host": "ch-disconnect-1dc2c006af-0",
+      "table": "transactions_local",
+      "merges": 4,
+      "duration_ms": 2511,
+      "read_rows": 1600000,
+      "read_bytes": 1672706528,
+      "peak_memory": 93129028
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-0",
+      "table": "transactions1024_local",
+      "merges": 4,
+      "duration_ms": 3764,
+      "read_rows": 1600000,
+      "read_bytes": 1673105696,
+      "peak_memory": 29804556
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-1",
+      "table": "transactions_local",
+      "merges": 4,
+      "duration_ms": 5416,
+      "read_rows": 1600000,
+      "read_bytes": 1672706528,
+      "peak_memory": 93129092
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-1",
+      "table": "transactions1024_local",
+      "merges": 4,
+      "duration_ms": 3686,
+      "read_rows": 1600000,
+      "read_bytes": 1673105696,
+      "peak_memory": 29804460
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-2",
+      "table": "transactions_local",
+      "merges": 4,
+      "duration_ms": 4223,
+      "read_rows": 1600000,
+      "read_bytes": 1672706528,
+      "peak_memory": 93129028
+    },
+    {
+      "host": "ch-disconnect-1dc2c006af-2",
+      "table": "transactions1024_local",
+      "merges": 4,
+      "duration_ms": 3621,
+      "read_rows": 1600000,
+      "read_bytes": 1673105696,
+      "peak_memory": 29804556
+    }
+  ],
+  "plans": {
+    "combined": "node 0:\nReadFromRemote (Read from remote replica)\n",
+    "position": "node 0:\nReadFromRemote (Read from remote replica)\n",
+    "granularity1024": "node 0:\nReadFromRemote (Read from remote replica)\n",
+    "slot_only": "node 0:\nReadFromRemote (Read from remote replica)\n",
+    "local_position": "node 0:\nExpression ((Project names + (Projection + Change column names to column identifiers)))\n  Limit (preliminary LIMIT)\n    ReadFromMergeTree (default.transactions_local)\n    Indexes:\n      MinMax\n        Keys:\n          slot\n        Condition: (slot in [432001, 432001])\n        Parts: 0/2\n        Granules: 0/140\n      Partition\n        Keys:\n          intDiv(slot, 432000)\n        Condition: (intDiv(slot, 432000) in [1, 1])\n        Parts: 0/0\n        Granules: 0/0\n      PrimaryKey\n        Keys:\n          slot\n          slot_idx\n          signature\n        Condition: and((signature in [\\'\ufffd\u0004U\ufffd`.\ufffdo\ufffd\u0002\ufffdv\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd603^\ufffd\u001f\\\\tz\ufffd\u000e\ufffd\ufffdv\ufffd\ufffd(Q/.\\\\0\u000b\ufffd\u0004\ufffd\ufffd\u0013>\ufffd\u001cn\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd`\ufffdK\ufffd\u031e\ufffd\ufffd\\', \\'\ufffd\u0004U\ufffd`.\ufffdo\ufffd\u0002\ufffdv\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd603^\ufffd\u001f\\\\tz\ufffd\u000e\ufffd\ufffdv\ufffd\ufffd(Q/.\\\\0\u000b\ufffd\u0004\ufffd\ufffd\u0013>\ufffd\u001cn\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd`\ufffdK\ufffd\u031e\ufffd\ufffd\\']), and((slot_idx in [234, 234]), (slot in [432001, 432001])))\n        Parts: 0/0\n        Granules: 0/0\n      Skip\n        Name: bf_signature\n        Description: bloom_filter GRANULARITY 64\n        Parts: 0/0\n        Granules: 0/0\n      Ranges: 0\n\nnode 1:\nExpression ((Project names + (Projection + Change column names to column identifiers)))\n  Limit (preliminary LIMIT)\n    ReadFromMergeTree (default.transactions_local)\n    Indexes:\n      MinMax\n        Keys:\n          slot\n        Condition: (slot in [432001, 432001])\n        Parts: 1/2\n        Granules: 70/140\n      Partition\n        Keys:\n          intDiv(slot, 432000)\n        Condition: (intDiv(slot, 432000) in [1, 1])\n        Parts: 1/1\n        Granules: 70/70\n      PrimaryKey\n        Keys:\n          slot\n          slot_idx\n          signature\n        Condition: and((signature in [\\'\ufffd\u0004U\ufffd`.\ufffdo\ufffd\u0002\ufffdv\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd603^\ufffd\u001f\\\\tz\ufffd\u000e\ufffd\ufffdv\ufffd\ufffd(Q/.\\\\0\u000b\ufffd\u0004\ufffd\ufffd\u0013>\ufffd\u001cn\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd`\ufffdK\ufffd\u031e\ufffd\ufffd\\', \\'\ufffd\u0004U\ufffd`.\ufffdo\ufffd\u0002\ufffdv\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd603^\ufffd\u001f\\\\tz\ufffd\u000e\ufffd\ufffdv\ufffd\ufffd(Q/.\\\\0\u000b\ufffd\u0004\ufffd\ufffd\u0013>\ufffd\u001cn\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd`\ufffdK\ufffd\u031e\ufffd\ufffd\\']), and((slot_idx in [234, 234]), (slot in [432001, 432001])))\n        Parts: 1/1\n        Granules: 1/70\n        Search Algorithm: binary search\n      Skip\n        Name: bf_signature\n        Description: bloom_filter GRANULARITY 64\n        Parts: 1/1\n        Granules: 1/1\n      Ranges: 1\n\nnode 2:\nExpression ((Project names + (Projection + Change column names to column identifiers)))\n  Limit (preliminary LIMIT)\n    ReadFromMergeTree (default.transactions_local)\n    Indexes:\n      MinMax\n        Keys:\n          slot\n        Condition: (slot in [432001, 432001])\n        Parts: 0/2\n        Granules: 0/140\n      Partition\n        Keys:\n          intDiv(slot, 432000)\n        Condition: (intDiv(slot, 432000) in [1, 1])\n        Parts: 0/0\n        Granules: 0/0\n      PrimaryKey\n        Keys:\n          slot\n          slot_idx\n          signature\n        Condition: and((signature in [\\'\ufffd\u0004U\ufffd`.\ufffdo\ufffd\u0002\ufffdv\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd603^\ufffd\u001f\\\\tz\ufffd\u000e\ufffd\ufffdv\ufffd\ufffd(Q/.\\\\0\u000b\ufffd\u0004\ufffd\ufffd\u0013>\ufffd\u001cn\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd`\ufffdK\ufffd\u031e\ufffd\ufffd\\', \\'\ufffd\u0004U\ufffd`.\ufffdo\ufffd\u0002\ufffdv\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd603^\ufffd\u001f\\\\tz\ufffd\u000e\ufffd\ufffdv\ufffd\ufffd(Q/.\\\\0\u000b\ufffd\u0004\ufffd\ufffd\u0013>\ufffd\u001cn\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd`\ufffdK\ufffd\u031e\ufffd\ufffd\\']), and((slot_idx in [234, 234]), (slot in [432001, 432001])))\n        Parts: 0/0\n        Granules: 0/0\n      Skip\n        Name: bf_signature\n        Description: bloom_filter GRANULARITY 64\n        Parts: 0/0\n        Granules: 0/0\n      Ranges: 0\n",
+    "local_granularity1024": "node 0:\nExpression ((Project names + (Projection + Change column names to column identifiers)))\n  Limit (preliminary LIMIT)\n    ReadFromMergeTree (default.transactions1024_local)\n    Indexes:\n      MinMax\n        Keys:\n          slot\n        Condition: (slot in [432001, 432001])\n        Parts: 0/2\n        Granules: 0/980\n      Partition\n        Keys:\n          intDiv(slot, 432000)\n        Condition: (intDiv(slot, 432000) in [1, 1])\n        Parts: 0/0\n        Granules: 0/0\n      PrimaryKey\n        Keys:\n          slot\n          slot_idx\n          signature\n        Condition: and((signature in [\\'\ufffd\u0004U\ufffd`.\ufffdo\ufffd\u0002\ufffdv\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd603^\ufffd\u001f\\\\tz\ufffd\u000e\ufffd\ufffdv\ufffd\ufffd(Q/.\\\\0\u000b\ufffd\u0004\ufffd\ufffd\u0013>\ufffd\u001cn\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd`\ufffdK\ufffd\u031e\ufffd\ufffd\\', \\'\ufffd\u0004U\ufffd`.\ufffdo\ufffd\u0002\ufffdv\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd603^\ufffd\u001f\\\\tz\ufffd\u000e\ufffd\ufffdv\ufffd\ufffd(Q/.\\\\0\u000b\ufffd\u0004\ufffd\ufffd\u0013>\ufffd\u001cn\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd`\ufffdK\ufffd\u031e\ufffd\ufffd\\']), and((slot_idx in [234, 234]), (slot in [432001, 432001])))\n        Parts: 0/0\n        Granules: 0/0\n      Skip\n        Name: bf_signature\n        Description: bloom_filter GRANULARITY 64\n        Parts: 0/0\n        Granules: 0/0\n      Ranges: 0\n\nnode 1:\nExpression ((Project names + (Projection + Change column names to column identifiers)))\n  Limit (preliminary LIMIT)\n    ReadFromMergeTree (default.transactions1024_local)\n    Indexes:\n      MinMax\n        Keys:\n          slot\n        Condition: (slot in [432001, 432001])\n        Parts: 1/2\n        Granules: 490/980\n      Partition\n        Keys:\n          intDiv(slot, 432000)\n        Condition: (intDiv(slot, 432000) in [1, 1])\n        Parts: 1/1\n        Granules: 490/490\n      PrimaryKey\n        Keys:\n          slot\n          slot_idx\n          signature\n        Condition: and((signature in [\\'\ufffd\u0004U\ufffd`.\ufffdo\ufffd\u0002\ufffdv\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd603^\ufffd\u001f\\\\tz\ufffd\u000e\ufffd\ufffdv\ufffd\ufffd(Q/.\\\\0\u000b\ufffd\u0004\ufffd\ufffd\u0013>\ufffd\u001cn\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd`\ufffdK\ufffd\u031e\ufffd\ufffd\\', \\'\ufffd\u0004U\ufffd`.\ufffdo\ufffd\u0002\ufffdv\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd603^\ufffd\u001f\\\\tz\ufffd\u000e\ufffd\ufffdv\ufffd\ufffd(Q/.\\\\0\u000b\ufffd\u0004\ufffd\ufffd\u0013>\ufffd\u001cn\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd`\ufffdK\ufffd\u031e\ufffd\ufffd\\']), and((slot_idx in [234, 234]), (slot in [432001, 432001])))\n        Parts: 1/1\n        Granules: 2/490\n        Search Algorithm: binary search\n      Skip\n        Name: bf_signature\n        Description: bloom_filter GRANULARITY 64\n        Parts: 1/1\n        Granules: 2/2\n      Ranges: 1\n\nnode 2:\nExpression ((Project names + (Projection + Change column names to column identifiers)))\n  Limit (preliminary LIMIT)\n    ReadFromMergeTree (default.transactions1024_local)\n    Indexes:\n      MinMax\n        Keys:\n          slot\n        Condition: (slot in [432001, 432001])\n        Parts: 0/2\n        Granules: 0/980\n      Partition\n        Keys:\n          intDiv(slot, 432000)\n        Condition: (intDiv(slot, 432000) in [1, 1])\n        Parts: 0/0\n        Granules: 0/0\n      PrimaryKey\n        Keys:\n          slot\n          slot_idx\n          signature\n        Condition: and((signature in [\\'\ufffd\u0004U\ufffd`.\ufffdo\ufffd\u0002\ufffdv\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd603^\ufffd\u001f\\\\tz\ufffd\u000e\ufffd\ufffdv\ufffd\ufffd(Q/.\\\\0\u000b\ufffd\u0004\ufffd\ufffd\u0013>\ufffd\u001cn\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd`\ufffdK\ufffd\u031e\ufffd\ufffd\\', \\'\ufffd\u0004U\ufffd`.\ufffdo\ufffd\u0002\ufffdv\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd603^\ufffd\u001f\\\\tz\ufffd\u000e\ufffd\ufffdv\ufffd\ufffd(Q/.\\\\0\u000b\ufffd\u0004\ufffd\ufffd\u0013>\ufffd\u001cn\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd`\ufffdK\ufffd\u031e\ufffd\ufffd\\']), and((slot_idx in [234, 234]), (slot in [432001, 432001])))\n        Parts: 0/0\n        Granules: 0/0\n      Skip\n        Name: bf_signature\n        Description: bloom_filter GRANULARITY 64\n        Parts: 0/0\n        Granules: 0/0\n      Ranges: 0\n"
+  },
+  "raw_report_sha256": "15aeaf5d3f78057c615b3f1474d278081e87da1d28b31ed126533a7601cd52c5",
+  "raw_report_path": "/tmp/gettx-bench-matched/report.json",
+  "validation": {
+    "workspace_tests_passed": 666,
+    "rpc_all_features_tests_passed": 551,
+    "disk_integration_passed": true,
+    "http_parity_comparisons": 1041,
+    "http_parity_checks_passed": 1122,
+    "http_parity_requests": 2122,
+    "basic_k6_requests": 1244,
+    "complexity_functions_checked": 25,
+    "protocol_passed": true
+  },
+  "complete_measurements": 2500,
+  "measurements_with_terminal_telemetry": 2500
+}

--- a/scripts/test/benchmark-get-transaction.py
+++ b/scripts/test/benchmark-get-transaction.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: AGPL-3.0-only
+"""Local-only getTransaction SQL benchmarks; creates and removes its own cluster.
+
+Uses repository payload/signature DDL and full transaction projection. All raw
+measurements, query plans and terminal query logs are retained in --output.
+This fixture does not measure deployed gateway behavior or production capacity.
+"""
+import argparse
+import hashlib
+import http.client
+import importlib.util
+import json
+import math
+import pathlib
+import platform
+import random
+import re
+import statistics
+import struct
+import socketserver
+import threading
+import time
+import urllib.parse
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location("protocol", pathlib.Path(__file__).with_name("test-clickhouse-http-disconnect.py"))
+PROTOCOL = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(PROTOCOL)
+SETTINGS = ("max_threads=2,max_execution_time=10,max_execution_time_leaf=10,"
+            "optimize_skip_unused_shards=1,use_query_cache=0,"
+            "log_queries=1,log_profile_events=1,use_hedged_requests=0,max_parallel_replicas=1")
+COLUMNS = re.search(r'TRANSACTION_SELECT_COLUMNS: &str = "(.*?)";',
+                    (ROOT / "crates/superbank-rpc/src/clickhouse/queries.rs").read_text(), re.S)[1]
+
+
+def request(port, query, query_id=None):
+    connection = http.client.HTTPConnection("127.0.0.1", port, timeout=120)
+    params = {"query_id": query_id} if query_id else {}
+    started = time.perf_counter()
+    try:
+        connection.request("POST", "/?" + urllib.parse.urlencode(params), query.encode())
+        response = connection.getresponse()
+        body = response.read()
+        if response.status != 200:
+            raise RuntimeError(body.decode(errors="replace"))
+        return body, (time.perf_counter() - started) * 1000
+    finally:
+        connection.close()
+
+
+def sql(cluster, query, node=0):
+    return request(cluster.ports[node], query)[0].decode(errors="replace")
+
+
+def statements(text):
+    # These two cluster DDL files have no embedded semicolons in literals.
+    return [part for part in text.split(";") if part.strip()]
+
+
+def position(number):
+    return 432000 * (1 + number // 500000) + number % 500000 // 1000, number % 1000
+
+
+def literal(number):
+    return "unhex('" + hashlib.sha512(str(number).encode()).hexdigest() + "')"
+
+
+def signature_query(number):
+    key = literal(number)
+    return ("SELECT slot,slot_idx FROM default.signatures "
+            f"PREWHERE sig_bucket=cityHash64({key})%32 AND signature={key} "
+            "ORDER BY slot DESC,slot_idx DESC LIMIT 1")
+
+
+def payload_query(table, number, indexed=True, index_override=None, resolved=None):
+    slot, idx = resolved if resolved is not None else position(number)
+    if index_override is not None:
+        idx = index_override
+    pred = f" AND slot_idx={idx}" if indexed else ""
+    order = "" if indexed else " ORDER BY slot_idx DESC"
+    return (f"SELECT {COLUMNS} FROM default.{table} PREWHERE slot={slot}{pred} "
+            f"AND signature={literal(number)}{order} LIMIT 1")
+
+
+def combined_query(number):
+    # An array explicitly distinguishes an absent signature from valid position (0,0).
+    lookup = signature_query(number)
+    return (f"WITH (SELECT groupArray(tuple(slot,slot_idx)) FROM ({lookup})) AS positions "
+            f"SELECT {COLUMNS} FROM default.transactions "
+            "PREWHERE slot=tupleElement(arrayElement(positions,1),1) "
+            "AND slot_idx=tupleElement(arrayElement(positions,1),2) "
+            f"AND signature={literal(number)} WHERE notEmpty(positions) LIMIT 1")
+
+
+def snapshot(cluster):
+    query = ("SELECT hostName() AS host,table,sumIf(rows,active) AS rows,sumIf(bytes_on_disk,active) AS disk_bytes,sum(bytes_on_disk) AS resident_parts_bytes,"
+             "sumIf(data_compressed_bytes,active) AS compressed_bytes,sumIf(marks_bytes,active) AS marks_bytes,"
+             "sumIf(primary_key_bytes_in_memory,active) AS primary_key_memory,countIf(active) AS parts "
+             "FROM system.parts WHERE database='default' "
+             "AND table IN ('transactions_local','transactions1024_local','signatures_local','signatures1024_local') "
+             "GROUP BY host,table FORMAT JSONEachRow")
+    return [json.loads(line) for i in range(3) for line in sql(cluster, query, i).splitlines()]
+
+
+def prepare(cluster, rows):
+    for table, granularity in [("transactions", 8192), ("transactions1024", 1024)]:
+        ddl = (ROOT / "ddl/cluster/transactions.sql").read_text().replace("{cluster}", "fixture")
+        ddl = ddl.replace("transactions", table).replace(
+            "ORDER BY (slot, slot_idx, signature);",
+            f"ORDER BY (slot, slot_idx, signature) SETTINGS index_granularity={granularity},index_granularity_bytes=10485760;")
+        for statement in statements(ddl):
+            sql(cluster, statement)
+    for suffix in ["", "1024"]:
+        ddl = (ROOT / "ddl/cluster/signatures.sql").read_text().replace("{cluster}", "fixture")
+        ddl = re.sub(r"\bsignatures(?:_local)?\b", lambda match: match[0].replace("signatures", "signatures" + suffix), ddl)
+        ddl = ddl.replace("transactions_local", "transactions" + suffix + "_local")
+        for statement in statements(ddl):
+            sql(cluster, statement)
+    ingestion = []
+    for table in ["transactions", "transactions1024"]:
+        started = time.perf_counter()
+        sampled_peak = 0
+        for first in range(0, rows, 50000):
+            count = min(50000, rows - first)
+            query = (f"INSERT INTO default.{table} "
+                     "(signature,slot,slot_idx,block_time,tx_version,tx_signatures,"
+                     "tx_num_required_signatures,tx_account_keys,meta_status_ok,meta_log_messages_present,meta_log_messages) "
+                     "SELECT SHA512(toString(number)),432000*(1+intDiv(number,500000))+intDiv(number%500000,1000),"
+                     "number%1000,1700000000+intDiv(number,1000),"
+                     "if(number%3=0,NULL,toNullable(toUInt8(number%3-1))),[SHA512(toString(number))],"
+                     "1,[toFixedString('fixture-account',32)],1,1,"
+                     "arrayMap(x->hex(SHA256(concat(toString(number),':',toString(x)))),"
+                     "range(if(number%100=0,128,if(number%2=0,8,2)))) "
+                     f"FROM numbers({first},{count}) SETTINGS distributed_foreground_insert=1,max_threads=2")
+            sql(cluster, query)
+            sampled_peak = max(sampled_peak, sum(row["resident_parts_bytes"] for row in snapshot(cluster)))
+        ingestion.append({"table": table, "rows": rows, "seconds": time.perf_counter() - started,
+                          "sampled_peak_all_table_parts_bytes": sampled_peak, "parts": snapshot(cluster)})
+        print(f"loaded {table}: {rows} rows", flush=True)
+    for suffix in ["", "1024"]:
+        assert int(sql(cluster, "SELECT count() FROM default.signatures" + suffix)) == rows
+    return ingestion
+
+
+def run_lookup(port, number, variant, prefix, delay_ms):
+    queries = []
+    if variant == "two_step":
+        queries.append(signature_query(number))
+    table = "transactions1024" if variant == "granularity1024" else "transactions"
+    queries.append(combined_query(number) if variant == "combined" else
+                   payload_query(table, number, indexed=variant != "slot_only"))
+    records, elapsed = [], 0
+    for index, query in enumerate(queries):
+        # Explicit simulated per-request latency, separate from measured HTTP time.
+        if delay_ms:
+            time.sleep(delay_ms / 1000)
+        body, ms = request(port, query + " SETTINGS " + SETTINGS + " FORMAT RowBinary", f"{prefix}-{index}")
+        elapsed += ms
+        if variant == "two_step" and index == 0:
+            if not body:
+                records.append({"query_id": f"{prefix}-{index}", "http_ms": ms, "bytes": 0})
+                break
+            resolved = struct.unpack("<QI", body)
+            queries[1] = payload_query(table, number, resolved=resolved)
+        records.append({"query_id": f"{prefix}-{index}", "http_ms": ms, "bytes": len(body)})
+    return {"http_ms": elapsed, "simulated_elapsed_ms": elapsed + delay_ms * len(records),
+            "requests": records, "digest": hashlib.sha256(body).hexdigest()}
+
+
+def query_logs(cluster):
+    columns = ("hostName() AS host,type,query_id,initial_query_id,is_initial_query,query_duration_ms,"
+               "read_rows,read_bytes,result_rows,memory_usage,exception_code,tables,query,ProfileEvents")
+    result = []
+    for i in range(3):
+        sql(cluster, "SYSTEM FLUSH LOGS", i)
+        query = (f"SELECT {columns} FROM system.query_log "
+                 "WHERE startsWith(initial_query_id,'gettx-bench-') AND type!='QueryStart' FORMAT JSONEachRow")
+        result.extend(json.loads(line) for line in sql(cluster, query, i).splitlines())
+    return result
+
+
+def quantiles(values):
+    ordered = sorted(values)
+    return {"p50": statistics.median(ordered), "p95": ordered[math.ceil(len(ordered)*.95)-1],
+            "p99": ordered[math.ceil(len(ordered)*.99)-1]}
+
+
+def run(args):
+    args.output.mkdir(parents=True, exist_ok=False)
+    cluster = PROTOCOL.Cluster(args.output, args.image, memory=args.node_memory)
+    report = {"image": args.image, "node_memory": args.node_memory, "rows_per_payload_table": args.rows, "host": platform.platform(),
+              "script_sha256": hashlib.sha256(pathlib.Path(__file__).read_bytes()).hexdigest(),
+              "settings": SETTINGS, "seed": 88, "runs": args.runs, "samples_per_run": args.samples,
+              "filesystem_cache": "uncontrolled; cache-cleared means ClickHouse mark/uncompressed caches only",
+              "measurements": [], "gateway_integration": "not accepted; all gates require explicit evidence"}
+    proxy = None
+    try:
+        cluster.start()
+        proxy = socketserver.ThreadingTCPServer(("127.0.0.1", 0), PROTOCOL.GatewayHandler)
+        proxy.daemon_threads = True
+        proxy.upstream_port = cluster.ports[0]
+        proxy.stopping = threading.Event()
+        proxy_thread = threading.Thread(target=proxy.serve_forever, daemon=True)
+        proxy_thread.start()
+        port = proxy.server_address[1]
+        report["ingestion"] = prepare(cluster, args.rows)
+        report["before_merge"] = snapshot(cluster)
+        merge_start = time.perf_counter()
+        for table in ["transactions_local", "transactions1024_local"]:
+            for node in range(3):
+                sql(cluster, f"OPTIMIZE TABLE default.{table} FINAL SETTINGS max_threads=2", node)
+        report["merge_wall_seconds"] = time.perf_counter() - merge_start
+        report["merges"] = []
+        for node in range(3):
+            sql(cluster, "SYSTEM FLUSH LOGS", node)
+            query = ("SELECT hostName() AS host,table,count() AS merges,sum(duration_ms) AS duration_ms,"
+                     "sum(read_rows) AS read_rows,sum(read_bytes) AS read_bytes,max(peak_memory_usage) AS peak_memory "
+                     "FROM system.part_log WHERE database='default' AND event_type='MergeParts' AND error=0 "
+                     "AND table IN ('transactions_local','transactions1024_local') GROUP BY host,table FORMAT JSONEachRow")
+            report["merges"].extend(json.loads(line) for line in sql(cluster, query, node).splitlines())
+        report["after_merge"] = snapshot(cluster)
+        plans = {}
+        for variant, query in {"combined": combined_query(1234), "position": payload_query("transactions", 1234),
+                               "granularity1024": payload_query("transactions1024", 1234),
+                               "slot_only": payload_query("transactions", 1234),
+                               "local_position": payload_query("transactions_local", 1234),
+                               "local_granularity1024": payload_query("transactions1024_local", 1234)}.items():
+            try:
+                nodes = range(3) if variant.startswith("local_") else [0]
+                plans[variant] = "\n".join(
+                    f"node {node}:\n" + sql(cluster, "EXPLAIN indexes=1 " + query + " SETTINGS " + SETTINGS, node)
+                    for node in nodes)
+            except RuntimeError as error:
+                plans[variant] = str(error)
+        report["plans"] = plans
+        # Absent and stale position evidence is retained separately from steady-state reads.
+        report["edge_cases"] = {}
+        stale_slot, _ = position(1234)
+        sql(cluster, "INSERT INTO default.signatures (signature,slot,slot_idx,err) "
+            f"SELECT {literal(1234)},{stale_slot},9999,NULL SETTINGS distributed_foreground_insert=1")
+        for label, query in [("absent", combined_query(args.rows + 1)),
+                             ("stale_combined", combined_query(1234)),
+                             ("stale_position", payload_query("transactions", 1234, index_override=9999)),
+                             ("stale_fallback", payload_query("transactions", 1234, indexed=False))]:
+            try:
+                body, ms = request(port, query + " SETTINGS " + SETTINGS + " FORMAT RowBinary", "gettx-bench-edge-" + label)
+                report["edge_cases"][label] = {"bytes": len(body), "http_ms": ms}
+            except RuntimeError as error:
+                report["edge_cases"][label] = {"error": str(error)}
+        report["gateway_integration"] = (
+            "rejected: combined query returns indistinguishable empty responses for an absent signature "
+            "and a stale position whose payload exists; it cannot preserve fallback without resolving the signature again"
+            if report["edge_cases"].get("stale_combined", {}).get("bytes") == 0
+            and report["edge_cases"].get("stale_fallback", {}).get("bytes", 0) > 0
+            else "not accepted: remaining correctness, pruning, performance and cancellation gates require evidence")
+        corpus = random.Random(88).sample(range(args.rows), args.samples)
+        corpus = [number if number != 1234 else 1235 for number in corpus]
+        variants = ["position", "slot_only", "granularity1024", "two_step", "combined"]
+        expected = {}
+        for run in range(args.runs):
+            for cold in [False, True]:
+                for variant in variants[::1 if run % 2 == 0 else -1]:
+                    for sample, number in enumerate(corpus):
+                        if cold:
+                            for node in range(3):
+                                sql(cluster, "SYSTEM DROP MARK CACHE", node)
+                                sql(cluster, "SYSTEM DROP UNCOMPRESSED CACHE", node)
+                        prefix = f"gettx-bench-{run}-{int(cold)}-{variant}-{sample}"
+                        try:
+                            row = run_lookup(port, number, variant, prefix, args.delay_ms)
+                            if number in expected:
+                                assert row["digest"] == expected[number], (variant, number)
+                            expected[number] = row["digest"]
+                        except RuntimeError as error:
+                            row = {"error": str(error)}
+                        row.update(run=run, cold=cold, variant=variant, sample=sample)
+                        report["measurements"].append(row)
+                    print(f"run {run+1}/{args.runs} cold={cold} {variant}", flush=True)
+        report["query_logs"] = query_logs(cluster)
+        report["final_parts"] = snapshot(cluster)
+        terminals = {row["query_id"]: row for row in report["query_logs"]
+                     if row["is_initial_query"] and row["type"] == "QueryFinish"}
+        for row in report["measurements"]:
+            events = [terminals.get(request["query_id"]) for request in row.get("requests", [])]
+            if not events or any(event is None for event in events):
+                continue
+            row["server_ms"] = sum(int(event["query_duration_ms"]) for event in events)
+            row["read_rows"] = sum(int(event["read_rows"]) for event in events)
+            row["read_bytes"] = sum(int(event["read_bytes"]) for event in events)
+            row["cpu_us"] = sum(int(event["ProfileEvents"].get(key, 0)) for event in events
+                                for key in ["UserTimeMicroseconds", "SystemTimeMicroseconds"])
+            row["modeled_100ms_rtt"] = row["http_ms"] + 100 * len(events)
+        report["summary"] = {}
+        for variant in variants:
+            for cold in [False, True]:
+                rows = [r for r in report["measurements"] if r["variant"] == variant and r["cold"] == cold]
+                good = [r["http_ms"] for r in rows if "http_ms" in r]
+                report["summary"][f"{variant}-cold={cold}"] = {"errors": len(rows)-len(good),
+                    "http_ms": quantiles(good) if good else None,
+                    "means": {key: statistics.mean(r[key] for r in rows if key in r)
+                              for key in ["server_ms", "read_rows", "read_bytes", "cpu_us"]
+                              if any(key in r for r in rows)}}
+    finally:
+        (args.output / "report.json").write_text(json.dumps(report, indent=2))
+        if proxy:
+            proxy.stopping.set()
+            proxy.shutdown()
+            proxy.server_close()
+            proxy_thread.join()
+        cluster.close()
+    print(json.dumps(report.get("summary", {}), indent=2))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=pathlib.Path, required=True)
+    parser.add_argument("--image", default=PROTOCOL.IMAGE)
+    parser.add_argument("--node-memory", default="8g")
+    parser.add_argument("--rows", type=int, default=3000000)
+    parser.add_argument("--samples", type=int, default=50)
+    parser.add_argument("--runs", type=int, default=5)
+    parser.add_argument("--delay-ms", type=float, default=0)
+    args = parser.parse_args()
+    if args.rows < 2000 or args.samples < 1 or args.samples > args.rows or args.runs < 1 or args.delay_ms < 0:
+        parser.error("require rows>=2000, 1<=samples<=rows, runs>=1, delay-ms>=0")
+    run(args)

--- a/scripts/test/test-clickhouse-http-disconnect.py
+++ b/scripts/test/test-clickhouse-http-disconnect.py
@@ -47,8 +47,8 @@ def wait_for(check, seconds=30):
 
 
 class Cluster:
-    def __init__(self, output, image):
-        self.output, self.image = output, image
+    def __init__(self, output, image, memory="2g"):
+        self.output, self.image, self.memory = output, image, memory
         self.name = "ch-disconnect-" + uuid.uuid4().hex[:10]
         self.nodes = [self.name + f"-{i}" for i in range(3)]
         self.created = []
@@ -80,7 +80,7 @@ class Cluster:
 </server></raft_configuration></keeper_server></clickhouse>""")
         for i, name in enumerate(self.nodes):
             args = ["run", "-d", "--name", name, "--hostname", name, "--network", self.name,
-                    "--cpus", "2", "--memory", "2g", "-p", "127.0.0.1::8123",
+                    "--cpus", "2", "--memory", self.memory, "-p", "127.0.0.1::8123",
                     "-e", "CLICKHOUSE_SKIP_USER_SETUP=1", "-v",
                     f"{common}:/etc/clickhouse-server/config.d/fixture.xml:ro"]
             if i == 0:

--- a/tests/k6/README.md
+++ b/tests/k6/README.md
@@ -1116,3 +1116,45 @@ observations. These controls must fail the cancellation gate for the overall fix
 The production gateway must promptly close the upstream connection and discard queued work
 when the caller disconnects. This local protocol gate does not replace the staged customer
 replay or prove the deployed gateway follows that contract.
+
+### getTransaction follow-up benchmarks
+
+Run the basic transaction scenario against a local/staging fixture, then compare full
+JSON-RPC envelopes with a known-present signature corpus covering legacy, v0, and v1:
+
+```sh
+RPC_URL=http://127.0.0.1:18899 SIGNATURE_FILE=/tmp/gettx-signatures.txt \
+VUS=1 DURATION=10s MAX_SUPPORTED_TX_VERSION=1 \
+k6 run tests/k6/scenarios/basic/superbank-rpc-get-transaction.js
+
+RPC_URL=http://127.0.0.1:18899 REFERENCE_RPC_URL=http://127.0.0.1:18900 \
+SIGNATURE_FILE=/tmp/gettx-signatures.txt \
+k6 run tests/k6/scenarios/validation/superbank-rpc-get-transaction-parity.js
+```
+
+The parity scenario checks all four encodings, confirmed/finalized commitment,
+omitted/0/1 maximum supported versions, pinned/mismatched slots, and null/string/number
+request IDs. Existing disk-cache integration tests cover unavailable reads, invalidation,
+concurrent coverage publication, absent signatures, skipped slots, and stale positions.
+
+The SQL benchmark creates its own three-node Docker cluster and transparent local gateway;
+it never connects to an existing ClickHouse endpoint. It uses the repository transaction
+projection and schemas, with separate 8192/1024-granularity payload copies:
+
+```sh
+python3 scripts/test/benchmark-get-transaction.py --output /tmp/gettx-benchmark
+```
+
+The output directory must not exist. Defaults: ClickHouse 26.2.3.2, 3 million rows per
+payload table, 8 GiB memory and 2 CPUs per node, 50 seeded signatures, five alternating
+runs. `--rows 2000 --samples 2 --runs 1` is only a harness smoke test. `--node-memory`
+changes the fixture container limit; the cancellation fixture retains its 2 GiB default.
+`--delay-ms` injects an explicit delay per client request; `modeled_100ms_rtt` is an
+arithmetic sensitivity model, not measured deployed network latency.
+
+`report.json` contains settings, source-script hash, ingestion/merge/part measurements,
+query plans, raw HTTP observations and per-query ClickHouse logs. Payload digests must
+match across variants. Cache-cleared runs drop ClickHouse mark/uncompressed caches;
+filesystem caches remain uncontrolled. SQL timing excludes Rust admission, hydration,
+and serialization. Physical I/O and production-scale capacity are not inferred from
+logical read bytes. See [the findings](../../GETTRANSACTION_BENCHMARKS.md).

--- a/tests/k6/scenarios/validation/superbank-rpc-get-transaction-parity.js
+++ b/tests/k6/scenarios/validation/superbank-rpc-get-transaction-parity.js
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Compare complete getTransaction JSON-RPC envelopes against an authoritative
+// reference. SIGNATURE_FILE must contain known-present signatures, including
+// each transaction version being validated. This scenario generates real load.
+import http from 'k6/http';
+import { check, fail } from 'k6';
+import { config } from '../../lib/config.js';
+import { initSignaturePool, generateRandomSignature } from '../../lib/signatures.js';
+import { deepEqual } from '../../lib/compare.js';
+
+const signatures = initSignaturePool();
+export const options = {
+  vus: 1,
+  iterations: 1,
+  thresholds: { checks: ['rate==1'], http_req_failed: ['rate==0'] },
+};
+
+function rpc(url, signature, options, id) {
+  const response = http.post(url, JSON.stringify({
+    jsonrpc: '2.0', id, method: 'getTransaction', params: [signature, options],
+  }), { headers: { 'Content-Type': 'application/json' }, timeout: '10s' });
+  if (response.status !== 200) fail(`HTTP ${response.status}`);
+  return response.json();
+}
+
+function compare(signature, options, id) {
+  const reference = rpc(config.referenceRpcUrl, signature, options, id);
+  const target = rpc(config.rpcUrl, signature, options, id);
+  if (!check(target, { 'complete JSON-RPC envelope parity': value => deepEqual(value, reference) })) {
+    fail(`getTransaction parity failed for options ${JSON.stringify(options)}`);
+  }
+  return reference;
+}
+
+export default function () {
+  if (!config.referenceRpcUrl || !config.signatureFile) {
+    fail('REFERENCE_RPC_URL and a known-present SIGNATURE_FILE are required');
+  }
+  const absent = generateRandomSignature();
+  const missing = compare(absent, { maxSupportedTransactionVersion: 1 }, 'absent');
+  check(missing, { 'absent signature is null': value => value.result === null && !value.error });
+  let index = 0;
+  for (const signature of signatures) {
+    const known = rpc(config.referenceRpcUrl, signature, { maxSupportedTransactionVersion: 1 }, 'fixture');
+    if (!check(known, { 'fixture transaction exists': value => value.result?.transaction != null })) {
+      fail('The signature corpus must contain known-present transactions');
+    }
+    for (const encoding of ['json', 'jsonParsed', 'base58', 'base64']) {
+      for (const commitment of ['confirmed', 'finalized']) {
+        for (const version of [undefined, 0, 1]) {
+          const id = [null, 'parity', index][index % 3];
+          index += 1;
+          compare(signature, { encoding, commitment, maxSupportedTransactionVersion: version }, id);
+        }
+      }
+    }
+    compare(signature, { slot: known.result.slot, maxSupportedTransactionVersion: 1 }, 'pinned');
+    const mismatch = compare(signature, { slot: known.result.slot + 1, maxSupportedTransactionVersion: 1 }, 'mismatch');
+    check(mismatch, { 'slot mismatch is null': value => value.result === null && !value.error });
+  }
+}


### PR DESCRIPTION
Disk-cache timeouts and query failures could make a slot-pinned `getTransaction` return `null` even when the primary store had the transaction. Cache reads now distinguish definitive absence from unavailability, with coverage and generation checks under the same deadline, so failed reads fall back to primary.

Payload reads also retain the resolved `slot_idx` and share the existing positioned lookup, including stale-position fallback. No table settings, cache format, retention, or gateway routing changes are introduced.

Adds failure/race regression coverage, full-response parity checks, and a reproducible synthetic benchmark. The benchmark compares positioned reads, payload granularity, and a combined gateway query; the combined candidate is rejected because it cannot distinguish an absent signature from a stale position. Results and limitations are in `GETTRANSACTION_BENCHMARKS.md`.

Validation:
- Formatting, workspace and all-feature RPC Clippy/tests passed; scoped complexity passed for all 25 changed functions.
- Local disk-cache integration covers admission timeouts, database failure, invalidation, concurrent coverage publication, and stale positions.
- Local basic k6: 1,244 requests, zero failures. Full-response parity: 1,041 matching envelopes and 1,122 passing checks.
- Synthetic benchmark: 2,500 successful observations with matching payload digests. These measurements do not establish deployed latency or full-retention performance.
